### PR TITLE
Fix placeholder in multiple select for good.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+- [BUGFIX] Fix placeholder of multiple select showing "null".
+
 # 0.4.2
 - [BUGFIX] Stop propagation of the events that trigger the `select` action. This was preventing
   to use this component within another component that closes when clicking on the body, like

--- a/addon/components/power-select/multiple/selected.js
+++ b/addon/components/power-select/multiple/selected.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
   }),
 
   maybePlaceholder: computed('placeholder', 'selection.length', function() {
-    return this.get('selection.length') === 0 ? (this.get('placeholder') || undefined) : undefined;
+    return this.get('selection.length') === 0 ? (this.get('placeholder') || '') : '';
   }),
 
   actions: {

--- a/tests/integration/components/power-select-test.js
+++ b/tests/integration/components/power-select-test.js
@@ -1842,11 +1842,11 @@ test('The placeholder is only visible when no options are selected', function(as
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), 'Select stuff here', 'There is a placeholder');
   Ember.run(() => this.$('.ember-power-select-trigger').click());
   Ember.run(() => $('.ember-power-select-option:eq(1)').click());
-  assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), undefined, 'The placeholder is gone');
+  assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'The placeholder is gone');
 });
 
 test('If the placeholder is null the placeholders shouldn\'t be "null" (issue #94)', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   this.numbers = numbers;
   this.render(hbs`
@@ -1855,11 +1855,12 @@ test('If the placeholder is null the placeholders shouldn\'t be "null" (issue #9
     {{/power-select}}
   `);
 
-  assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), undefined, 'Input does not have a placeholder');
+  assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'Input does not have a placeholder');
   Ember.run(() => this.$('.ember-power-select-trigger').click());
   Ember.run(() => $('.ember-power-select-option:eq(1)').click());
+  assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'Input still does not have a placeholder');
   Ember.run(() => this.$('.ember-power-select-multiple-remove-btn').click());
-  assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), undefined, 'Input still does not have a placeholder');
+  assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'Input still does not have a placeholder');
 });
 
 test('Typing in the input opens the component and filters the options', function(assert) {


### PR DESCRIPTION
Tests were passing in phantomjs but the feature was actually broken in real life.
Apparently there is some kind if irregular on how attributes are treated when it's value
is undefined.
Now the placeholder is always present, but when falsey its value is an empty strings. That
behaves consistently across browsers.