### PR TITLE
Stop underscoring some internal fields.

### DIFF
--- a/addon/components/power-select/base.js
+++ b/addon/components/power-select/base.js
@@ -4,8 +4,8 @@ const { RSVP, computed, run, get } = Ember;
 
 export default Ember.Component.extend({
   tagName: '',
-  _highlighted: null,
-  _searchText: '',
+  highlighted: null,
+  searchText: '',
   hasPendingPromises: false,
   attributeBindings: ['dir'],
 
@@ -34,8 +34,8 @@ export default Ember.Component.extend({
     return classes.join(' ');
   }),
 
-  mustShowSearchMessage: computed('_searchText', 'search', 'searchMessage', function(){
-    return this.get('_searchText.length') === 0 && !!this.get('search') && !!this.get('searchMessage');
+  mustShowSearchMessage: computed('searchText', 'search', 'searchMessage', function(){
+    return this.get('searchText.length') === 0 && !!this.get('search') && !!this.get('searchMessage');
   }),
 
   resultsLength: computed('results.[]', function() {
@@ -54,7 +54,7 @@ export default Ember.Component.extend({
 
     highlight(dropdown, option) {
       if (option && get(option, 'disabled')) { return; }
-      this.set('_highlighted', option);
+      this.set('highlighted', option);
     },
 
     search(dropdown, term /*, e */) {
@@ -97,13 +97,13 @@ export default Ember.Component.extend({
   // Methods
   onOpen(e) {
     if (this._resultsDirty) { this.refreshResults(); }
-    this.set('_highlighted', this.defaultHighlighted());
+    this.set('highlighted', this.defaultHighlighted());
     run.scheduleOnce('afterRender', this, this.focusSearch, e);
     run.scheduleOnce('afterRender', this, this.scrollIfHighlightedIsOutOfViewport);
   },
 
   onClose() {
-    this.set('_searchText', '');
+    this.set('searchText', '');
     if (this.get('search')) {
       this.set('results', this.get('_options'));
     }
@@ -113,8 +113,8 @@ export default Ember.Component.extend({
 
   handleVerticalArrowKey(e) {
     e.preventDefault();
-    const newHighlighted = this.advanceSelectableOption(this.get('_highlighted'), e.keyCode === 40 ? 1 : -1);
-    this.set('_highlighted', newHighlighted);
+    const newHighlighted = this.advanceSelectableOption(this.get('highlighted'), e.keyCode === 40 ? 1 : -1);
+    this.set('highlighted', newHighlighted);
     run.scheduleOnce('afterRender', this, this.scrollIfHighlightedIsOutOfViewport);
   },
 
@@ -151,7 +151,7 @@ export default Ember.Component.extend({
   },
 
   refreshResults() {
-    const { _options: options, _searchText: searchText } = this.getProperties('_options', '_searchText');
+    const { _options: options, searchText } = this.getProperties('_options', 'searchText');
     if (!this.get('search')) {
       let matcher;
       if (this.get('searchField')) {
@@ -162,7 +162,7 @@ export default Ember.Component.extend({
       this.set('results', filterOptions(options || [], searchText, matcher));
     }
     this._resultsDirty = false;
-    this.set('_highlighted', this.optionAtIndex(0));
+    this.set('highlighted', this.optionAtIndex(0));
   },
 
   updateOptions(options) {
@@ -183,7 +183,7 @@ export default Ember.Component.extend({
     promise.then(results => {
       if (promise !== this.get('_activeSearch')) { return; }
       this.set('results', results);
-      this.set('_highlighted', this.optionAtIndex(0));
+      this.set('highlighted', this.optionAtIndex(0));
     }).finally(() => {
       const activePromise = this.get('_activeSearch');
       if (activePromise && promise !== activePromise) { return; }
@@ -192,7 +192,7 @@ export default Ember.Component.extend({
   },
 
   performSearch(term) {
-    this.set('_searchText', term);
+    this.set('searchText', term);
     if (this.get('search')) {
       this.performCustomSearch(term);
     } else {

--- a/addon/components/power-select/multiple.js
+++ b/addon/components/power-select/multiple.js
@@ -59,7 +59,7 @@ export default PowerSelectBaseComponent.extend({
       } else if (e.keyCode === 13) {
         e.stopPropagation();
         if (dropdown.isOpen) {
-          const highlighted = this.get('_highlighted');
+          const highlighted = this.get('highlighted');
           if (highlighted && (this.get('selected') || []).indexOf(highlighted) === -1) {
             this.send('select', dropdown, highlighted, e);
           } else {
@@ -80,7 +80,7 @@ export default PowerSelectBaseComponent.extend({
   },
 
   removeLastOptionIfSearchIsEmpty(dropdown) {
-    if (this.get('_searchText.length') !== 0) { return; }
+    if (this.get('searchText.length') !== 0) { return; }
     const lastSelection = this.get('selection.lastObject');
     if (!lastSelection) { return; }
     this.removeOption(dropdown, lastSelection);

--- a/addon/components/power-select/single.js
+++ b/addon/components/power-select/single.js
@@ -37,7 +37,7 @@ export default PowerSelectBaseComponent.extend({
       if (onkeydown) { onkeydown(dropdown, e); }
       if (e.defaultPrevented) { return; }
       if (e.keyCode === 13 && dropdown.isOpen) { // Enter
-        this.send('select', dropdown, this.get('_highlighted'), e);
+        this.send('select', dropdown, this.get('highlighted'), e);
       } else {
         this._super(...arguments);
       }

--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -18,8 +18,8 @@
         <li class="ember-power-select-option">{{loadingMessage}}</li>
       {{/if}}
       {{#if resultsLength}}
-        {{#component optionsComponent options=(readonly results) highlighted=(readonly _highlighted)
-          selection=(readonly selection) optionsComponent=(readonly optionsComponent) searchText=(readonly _searchText)
+        {{#component optionsComponent options=(readonly results) highlighted=(readonly highlighted)
+          selection=(readonly selection) optionsComponent=(readonly optionsComponent) searchText=(readonly searchText)
           select=(readonly select) extra=(readonly extra) as |option term|}}
           {{yield option term}}
         {{/component}}
@@ -46,8 +46,8 @@
       removeOption=(action "removeOption" registeredDropdown)
       handleKeydown=(action "handleKeydown" registeredDropdown)
     )) as |select|}}
-    {{#component selectedComponent options=(readonly results) selection=(readonly selection) searchText=(readonly _searchText)
-      placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly _highlighted)
+    {{#component selectedComponent options=(readonly results) selection=(readonly selection) searchText=(readonly searchText)
+      placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly highlighted)
       hasPendingPromises=(readonly hasPendingPromises) select=(readonly select) extra=(readonly extra) as |opt term|}}
       {{yield opt term}}
     {{/component}}

--- a/addon/templates/components/power-select/single.hbs
+++ b/addon/templates/components/power-select/single.hbs
@@ -24,8 +24,8 @@
         <li class="ember-power-select-option">{{loadingMessage}}</li>
       {{/if}}
       {{#if resultsLength}}
-        {{#component optionsComponent options=(readonly results) highlighted=(readonly _highlighted)
-          selection=(readonly selection) optionsComponent=(readonly optionsComponent) searchText=(readonly _searchText)
+        {{#component optionsComponent options=(readonly results) highlighted=(readonly highlighted)
+          selection=(readonly selection) optionsComponent=(readonly optionsComponent) searchText=(readonly searchText)
           select=(readonly select) extra=(readonly extra) as |option term|}}
           {{yield option term}}
         {{/component}}
@@ -52,8 +52,8 @@
       clear=(if allowClear (action "select" registeredDropdown null))
       handleKeydown=(action "handleKeydown" registeredDropdown)
     )) as |select|}}
-    {{#component selectedComponent options=(readonly results) selection=(readonly selection) searchText=(readonly _searchText)
-      placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly _highlighted)
+    {{#component selectedComponent options=(readonly results) selection=(readonly selection) searchText=(readonly searchText)
+      placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly highlighted)
       hasPendingPromises=(readonly hasPendingPromises) select=(readonly select) extra=(readonly extra) as |opt term|}}
       {{yield opt term}}
     {{/component}}

--- a/tests/integration/components/power-select-test.js
+++ b/tests/integration/components/power-select-test.js
@@ -1629,7 +1629,7 @@ test('Disabled options are not highlighted when hovered with the mouse', functio
 
   Ember.run(() => this.$('.ember-power-select-trigger').click());
   Ember.run(() => $('.ember-power-select-option--disabled:eq(0)').trigger('mouseover'));
-  assert.ok(!$('.ember-power-select-option--disabled:eq(0)').hasClass('ember-power-select-option--highlighted'), 'The hovered option was not highligted because it\'s disabled');
+  assert.ok(!$('.ember-power-select-option--disabled:eq(0)').hasClass('ember-power-select-option--highlighted'), 'The hovered option was not highlighted because it\'s disabled');
 });
 
 test('Disabled options are skipped when highlighting items with the keyboard', function(assert) {
@@ -1645,7 +1645,7 @@ test('Disabled options are skipped when highlighting items with the keyboard', f
   Ember.run(() => this.$('.ember-power-select-trigger').click());
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 40));
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 40));
-  assert.ok($('.ember-power-select-option--highlighted').text().trim(), 'LV: Latvia' ,'The hovered option was not highligted because it\'s disabled');
+  assert.ok($('.ember-power-select-option--highlighted').text().trim(), 'LV: Latvia' ,'The hovered option was not highlighted because it\'s disabled');
 });
 
 /**


### PR DESCRIPTION
The public API is clearly documented, so there is no need to using
underscores for this.

_searchText is no just searchText
_highlighted is now just highlighted