### PR TITLE
Update to ember-basic-dropdown 0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-basic-dropdown": "^0.4.6"
+    "ember-basic-dropdown": "^0.4.7"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This bings subpixel precission also when calculation the vertical position
of the dropdown