### PR TITLE
Update ember-basic-dropdown to 0.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-basic-dropdown": "^0.6.5",
+    "ember-basic-dropdown": "^0.6.6",
     "ember-hash-helper-polyfill": "^0.1.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Required update to be able to open/close the select from the outside.