### PR TITLE
Enable open close via property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Master
 
+- [FEATURE] EPS now accepts a `opened` boolean property used to open/close the component
+  without triggering events on it. Useful to render the component already opened.
+
 # 0.6.3
 - [BUGFIX] Fix rendenring issue triggered somehow by Ember 2.2. Fixed in ember-basic-dropdown.
 - [REFACTOR] The list of results and the highlighted element are not computed properties, so they are lazy.

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -19,6 +19,7 @@ export const defaultOptions = {
   closeOnSelect: true,
   dropdownClass: null,
   dir: null,
+  opened: false,
 
   // Select single config
   searchEnabled: true,

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -19,6 +19,7 @@
     allowClear=allowClear
     dropdownPosition=dropdownPosition
     closeOnSelect=closeOnSelect
+    opened=opened
     hasInverseBlock=(hasBlock "inverse")
     tabindex=tabindex
     dir=dir

--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -1,6 +1,6 @@
 {{#basic-dropdown class=(readonly concatenatedClasses) dir=dir tabindex=(readonly tabindex) renderInPlace=renderInPlace matchTriggerWidth=true
   disabled=disabled dropdownPosition=dropdownPosition triggerClass=(readonly triggerClass) dropdownClass=concatenatedDropdownClasses
-  onOpen=(action onOpen) onClose=(action onClose) onFocus=(action focusSearch) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
+  opened=opened onOpen=(action onOpen) onClose=(action onClose) onFocus=(action focusSearch) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
   {{#with (hash
     isOpen=dropdown.isOpen
     actions=(hash

--- a/addon/templates/components/power-select/single.hbs
+++ b/addon/templates/components/power-select/single.hbs
@@ -1,6 +1,6 @@
 {{#basic-dropdown class=(readonly concatenatedClasses) dir=dir tabindex=(readonly tabindex) renderInPlace=renderInPlace matchTriggerWidth=true
   disabled=disabled dropdownPosition=dropdownPosition triggerClass="ember-power-select-trigger" dropdownClass=concatenatedDropdownClasses
-  onOpen=(action onOpen) onClose=(action onClose) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
+  opened=opened onOpen=(action onOpen) onClose=(action onClose) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
   {{#with (hash
     isOpen=dropdown.isOpen
     actions=(hash

--- a/tests/dummy/app/templates/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/docs/api-reference.hbs
@@ -17,7 +17,7 @@
     <tr>
       <td>selected</td>
       <td><code>any or array</code></td>
-      <td>The selected option</td>
+      <td>The selected option (or collection of options in multiple mode)</td>
     </tr>
     <tr>
       <td>onchange</td>
@@ -122,6 +122,14 @@
       <td>extra</td>
       <td><code>object</code></td>
       <td>Object to store any arbitrary configuration meant to be used by custom components</td>
+    </tr>
+    <tr>
+      <td>opened</td>
+      <td><code>boolean</code></td>
+      <td>
+        Boolean property that controls if the component is opened or closed. Unlinke all other properties
+        passed to this component, this is the only one desiged to be mutable.
+      </td>
     </tr>
   </tbody>
 </table>

--- a/tests/integration/components/power-select-test.js
+++ b/tests/integration/components/power-select-test.js
@@ -2347,7 +2347,62 @@ test('the list of options can be customized using optionsComponent', function(as
 });
 
 /**
-12 - Development assertions
+13 - Open/Close vía property
+*/
+
+moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Open/close via property)', {
+  integration: true
+});
+
+test('the select can be rendered already opened by passing `opened=true`', function(assert) {
+  assert.expect(1);
+
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select options=numbers onchange=(action (mut foo)) opened=true as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is opened');
+});
+
+test('It can be opened and closed by toggling the `opened` property', function(assert) {
+  assert.expect(3);
+
+  this.numbers = numbers;
+  this.opened = false;
+  this.render(hbs`
+    {{#power-select options=numbers onchange=(action (mut foo)) opened=opened as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is closed');
+  Ember.run(() => this.set('opened', true));
+  assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is opened');
+  Ember.run(() => this.set('opened', false));
+  assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is closed again');
+});
+
+test('when it is opened/closed and the `opened` property is multable, it gets updated', function(assert) {
+  assert.expect(2);
+
+  this.numbers = numbers;
+  this.opened = false;
+  this.render(hbs`
+    {{#power-select options=numbers onchange=(action (mut foo)) opened=opened as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  assert.ok(!this.get('opened'), 'The opened property is false');
+  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  assert.ok(this.get('opened'), 'The opened property is true now');
+});
+
+/**
+13 - Development assertions
 */
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Assertions)', {


### PR DESCRIPTION
This enables the component to be rendered already opened.

Example:

```hbs
{{#power-select options=opts selected=foo onchange=(action (mut foo)) opened=true as |opt|}}
  {{opt}}
{{/power-select}}
```

Also, toggling the `opened` property on the context will open and close the component (identical behaviour as clicking on it).

Unlike all other properties passed to this component, `opened` is the only one designed to be mutable (otherwise it would diverge with the internal state of the component once it is opened normally, loosing it's usefulness).

The component is still not designed to be opened at the same time as other selects/dropdowns, so opening more than one component at the same time with this technique might cause unexpected results.
