### PR TITLE
BUGFIX: Trigger custom search when the term is an empty string.

### DIFF
--- a/addon/components/ember-power-select/base.js
+++ b/addon/components/ember-power-select/base.js
@@ -146,7 +146,7 @@ export default Ember.Component.extend({
 
   performCustomSearch(term) {
     this.set('_loadingOptions', true);
-    const promise = term.length > 0 ? RSVP.Promise.resolve(this.get('search')(term)) : RSVP.resolve([]);
+    const promise = RSVP.Promise.resolve(this.get('search')(term));
     this.set('_activeSearch', promise);
     promise.then(results => {
       if (promise !== this.get('_activeSearch')) { return; }


### PR DESCRIPTION
When the user deletes text from the searchbox and it reaches 0, the custom
search function should be invoked too. An empty string is perfectly valid string
and is up to the user to decide what to do (perhaps show everithing, perhaps show nothing)