### PR TITLE
Update ember-basic-dropdown to fix rendering issue in ember 2.2.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-basic-dropdown": "^0.6.4",
+    "ember-basic-dropdown": "^0.6.5",
     "ember-hash-helper-polyfill": "^0.1.0"
   },
   "ember-addon": {


### PR DESCRIPTION
The bug was always there but ember 2.2.0 triggered it, perhaps for being
faster or something.

tl;dr; Ember-basic-dropdown has to ensure that the opened dropdown is
closed before the new one opens (otherwise the reposition code will target
the first one).
The solution is to attach the click event to close the dropdown when clicked outside
in the capture fase, instead of in the bubbling fase.

Closes #166 