### PR TITLE
Fixed disabled behaviour of multiple selects

### DIFF
--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -23,8 +23,8 @@
   </ul>
 {{else}}
   {{#component selectedComponent selection=(readonly selection) dropdown=(readonly registeredDropdown)
-    searchText=(readonly _searchText) placeholder=(readonly placeholder) removeOption=(action "removeOption")
-    search=(action "search") onKeydown=(action onKeydown registeredDropdown) as |opt|}}
+    searchText=(readonly _searchText) placeholder=(readonly placeholder) disabled=(readonly disabled)
+    removeOption=(action "removeOption") search=(action "search") onKeydown=(action onKeydown registeredDropdown) as |opt|}}
     {{yield opt}}
   {{/component}}
  {{/basic-dropdown}}

--- a/addon/templates/components/power-select/multiple/selected.hbs
+++ b/addon/templates/components/power-select/multiple/selected.hbs
@@ -1,7 +1,7 @@
 {{#each selection as |opt|}}
   <span class="ember-power-select-multiple-option">
     {{#unless disabled}}
-      <span aria-label="remove element"> class="ember-power-select-multiple-remove-btn" onclick={{action removeOption opt dropdown}}>&times;</span>
+      <span aria-label="remove element" class="ember-power-select-multiple-remove-btn" onclick={{action removeOption opt dropdown}}>&times;</span>
     {{/unless}}
     {{yield opt}}
   </span>

--- a/addon/templates/components/power-select/multiple/selected.hbs
+++ b/addon/templates/components/power-select/multiple/selected.hbs
@@ -1,9 +1,12 @@
 {{#each selection as |opt|}}
   <span class="ember-power-select-multiple-option">
-    <span class="ember-power-select-multiple-remove-btn" onclick={{action removeOption opt dropdown}}>&times;</span>
+    {{#unless disabled}}
+      <span class="ember-power-select-multiple-remove-btn" onclick={{action removeOption opt dropdown}}>&times;</span>
+    {{/unless}}
     {{yield opt}}
   </span>
 {{/each}}
 <input type="search" class="ember-power-select-trigger-multiple-input" tabindex="0" autocomplete="off"
   autocorrect="off" autocapitalize="off" spellcheck="false" role="textbox" style={{triggerMultipleInputStyle}}
-  placeholder={{maybePlaceholder}} value={{searchText}} oninput={{action "search" value="target.value"}} onkeydown={{onKeydown}}>
+  placeholder={{maybePlaceholder}} value={{searchText}} disabled={{disabled}}
+  oninput={{action "search" value="target.value"}} onkeydown={{onKeydown}}>

--- a/addon/templates/components/power-select/multiple/selected.hbs
+++ b/addon/templates/components/power-select/multiple/selected.hbs
@@ -1,7 +1,7 @@
 {{#each selection as |opt|}}
   <span class="ember-power-select-multiple-option">
     {{#unless disabled}}
-      <span class="ember-power-select-multiple-remove-btn" onclick={{action removeOption opt dropdown}}>&times;</span>
+      <span aria-label="remove element"> class="ember-power-select-multiple-remove-btn" onclick={{action removeOption opt dropdown}}>&times;</span>
     {{/unless}}
     {{yield opt}}
   </span>

--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -65,6 +65,9 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
   line-height: inherit;
   -webkit-appearance: none;
   outline: none;
+  &:disabled {
+    background-color: $ember-power-select-disabled-background-color;
+  }
 }
 .ember-power-select-multiple-option {
   border: 1px solid gray;

--- a/tests/integration/components/power-select-test.js
+++ b/tests/integration/components/power-select-test.js
@@ -1390,7 +1390,10 @@ test('Disabled options are skipped when highlighting items with the keyboard', f
   q) [DONE] Pressing ENTER when the select is closed opens and nothing is written on the box opens it.
   r) [DONE] If the multiple component is focused, pressing KEYDOWN opens it
   s) [DONE] If the multiple component is focused, pressing KEYUP opens it
-  Is it possible to remove this searchbox from multiple selects??
+  t) [DONE] Typing in the input opens the component and filters the options
+  u) [DONE] Typing in the input opens the component and filters the options also with async searches
+  v) [DONE] When passed `disabled=true`, the input inside the trigger is also disabled
+  w) [DONE] When passed `disabled=true`, the selected elements can't be removed
 */
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Multiple)', {
@@ -1874,6 +1877,32 @@ test('Typing in the input opens the component and filters the options also with 
   }, 150);
 });
 
+test('When passed `disabled=true`, the input inside the trigger is also disabled', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    {{#power-select multiple=true selected=foo onchange=(action (mut foo)) search=(action search) disabled=true as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  assert.ok(this.$('.ember-power-select-trigger-multiple-input').prop('disabled'), 'The input is disabled');
+});
+
+test('When passed `disabled=true`, the input inside the trigger is also disabled', function(assert) {
+  assert.expect(1);
+
+  this.numbers = numbers;
+  this.selectedNumbers = [numbers[2], numbers[4]];
+
+  this.render(hbs`
+    {{#power-select multiple=true selected=selectedNumbers onchange=(action (mut foo)) options=numbers disabled=true as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  assert.equal(this.$('.ember-power-select-multiple-remove-btn').length, 0, 'There is no button to remove selected elements');
+});
 
 /**
 10 - Dropdown positioning

--- a/tests/integration/components/power-select-test.js
+++ b/tests/integration/components/power-select-test.js
@@ -1880,8 +1880,9 @@ test('Typing in the input opens the component and filters the options also with 
 test('When passed `disabled=true`, the input inside the trigger is also disabled', function(assert) {
   assert.expect(1);
 
+  this.numbers = numbers;
   this.render(hbs`
-    {{#power-select multiple=true selected=foo onchange=(action (mut foo)) search=(action search) disabled=true as |option|}}
+    {{#power-select multiple=true options=numbers selected=foo onchange=(action (mut foo)) disabled=true as |option|}}
       {{option}}
     {{/power-select}}
   `);


### PR DESCRIPTION
Closes #96

- [x] Input inside the trigger is disabled and has the sabe background color as the rest of the trigger.
- [x] If there is selected elements, they don't show the `×` to remove them.