### PR TITLE
Refactor components composition

### DIFF
--- a/addon/components/power-select/base.js
+++ b/addon/components/power-select/base.js
@@ -22,7 +22,7 @@ export default Ember.Component.extend({
   noPendingPromises: computed.not('hasPendingPromises'),
   showLoadingMessage: computed.and('loadingMessage', 'hasPendingPromises'),
 
-  _dropdownClass: computed('class', function() {
+  concatenatedDropdownClasses: computed('class', function() {
     let classes = Ember.A(['ember-power-select-dropdown']);
     if (this.get('dropdownClass')) {
       classes.push(this.get('dropdownClass'));
@@ -42,8 +42,10 @@ export default Ember.Component.extend({
   }),
 
   // hasContent: computed('searchEnabled', 'resultsLength', 'showLoadingMessage', 'mustShowSearchMessage', 'hasInverseBlock', 'noMatchesMessage', function() {
-  //   return this.get('searchEnabled') || this.get('resultsLength') > 0 || this.get('showLoadingMessage') ||
-  //     this.get('mustShowSearchMessage') || this.get('hasInverseBlock') || this.get('noMatchesMessage');
+  //   return this.get('searchEnabled') || this.get('resultsLength') > 0 ||
+  //     (this.get('hasPendingPromises') && !!this.get('showLoadingMessage')) ||
+  //     this.get('mustShowSearchMessage') ||
+  //     (!this.get('hasPendingPromises') && (this.get('hasInverseBlock') || this.get('noMatchesMessage')));
   // }),
 
   // Actions
@@ -111,6 +113,7 @@ export default Ember.Component.extend({
   onClose() {
     this.set('_searchText', '');
     this._resultsDirty = true;
+    this.set('_activeSearch', null);
   },
 
   handleVerticalArrowKey(e) {

--- a/addon/components/power-select/base.js
+++ b/addon/components/power-select/base.js
@@ -48,13 +48,38 @@ export default Ember.Component.extend({
 
   // Actions
   actions: {
-    highlight(option) {
+    open(dropdown, e) {
+      dropdown.actions.open(e);
+      this.onOpen(e);
+    },
+
+    close(dropdown, e) {
+      dropdown.actions.close(e);
+      this.onClose(e);
+    },
+
+    highlight(dropdown, option) {
       if (option && get(option, 'disabled')) { return; }
       this.set('_highlighted', option);
     },
 
-    search(term /*, e */) {
+    search(dropdown, term /*, e */) {
       this.performSearch(term);
+    },
+
+    handleKeydown(dropdown, e) {
+      if (e.defaultPrevented) { return; }
+      if (e.keyCode === 38 || e.keyCode === 40) { // Up & Down
+        if (dropdown.isOpen) {
+          this.handleVerticalArrowKey(e);
+        } else {
+          dropdown.actions.open(e);
+        }
+      } else if (e.keyCode === 9) {  // Tab
+        dropdown.actions.close(e);
+      } else if (e.keyCode === 27) { // ESC
+        dropdown.actions.close(e);
+      }
     },
 
     // It is not evident what is going on here, so I'll explain why.
@@ -86,21 +111,6 @@ export default Ember.Component.extend({
   onClose() {
     this.set('_searchText', '');
     this._resultsDirty = true;
-  },
-
-  onKeydown(dropdown, e) {
-    if (e.defaultPrevented) { return; }
-    if (e.keyCode === 38 || e.keyCode === 40) { // Up & Down
-      if (dropdown.isOpen) {
-        this.handleVerticalArrowKey(e);
-      } else {
-        dropdown.actions.open(e);
-      }
-    } else if (e.keyCode === 9) {  // Tab
-      dropdown.actions.close(e);
-    } else if (e.keyCode === 27) { // ESC
-      dropdown.actions.close(e);
-    }
   },
 
   handleVerticalArrowKey(e) {

--- a/addon/components/power-select/multiple.js
+++ b/addon/components/power-select/multiple.js
@@ -29,59 +29,59 @@ export default PowerSelectBaseComponent.extend({
 
   // Actions
   actions: {
-    removeOption(option, dropdown, e) {
+    select(dropdown, option, e) {
+      e.preventDefault();
+      e.stopPropagation();
+      const newSelection = this.cloneSelection();
+      if (newSelection.indexOf(option) > -1) {
+        newSelection.removeObject(option);
+      } else {
+        newSelection.addObject(option);
+      }
+      if (this.get('closeOnSelect')) {
+        dropdown.actions.close(e);
+      }
+      this.get('onchange')(newSelection, dropdown);
+    },
+
+    removeOption(dropdown, option, e) {
       e.stopPropagation();
       this.removeOption(option, dropdown);
+    },
+
+    handleKeydown(dropdown, e) {
+      if (e.defaultPrevented) { return; }
+      if (e.keyCode === 8) {  // BACKSPACE
+        this.removeLastOptionIfSearchIsEmpty(dropdown);
+        dropdown.actions.open(e);
+      } else if (e.keyCode === 13) {
+        e.stopPropagation();
+        if (dropdown.isOpen) {
+          const highlighted = this.get('_highlighted');
+          if (highlighted && (this.get('selected') || []).indexOf(highlighted) === -1) {
+            this.send('select', dropdown, highlighted, e);
+          } else {
+            dropdown.actions.close(e);
+          }
+        } else {
+          dropdown.actions.open(e);
+        }
+      } else {
+        this._super(...arguments);
+      }
     },
   },
 
   // Methods
-  onKeydown(dropdown, e) {
-    if (e.defaultPrevented) { return; }
-    if (e.keyCode === 8) {  // BACKSPACE
-      this.removeLastOptionIfSearchIsEmpty(dropdown);
-      dropdown.actions.open(e);
-    } else if (e.keyCode === 13) {
-      e.stopPropagation();
-      if (dropdown.isOpen) {
-        const highlighted = this.get('_highlighted');
-        if (highlighted && (this.get('selected') || []).indexOf(highlighted) === -1) {
-          this.select(highlighted, dropdown, e);
-        } else {
-          dropdown.actions.close(e);
-        }
-      } else {
-        dropdown.actions.open(e);
-      }
-    } else {
-      this._super(...arguments);
-    }
-  },
-
   defaultHighlighted() {
     return this.optionAtIndex(0);
-  },
-
-  select(option, dropdown, e) {
-    e.preventDefault();
-    e.stopPropagation();
-    const newSelection = this.cloneSelection();
-    if (newSelection.indexOf(option) > -1) {
-      newSelection.removeObject(option);
-    } else {
-      newSelection.addObject(option);
-    }
-    if (this.get('closeOnSelect')) {
-      dropdown.actions.close(e);
-    }
-    this.get('onchange')(newSelection, dropdown);
   },
 
   removeLastOptionIfSearchIsEmpty(dropdown) {
     if (this.get('_searchText.length') !== 0) { return; }
     const lastSelection = this.get('selection.lastObject');
     if (!lastSelection) { return; }
-    this.removeOption(lastSelection, dropdown);
+    this.removeOption(dropdown, lastSelection);
     if (typeof lastSelection === 'string') {
       this.performSearch(lastSelection);
     } else {
@@ -90,7 +90,7 @@ export default PowerSelectBaseComponent.extend({
     }
   },
 
-  removeOption(option, dropdown) {
+  removeOption(dropdown, option) {
     const newSelection = this.cloneSelection();
     newSelection.removeObject(option);
     this._resultsDirty = true;

--- a/addon/components/power-select/multiple/selected.js
+++ b/addon/components/power-select/multiple/selected.js
@@ -23,8 +23,9 @@ export default Ember.Component.extend({
 
   actions: {
     search(term, e) {
-      this.get('search')(term, e);
-      this.get('dropdown.actions.open')(e);
+      let { search, open } = this.get('select.actions');
+      search(term, e);
+      open(e);
     }
   }
 });

--- a/addon/components/power-select/single.js
+++ b/addon/components/power-select/single.js
@@ -21,38 +21,33 @@ export default PowerSelectBaseComponent.extend({
 
   // Actions
   actions: {
-    clear(dropdown, e) {
-      e.stopPropagation();
+    select(dropdown, option, e) {
       e.preventDefault();
-      this.set('selection', null);
-      this.get('onchange')(null, dropdown);
-    }
+      e.stopPropagation();
+      if (this.get('closeOnSelect')) {
+        dropdown.actions.close(e);
+      }
+      if (this.get('selection') !== option) {
+        this.get('onchange')(option, dropdown);
+      }
+    },
+
+    handleKeydown(dropdown, e) {
+      if (e.defaultPrevented) { return; }
+      if (e.keyCode === 13 && dropdown.isOpen) { // Enter
+        this.send('select', dropdown, this.get('_highlighted'), e);
+      } else {
+        this._super(...arguments);
+      }
+    },
   },
 
   // Methods
-  onKeydown(dropdown, e) {
-    if (e.defaultPrevented) { return; }
-    if (e.keyCode === 13 && dropdown.isOpen) { // Enter
-      this.select(this.get('_highlighted'), dropdown, e);
-    } else {
-      this._super(...arguments);
-    }
-  },
 
   defaultHighlighted() {
     return this.get('selection') || this.optionAtIndex(0);
   },
 
-  select(option, dropdown, e) {
-    e.preventDefault();
-    e.stopPropagation();
-    if (this.get('closeOnSelect')) {
-      dropdown.actions.close(e);
-    }
-    if (this.get('selection') !== option) {
-      this.get('onchange')(option, dropdown);
-    }
-  },
 
   focusSearch() {
     Ember.$('.ember-power-select-search input').focus();

--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -1,5 +1,5 @@
 {{#basic-dropdown class=(readonly concatenatedClasses) dir=dir tabindex=(readonly tabindex) renderInPlace=renderInPlace matchTriggerWidth=true
-  disabled=disabled dropdownPosition=dropdownPosition triggerClass=(readonly triggerClass) dropdownClass=_dropdownClass
+  disabled=disabled dropdownPosition=dropdownPosition triggerClass=(readonly triggerClass) dropdownClass=concatenatedDropdownClasses
   onOpen=(action onOpen) onClose=(action onClose) onFocus=(action focusSearch) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
   {{#with (hash
     isOpen=dropdown.isOpen

--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -1,30 +1,55 @@
 {{#basic-dropdown class=(readonly concatenatedClasses) dir=dir tabindex=(readonly tabindex) renderInPlace=renderInPlace matchTriggerWidth=true
   disabled=disabled dropdownPosition=dropdownPosition triggerClass=(readonly triggerClass) dropdownClass=_dropdownClass
-  onOpen=(action onOpen) onClose=(action onClose) onFocus=(action focusSearch) onKeydown=(action onKeydown) registerActionsInParent=(action "registerDropdown") as |dropdown|}}
-  <ul class="ember-power-select-options">
-    {{#if showLoadingMessage}}
-      <li class="ember-power-select-option">{{loadingMessage}}</li>
-    {{/if}}
-    {{#if resultsLength}}
-      {{#component optionsComponent options=(readonly results) highlighted=(readonly _highlighted) selection=(readonly selection)
-        optionsComponent=(readonly optionsComponent) highlight=(action "highlight") select=(action select)
-        searchText=(readonly _searchText) dropdown=(readonly dropdown) as |option|}}
-        {{yield option}}
-      {{/component}}
-    {{else if mustShowSearchMessage}}
-      <li class="ember-power-select-option">{{searchMessage}}</li>
-    {{else if noPendingPromises}}
-      {{#if hasInverseBlock}}
-        {{yield to="inverse"}}
-      {{else if noMatchesMessage}}
-        <li class="ember-power-select-option">{{noMatchesMessage}}</li>
+  onOpen=(action onOpen) onClose=(action onClose) onFocus=(action focusSearch) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
+  {{#with (hash
+    isOpen=dropdown.isOpen
+    actions=(hash
+      open=(action "open" dropdown)
+      close=(action "close" dropdown)
+      select=(action "select" dropdown)
+      highlight=(action "highlight" dropdown)
+      search=(action "search" dropdown)
+      removeOption=(action "removeOption" dropdown)
+      handleKeydown=(action "handleKeydown" dropdown)
+    )) as |select|}}
+
+    <ul class="ember-power-select-options">
+      {{#if showLoadingMessage}}
+        <li class="ember-power-select-option">{{loadingMessage}}</li>
       {{/if}}
-    {{/if}}
-  </ul>
+      {{#if resultsLength}}
+        {{#component optionsComponent options=(readonly results) highlighted=(readonly _highlighted)
+          selection=(readonly selection) optionsComponent=(readonly optionsComponent)
+          searchText=(readonly _searchText) select=(readonly select) as |option|}}
+          {{yield option}}
+        {{/component}}
+      {{else if mustShowSearchMessage}}
+        <li class="ember-power-select-option">{{searchMessage}}</li>
+      {{else if noPendingPromises}}
+        {{#if hasInverseBlock}}
+          {{yield to="inverse"}}
+        {{else if noMatchesMessage}}
+          <li class="ember-power-select-option">{{noMatchesMessage}}</li>
+        {{/if}}
+      {{/if}}
+    </ul>
+  {{/with}}
 {{else}}
-  {{#component selectedComponent selection=(readonly selection) dropdown=(readonly registeredDropdown)
-    searchText=(readonly _searchText) placeholder=(readonly placeholder) disabled=(readonly disabled) hasPendingPromises=(readonly hasPendingPromises)
-    removeOption=(action "removeOption") search=(action "search") onKeydown=(action onKeydown registeredDropdown) as |opt|}}
-    {{yield opt}}
-  {{/component}}
+  {{#with (hash
+    isOpen=registeredDropdown.isOpen
+    actions=(hash
+      open=(action "open" registeredDropdown)
+      close=(action "close" registeredDropdown)
+      select=(action "select" registeredDropdown)
+      highlight=(action "highlight" registeredDropdown)
+      search=(action "search" registeredDropdown)
+      removeOption=(action "removeOption" registeredDropdown)
+      handleKeydown=(action "handleKeydown" registeredDropdown)
+    )) as |select|}}
+    {{#component selectedComponent selection=(readonly selection) searchText=(readonly _searchText)
+      placeholder=(readonly placeholder) disabled=(readonly disabled) hasPendingPromises=(readonly hasPendingPromises)
+      select=(readonly select) as |opt|}}
+      {{yield opt}}
+    {{/component}}
+  {{/with}}
  {{/basic-dropdown}}

--- a/addon/templates/components/power-select/multiple/selected.hbs
+++ b/addon/templates/components/power-select/multiple/selected.hbs
@@ -1,7 +1,7 @@
 {{#each selection as |opt|}}
   <span class="ember-power-select-multiple-option">
     {{#unless disabled}}
-      <span aria-label="remove element" class="ember-power-select-multiple-remove-btn" onclick={{action removeOption opt dropdown}}>&times;</span>
+      <span aria-label="remove element" class="ember-power-select-multiple-remove-btn" onclick={{action select.actions.removeOption opt}}>&times;</span>
     {{/unless}}
     {{yield opt}}
   </span>
@@ -9,5 +9,5 @@
 <input type="search" class="ember-power-select-trigger-multiple-input" tabindex="0" autocomplete="off"
   autocorrect="off" autocapitalize="off" spellcheck="false" role="textbox" style={{triggerMultipleInputStyle}}
   placeholder={{maybePlaceholder}} value={{searchText}} disabled={{disabled}}
-  oninput={{action "search" value="target.value"}} onkeydown={{onKeydown}}>
+  oninput={{action "search" value="target.value"}} onkeydown={{select.actions.handleKeydown}}>
 <span class="ember-power-select-status-icon"></span>

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -3,14 +3,15 @@
     <li class="ember-power-select-group">
       <span class="ember-power-select-group-name">{{opt.groupName}}</span>
       <ul class="ember-power-select-options ember-power-select-options--nested">
-        {{#component optionsComponent highlighted=(readonly highlighted) selection=(readonly selection) options=(readonly opt.options)
-          highlight=(readonly highlight) select=(readonly select) optionsComponent=(readonly optionsComponent) dropdown=(readonly dropdown) as |option|}}
+        {{#component optionsComponent highlighted=(readonly highlighted) selection=(readonly selection)
+          options=(readonly opt.options) optionsComponent=(readonly optionsComponent) select=(readonly select) as |option|}}
           {{yield option}}
         {{/component}}
       </ul>
     </li>
   {{else}}
-    <li class="ember-power-select-option {{ember-power-select-option-classes opt selection highlighted}}" onclick={{action select opt dropdown}} onmouseover={{action highlight opt}}>
+    <li class="ember-power-select-option {{ember-power-select-option-classes opt selection highlighted}}"
+      onclick={{action select.actions.select opt}} onmouseover={{action select.actions.highlight opt}}>
       {{yield opt}}
     </li>
   {{/if}}

--- a/addon/templates/components/power-select/single.hbs
+++ b/addon/templates/components/power-select/single.hbs
@@ -1,5 +1,5 @@
 {{#basic-dropdown class=(readonly concatenatedClasses) dir=dir tabindex=(readonly tabindex) renderInPlace=renderInPlace matchTriggerWidth=true
-  disabled=disabled dropdownPosition=dropdownPosition triggerClass="ember-power-select-trigger" dropdownClass=_dropdownClass
+  disabled=disabled dropdownPosition=dropdownPosition triggerClass="ember-power-select-trigger" dropdownClass=concatenatedDropdownClasses
   onOpen=(action onOpen) onClose=(action onClose) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
   {{#with (hash
     isOpen=dropdown.isOpen

--- a/addon/templates/components/power-select/single.hbs
+++ b/addon/templates/components/power-select/single.hbs
@@ -1,37 +1,61 @@
 {{#basic-dropdown class=(readonly concatenatedClasses) dir=dir tabindex=(readonly tabindex) renderInPlace=renderInPlace matchTriggerWidth=true
   disabled=disabled dropdownPosition=dropdownPosition triggerClass="ember-power-select-trigger" dropdownClass=_dropdownClass
-  onOpen=(action onOpen) onClose=(action onClose) onKeydown=(action onKeydown) registerActionsInParent=(action "registerDropdown") as |dropdown|}}
-  {{#if searchEnabled}}
-    <div class="ember-power-select-search">
-      <input type="search" autocomplete="off" autocorrect="off" autocapitalize="off"
-      spellcheck="false" role="textbox" oninput={{action "search" value="target.value"}}
-      onkeydown={{action onKeydown dropdown}} placeholder={{searchPlaceholder}}>
-    </div>
-  {{/if}}
-  <ul class="ember-power-select-options">
-    {{#if showLoadingMessage}}
-      <li class="ember-power-select-option">{{loadingMessage}}</li>
+  onOpen=(action onOpen) onClose=(action onClose) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
+  {{#with (hash
+    isOpen=dropdown.isOpen
+    actions=(hash
+      open=(action "open" dropdown)
+      close=(action "close" dropdown)
+      select=(action "select" dropdown)
+      highlight=(action "highlight" dropdown)
+      search=(action "search" dropdown)
+      clear=(if allowClear (action "select" dropdown null))
+      handleKeydown=(action "handleKeydown" dropdown)
+    )) as |select|}}
+    {{#if searchEnabled}}
+      <div class="ember-power-select-search">
+        <input type="search" autocomplete="off" autocorrect="off" autocapitalize="off"
+        spellcheck="false" role="textbox" oninput={{action select.actions.search value="target.value"}}
+        onkeydown={{select.actions.handleKeydown}} placeholder={{searchPlaceholder}}>
+      </div>
     {{/if}}
-    {{#if resultsLength}}
-      {{#component optionsComponent options=(readonly results) highlighted=(readonly _highlighted) selection=(readonly selection) optionsComponent=(readonly optionsComponent)
-        searchText=(readonly _searchText) highlight=(action "highlight") select=(action select) dropdown=(readonly dropdown) as |option|}}
-        {{yield option}}
-      {{/component}}
-    {{else if mustShowSearchMessage}}
-      <li class="ember-power-select-option">{{searchMessage}}</li>
-    {{else if noPendingPromises}}
-      {{#if hasInverseBlock}}
-        {{yield to="inverse"}}
-      {{else if noMatchesMessage}}
-        <li class="ember-power-select-option">{{noMatchesMessage}}</li>
+    <ul class="ember-power-select-options">
+      {{#if showLoadingMessage}}
+        <li class="ember-power-select-option">{{loadingMessage}}</li>
       {{/if}}
-    {{/if}}
-  </ul>
+      {{#if resultsLength}}
+        {{#component optionsComponent options=(readonly results) highlighted=(readonly _highlighted)
+          selection=(readonly selection) optionsComponent=(readonly optionsComponent) searchText=(readonly _searchText)
+          select=select as |option|}}
+          {{yield option}}
+        {{/component}}
+      {{else if mustShowSearchMessage}}
+        <li class="ember-power-select-option">{{searchMessage}}</li>
+      {{else if noPendingPromises}}
+        {{#if hasInverseBlock}}
+          {{yield to="inverse"}}
+        {{else if noMatchesMessage}}
+          <li class="ember-power-select-option">{{noMatchesMessage}}</li>
+        {{/if}}
+      {{/if}}
+    </ul>
+  {{/with}}
 {{else}}
-  {{#component selectedComponent selection=(readonly selection) dropdown=(readonly registeredDropdown)
-    searchText=(readonly _searchText) placeholder=(readonly placeholder) disabled=(readonly disabled)
-    highlighted=(readonly _highlighted) allowClear=(readonly allowClear) hasPendingPromises=(readonly hasPendingPromises)
-    search=(action "search") select=(action select) clearSelection=(action "clear") as |opt|}}
-    {{yield opt}}
-  {{/component}}
+  {{#with (hash
+    isOpen=registeredDropdown.isOpen
+    actions=(hash
+      open=(action "open" registeredDropdown)
+      close=(action "close" registeredDropdown)
+      select=(action "select" registeredDropdown)
+      highlight=(action "highlight" registeredDropdown)
+      search=(action "search" registeredDropdown)
+      clear=(if allowClear (action "select" registeredDropdown null))
+      handleKeydown=(action "handleKeydown" registeredDropdown)
+    )) as |select|}}
+    {{#component selectedComponent selection=(readonly selection) searchText=(readonly _searchText)
+      placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly _highlighted)
+      hasPendingPromises=(readonly hasPendingPromises) select=select as |opt|}}
+      {{yield opt}}
+    {{/component}}
+  {{/with}}
 {{/basic-dropdown}}

--- a/addon/templates/components/power-select/single/selected.hbs
+++ b/addon/templates/components/power-select/single/selected.hbs
@@ -1,7 +1,7 @@
 {{#if selection}}
   {{yield selection}}
-  {{#if allowClear}}
-    <span class="ember-power-select-clear-btn" onclick={{action clearSelection dropdown}}>&times;</span>
+  {{#if select.actions.clear}}
+    <span class="ember-power-select-clear-btn" onclick={{select.actions.clear}}>&times;</span>
   {{/if}}
 {{else if placeholder}}
   <span class="ember-power-select-placeholder">{{placeholder}}</span>

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-basic-dropdown": "^0.6.0"
+    "ember-basic-dropdown": "^0.6.0",
+    "ember-hash-helper-polyfill": "0.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/integration/components/power-select-test.js
+++ b/tests/integration/components/power-select-test.js
@@ -1103,12 +1103,14 @@ test('Clicking the clear button removes the selection', function(assert) {
   assert.expect(6);
 
   this.numbers = numbers;
-  this.onChange = function(selected, dropdown) {
+  this.onChange = (selected, dropdown) => {
     assert.equal(selected, null, 'The onchange action was called with the new selection (null)');
     assert.ok(dropdown.actions.close, 'The onchange action was called with the dropdown object as second argument');
+    this.set('selected', selected);
   };
+  this.selected = "three";
   this.render(hbs`
-    {{#power-select options=numbers selected="three" allowClear=true onchange=onChange as |option|}}
+    {{#power-select options=numbers selected=selected allowClear=true onchange=onChange as |option|}}
       {{option}}
     {{/power-select}}
   `);
@@ -2094,7 +2096,7 @@ test('Passing as options the result of `store.query` works', function(assert) {
 11 - Customization using components
   a) [DONE] selected option can be customized using selectedComponent.
   b) [DONE] the list of options can be customized using optionsComponent.
-  c) [NOT DONE] The selected component receives the search action and can make use of it
+  c) [NOT DONE] The selected component receives the select's public API and can make use of it
 */
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Customization using components)', {
@@ -2133,23 +2135,6 @@ test('the list of options can be customized using optionsComponent', function(as
   let text = $('.ember-power-select-options').text().trim();
   assert.ok(/Countries:/.test(text), 'The given component is rendered');
   assert.ok(/3\. Russia/.test(text), 'The component has access to the options');
-});
-
-test('The selected component receives the search action', function(assert) {
-  assert.expect(1);
-
-  this.search = (term) => {
-    assert.equal(term, 'foobar', 'The search action received the text typed in the trigger component');
-    return [];
-  };
-
-  this.render(hbs`
-    {{#power-select search=(action search) selected=foo selectedComponent="typeahead-for-test" onchange=(action (mut foo)) as |country|}}
-      {{country.name}}
-    {{/power-select}}
-  `);
-
-  Ember.run(() => typeText('.typeahead-for-test-input', 'foobar'));
 });
 
 /**


### PR DESCRIPTION
The way compositions was handled was a bit chaotic. That was an internal issue but
still an issue. Some actions received the `dropdown` and other didn't, and
you had to remember to pass the dropdown as last argument to function calls.

This refactor creates a uniform shape for the yielded public API of the component
as follows:

```js
{
  state1: 'foo',
  state2: 'bar',
  ...
  actions: {
    action1: fn,
    action2: fn,
    ...
  }
}
```

Each level can use the public API of the nested component as follows:

```hbs
{{!-- in delorean.hbs --}}
{{#flux-condensor as |condensor|}}
  {{#with (hash gammaPower=condensor.level actions=(hash goToFuture=(action "travelForward" condensor) goToPast=(action "travelBackwards" condensor))) as |delorean|}}
    {{control-panel delorean=delorean year=currentYear}}
  {{/with}}
{{/flux-condensor}}

{{!-- in control-panel.hbs --}}
Year: {{eight-segments-display number=year}}
Charge: {{eight-segments-display number=delorean.gammaPower}}
<button onclick={{action delorean.goToFuture 10 'years'}}>+10</button>
<button onclick={{action delorean.actions.goToPast 10 'years'}}>-10</button>
```

The division between state and actions is artifical but help to get my head around problems.

What goes inside this publicAPI and what is passed as separate attributes to the `selected` or `options`
components? Basically only the things I feel confortable considering public API. Eventually this "publicAPI-object" might be the only passed attribute.

This contains breaking changes for people creating component to replace the trigger or options components of the dropdown. AFAIK that is very few people, but in any case migration should be easy.