### PR TITLE
Bugfix: Don't apply the filter to the options if a search action is given

### DIFF
--- a/addon/components/ember-power-select/base.js
+++ b/addon/components/ember-power-select/base.js
@@ -125,13 +125,17 @@ export default Ember.Component.extend({
 
   refreshResults() {
     const { _options: options, _searchText: searchText } = this.getProperties('_options', '_searchText');
-    let matcher;
-    if (this.get('searchField')) {
-      matcher = (option, text) => this.matcher(get(option, this.get('searchField')), text);
+    if (this.get('search')) {
+      this.set('results', options);
     } else {
-      matcher = (option, text) => this.matcher(option, text);
+      let matcher;
+      if (this.get('searchField')) {
+        matcher = (option, text) => this.matcher(get(option, this.get('searchField')), text);
+      } else {
+        matcher = (option, text) => this.matcher(option, text);
+      }
+      this.set('results', filterOptions(options || [], searchText, matcher));
     }
-    this.set('results', filterOptions(options || [], searchText, matcher));
     this._resultsDirty = false;
   },
 


### PR DESCRIPTION
If a search action is provided, the addon should not apply any filtering at all. The
serch action is supposed to be in charge of everything