### PR TITLE
Refactor results and highlighted to be a computed property

### DIFF
--- a/addon/components/power-select/multiple.js
+++ b/addon/components/power-select/multiple.js
@@ -83,13 +83,9 @@ export default PowerSelectBaseComponent.extend({
     if (this.get('searchText.length') !== 0) { return; }
     const lastSelection = this.get('selection.lastObject');
     if (!lastSelection) { return; }
+    const lastText = typeof lastSelection === 'string' ? lastSelection : get(lastSelection, this.get('searchField'));
     this.removeOption(dropdown, lastSelection);
-    if (typeof lastSelection === 'string') {
-      this.performSearch(lastSelection);
-    } else {
-      if (!this.get('searchField')) { throw new Error('Need to provide `searchField` when options are not strings'); }
-      this.performSearch(get(lastSelection, this.get('searchField')));
-    }
+    this.set('searchText', lastText);
   },
 
   removeOption(dropdown, option) {

--- a/addon/components/power-select/single.js
+++ b/addon/components/power-select/single.js
@@ -50,7 +50,6 @@ export default PowerSelectBaseComponent.extend({
     return this.get('selection') || this.optionAtIndex(0);
   },
 
-
   focusSearch() {
     Ember.$('.ember-power-select-search input').focus();
   }

--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -25,7 +25,7 @@
         {{/component}}
       {{else if mustShowSearchMessage}}
         <li class="ember-power-select-option">{{searchMessage}}</li>
-      {{else if noPendingPromises}}
+      {{else if results.isFulfilled}}
         {{#if hasInverseBlock}}
           {{yield to="inverse"}}
         {{else if noMatchesMessage}}
@@ -48,7 +48,7 @@
     )) as |select|}}
     {{#component selectedComponent options=(readonly results) selection=(readonly selection) searchText=(readonly searchText)
       placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly highlighted)
-      hasPendingPromises=(readonly hasPendingPromises) select=(readonly select) extra=(readonly extra) as |opt term|}}
+      select=(readonly select) extra=(readonly extra) as |opt term|}}
       {{yield opt term}}
     {{/component}}
   {{/with}}

--- a/addon/templates/components/power-select/single.hbs
+++ b/addon/templates/components/power-select/single.hbs
@@ -31,7 +31,7 @@
         {{/component}}
       {{else if mustShowSearchMessage}}
         <li class="ember-power-select-option">{{searchMessage}}</li>
-      {{else if noPendingPromises}}
+      {{else if results.isFulfilled}}
         {{#if hasInverseBlock}}
           {{yield to="inverse"}}
         {{else if noMatchesMessage}}
@@ -54,7 +54,7 @@
     )) as |select|}}
     {{#component selectedComponent options=(readonly results) selection=(readonly selection) searchText=(readonly searchText)
       placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly highlighted)
-      hasPendingPromises=(readonly hasPendingPromises) select=(readonly select) extra=(readonly extra) as |opt term|}}
+      select=(readonly select) extra=(readonly extra) as |opt term|}}
       {{yield opt term}}
     {{/component}}
   {{/with}}

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -10,8 +10,11 @@ export function countOptions(collection) {
   let counter = 0;
   (function walk(collection) {
     if (!collection) { return null; }
+    if (!collection.objectAt) {
+      collection = Ember.A(collection);
+    }
     for (let i = 0; i < get(collection, 'length'); i++) {
-      let entry = get(collection, '' + i);
+      let entry = collection.objectAt(i);
       if (isGroup(entry)) {
         walk(get(entry, 'options'));
       } else {
@@ -26,8 +29,11 @@ export function indexOfOption(collection, option) {
   let index = 0;
   return (function walk(collection) {
     if (!collection) { return null; }
+    if (!collection.objectAt) {
+      collection = Ember.A(collection);
+    }
     for (let i = 0; i < get(collection, 'length'); i++) {
-      let entry = get(collection, '' + i);
+      let entry = collection.objectAt(i);
       if (isGroup(entry)) {
         let result = walk(get(entry, 'options'));
         if (result > -1) { return result; }
@@ -45,10 +51,13 @@ export function optionAtIndex(originalCollection, index) {
   let counter = 0;
   return (function walk(collection) {
     if (!collection) { return null; }
+    if (!collection.objectAt) {
+      collection = Ember.A(collection);
+    }
     let localCounter = 0;
     const length = get(collection, 'length');
     while (counter <= index && localCounter < length) {
-      let entry = get(collection, String(localCounter));
+      let entry = collection.objectAt(localCounter);
       if (isGroup(entry)) {
         let found = walk(get(entry, 'options'));
         if (found) { return found; }

--- a/tests/dummy/app/templates/legacy-demo.hbs
+++ b/tests/dummy/app/templates/legacy-demo.hbs
@@ -195,4 +195,4 @@
   <br>
   <br>
 
- </section>
+</section>

--- a/tests/integration/components/power-select-test.js
+++ b/tests/integration/components/power-select-test.js
@@ -195,7 +195,6 @@ test('If the passed options is a promise and it\'s not resolved the component sh
   `);
 
   Ember.run(() => this.$('.ember-power-select-trigger').click());
-
   assert.equal($('.ember-power-select-option').text().trim(), 'Loading options...', 'The loading message appears while the promise is pending');
   setTimeout(function() {
     assert.ok(!/Loading options/.test($('.ember-power-select-option').text()), 'The loading message is gone');
@@ -964,14 +963,14 @@ test('When one search is fired before the previous one resolved, the "Loading" c
     {{/power-select}}
   `);
   Ember.run(() => this.$('.ember-power-select-trigger').click());
-  Ember.run(() => typeInSearch("teen"));
+  Ember.run(() => typeInSearch("tee"));
 
   setTimeout(function() {
     Ember.run(() => typeInSearch("teen"));
   }, 50);
 
   setTimeout(function() {
-    assert.ok(/Loading options/.test($('.ember-power-select-option').text()));
+    assert.ok(/Loading options/.test($('.ember-power-select-option').text()), 'The loading message is visible');
     assert.equal($('.ember-power-select-option').length, 1, 'No results are shown');
   }, 120);
 


### PR DESCRIPTION
The code is significantly simpler, and also shorter. I haven't measured
but I also hope that being lazy there is some other advantage.

This might be slightly incompatible since the selectedComponent doesn't
receive the hasPendingPromises argument, but the `results` argument is now
a PromiseProxy, so it can check the `isFulfilled` there.