### PR TITLE
ensure incoming text is a string

### DIFF
--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -929,7 +929,7 @@ export function stripDiacritics(text) {
     return DIACRITICS[a] || a;
   }
 
-  return text.replace(/[^\u0000-\u007E]/g, match);
+  return `${text}`.replace(/[^\u0000-\u007E]/g, match);
 }
 
 export function defaultMatcher(value, text) {

--- a/tests/unit/utils/group-utils-test.js
+++ b/tests/unit/utils/group-utils-test.js
@@ -90,6 +90,10 @@ test('#stripDiacritics returns the given string with diacritics normalized into 
   assert.equal(stripDiacritics("áãàéèíìóõøòúùñ"), "aaaeeiioooouun");
 });
 
+test('#stripDiacritics is able to handle integers', function(assert) {
+  assert.equal(stripDiacritics(1), "1");
+});
+
 test('#countOptions returns the number of options, transversing the groups with no depth level', function(assert) {
   assert.equal(countOptions(groupedOptions), 16);
 });


### PR DESCRIPTION
if the text value that the user is searching for is an integer we need to ensure that its a string before running replacing on it.