### PR TITLE
Allow to use bootstrap theme to non-sass users

### DIFF
--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -8,6 +8,7 @@ $ember-power-select-text-color: #444444 !default;
 $ember-power-select-placeholder-color: #999999 !default;
 $ember-power-select-border-radius: 4px !default; // General border radius
 $ember-power-select-opened-border-radius: 0 !default; // Border radious of the side of the dropdown and the trigger where they touch
+$ember-power-select-search-input-border-radius: 0 !default;
 $ember-power-select-dropdown-margin: 0 !default; // Margin between the dropdown and the trigger
 $ember-power-select-dropdown-box-shadow: none !default;
 $ember-power-select-background-color: #ffffff !default;
@@ -109,6 +110,7 @@ $ember-power-select-focus-outline: null !default;
   padding: 4px;
   input {
     border: $ember-power-select-border;
+    border-radius: $ember-power-select-search-input-border-radius;
     width: 100%;
     font-size: inherit;
     line-height: inherit;

--- a/app/styles/ember-power-select/themes/bootstrap.scss
+++ b/app/styles/ember-power-select/themes/bootstrap.scss
@@ -4,6 +4,7 @@ $ember-power-select-border-color: #ccc;
 $ember-power-select-trigger-icon-color: #999;
 $ember-power-select-focus-outline: 0;
 $ember-power-select-opened-border-radius: 4px;
+$ember-power-select-search-input-border-radius: 3px;
 $ember-power-select-dropdown-margin: 3px;
 $ember-power-select-dropdown-box-shadow: rgba(black, 0.172549) 0px 6px 12px 0px;
 $ember-power-select-highlighted-color: inherit;

--- a/index.js
+++ b/index.js
@@ -5,10 +5,17 @@
 
 module.exports = {
   name: 'ember-power-select',
+
   included: function(app) {
     // Don't include the precompiled css file if the user uses ember-cli-sass
     if (!app.registry.availablePlugins['ember-cli-sass']) {
-      app.import('vendor/ember-power-select.css');
+      var addonConfig = app.options['ember-power-select'];
+
+      if (!addonConfig || !addonConfig.theme) {
+        app.import('vendor/ember-power-select.css');
+      } else {
+        app.import('vendor/ember-power-select-'+addonConfig.theme+'.css');
+      }
     }
   },
 

--- a/tests/dummy/app/templates/cookbook/bootstrap-theme.hbs
+++ b/tests/dummy/app/templates/cookbook/bootstrap-theme.hbs
@@ -39,6 +39,23 @@
   @import 'ember-power-select';
 </pre>
 
+<p>
+  If your project is not using sass, you can still use the precompiled bootstrap theme instead of
+  the default one with just a couple lines of configuration when creating your app on the
+  <code>ember-cli-build.js</code> file.
+</p>
+
+<pre>
+  var app = new EmberApp(defaults, {
+    'ember-power-select': {
+      theme: 'bootstrap'
+    }
+  });
+</pre>
+
+<p>
+  Remember to restart ember-cli to pick up the changes.
+</p>
 
 <div class="doc-page-nav">
   {{#link-to 'cookbook.index' class="doc-page-nav-link-prev"}}&lt; System-wide configuration{{/link-to}}

--- a/tests/dummy/app/templates/docs/styles.hbs
+++ b/tests/dummy/app/templates/docs/styles.hbs
@@ -16,7 +16,7 @@
 </p>
 
 <p>
-  Ember Power Select exposes Sass 27 variables you can set before importing
+  Ember Power Select exposes Sass 28 variables you can set before importing
   the styles. By example:
 </p>
 
@@ -34,12 +34,13 @@
 
 <p>
   This approach is powerful enough to built entire themes on top of it and to prove it Ember Power Select
-  ships with a {{#link-to 'cookbook.bootstrap-theme'}}Bootstrap theme{{/link-to}} out of the box.
+  ships with a {{#link-to 'cookbook.bootstrap-theme'}}Bootstrap theme{{/link-to}} out of the box that
+  can also be used in projects not using sass.
 </p>
 
 <p>
   You can find the entire list of available variables in
-  <a href="https://github.com/cibernox/ember-power-select/blob/master/app/styles/ember-power-select.scss#L1-L27">the source code</a>.
+  <a href="https://github.com/cibernox/ember-power-select/blob/master/app/styles/ember-power-select.scss#L1-L28">the source code</a>.
 </p>
 
 <div class="doc-page-nav">


### PR DESCRIPTION
Done with a configuration option in your app (ember-cli-build.js)

Doing so in the app initialization seemed more reasonable than adding the option in the environment.js because it's not something that depends on the environment.
```
  var app = new EmberApp(defaults, {
    'ember-power-select': {
      theme: 'bootstrap'
    }
  });
```