### PR TITLE
Onfocus action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Master
 
+- [BREAKING] Update to ember-basic-dropdown 0.7.0-beta.1. This means that the component is opened/
+  closed using mousedown instead of click. This makes the component feel more snappy. It is unlikeliy
+  that this breaks real world usage but might break integration tests of people where people rely
+  on `$('.ember-power-select-trigger').click()`.
+- [FEATURE] New action: `onfocus`. Unsurprisingly it is invoked when the component gains focus.
+  It receives `(dropdown, event)` and can be used, by example, to open the component on focus.
 - [FEATURE] EPS now accepts a `opened` boolean property used to open/close the component
   without triggering events on it. Useful to render the component already opened.
 

--- a/addon/components/power-select/multiple.js
+++ b/addon/components/power-select/multiple.js
@@ -72,6 +72,14 @@ export default PowerSelectBaseComponent.extend({
         this._super(...arguments);
       }
     },
+
+    handleFocus() {
+      const action = this.get('onfocus');
+      if (action) {
+        action();
+      }
+      this.focusSearch();
+    }
   },
 
   // Methods

--- a/addon/components/power-select/single.js
+++ b/addon/components/power-select/single.js
@@ -43,11 +43,10 @@ export default PowerSelectBaseComponent.extend({
       }
     },
 
-    handleFocus() {
-      debugger;
+    handleFocus(dropdown, event) {
       const action = this.get('onfocus');
       if (action) {
-        action();
+        action(dropdown, event);
       }
     }
   },

--- a/addon/components/power-select/single.js
+++ b/addon/components/power-select/single.js
@@ -42,6 +42,14 @@ export default PowerSelectBaseComponent.extend({
         this._super(...arguments);
       }
     },
+
+    handleFocus() {
+      debugger;
+      const action = this.get('onfocus');
+      if (action) {
+        action();
+      }
+    }
   },
 
   // Methods

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -3,6 +3,7 @@
     selected=selected
     onchange=onchange
     onkeydown=onkeydown
+    onfocus=onfocus
     disabled=disabled
     placeholder=placeholder
     searchEnabled=searchEnabled

--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -1,6 +1,6 @@
 {{#basic-dropdown class=(readonly concatenatedClasses) dir=dir tabindex=(readonly tabindex) renderInPlace=renderInPlace matchTriggerWidth=true
   disabled=disabled dropdownPosition=dropdownPosition triggerClass=(readonly triggerClass) dropdownClass=concatenatedDropdownClasses
-  opened=opened onOpen=(action onOpen) onClose=(action onClose) onFocus=(action focusSearch) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
+  opened=opened onOpen=(action onOpen) onClose=(action onClose) onFocus=(action "handleFocus") onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
   {{#with (hash
     isOpen=dropdown.isOpen
     actions=(hash

--- a/addon/templates/components/power-select/single.hbs
+++ b/addon/templates/components/power-select/single.hbs
@@ -1,6 +1,6 @@
 {{#basic-dropdown class=(readonly concatenatedClasses) dir=dir tabindex=(readonly tabindex) renderInPlace=renderInPlace matchTriggerWidth=true
   disabled=disabled dropdownPosition=dropdownPosition triggerClass="ember-power-select-trigger" dropdownClass=concatenatedDropdownClasses
-  opened=opened onOpen=(action onOpen) onClose=(action onClose) onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
+  opened=opened onOpen=(action onOpen) onClose=(action onClose) onFocus=(action "handleFocus") onKeydown=(action "handleKeydown") registerActionsInParent=(action "registerDropdown") as |dropdown|}}
   {{#with (hash
     isOpen=dropdown.isOpen
     actions=(hash

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-basic-dropdown": "^0.6.8",
+    "ember-basic-dropdown": "^0.7.0-beta.1",
     "ember-hash-helper-polyfill": "^0.1.0"
   },
   "ember-addon": {

--- a/tests/dummy/app/controllers/legacy-demo.js
+++ b/tests/dummy/app/controllers/legacy-demo.js
@@ -413,8 +413,12 @@ export default Ember.Controller.extend({
       });
     },
 
-    didFocus(/* select, e */) {
-      console.log('custom did focus');
+    didFocus(select, e) {
+      Ember.run.next(null, function() {
+        if (!select.isOpen) {
+          select.actions.open();
+        }
+      });
     }
   },
 

--- a/tests/dummy/app/controllers/legacy-demo.js
+++ b/tests/dummy/app/controllers/legacy-demo.js
@@ -414,11 +414,15 @@ export default Ember.Controller.extend({
     },
 
     didFocus(select, e) {
-      Ember.run.next(null, function() {
-        if (!select.isOpen) {
-          select.actions.open();
-        }
-      });
+      if (!select.isOpen) {
+        debugger;
+        select.actions.open();
+      }
+
+      // Ember.run.next(null, function() {
+      //   if (!select.isOpen) {
+      //   }
+      // });
     }
   },
 

--- a/tests/dummy/app/controllers/legacy-demo.js
+++ b/tests/dummy/app/controllers/legacy-demo.js
@@ -413,16 +413,8 @@ export default Ember.Controller.extend({
       });
     },
 
-    didFocus(select, e) {
-      if (!select.isOpen) {
-        debugger;
-        select.actions.open();
-      }
-
-      // Ember.run.next(null, function() {
-      //   if (!select.isOpen) {
-      //   }
-      // });
+    didFocus(select) {
+      select.actions.open();
     }
   },
 

--- a/tests/dummy/app/controllers/legacy-demo.js
+++ b/tests/dummy/app/controllers/legacy-demo.js
@@ -411,6 +411,10 @@ export default Ember.Controller.extend({
           resolve(numbers.filter(str => str.length === length)); // returns the numbers with the same length than the current
         }, 1500);
       });
+    },
+
+    didFocus(/* select, e */) {
+      console.log('custom did focus');
     }
   },
 

--- a/tests/dummy/app/templates/legacy-demo.hbs
+++ b/tests/dummy/app/templates/legacy-demo.hbs
@@ -11,7 +11,7 @@
   <h4>Select of strings without value tracking. You can filter right away.</h4>
   <p>simpleSelected is: {{simpleSelected}}</p> --}}
 
-  {{#power-select options=(readonly moarNumbers) selected=(readonly simpleSelected)
+  {{#power-select options=(readonly simpleOptions) selected=(readonly simpleSelected)
     onchange=(action (mut simpleSelected))
     onfocus=(action "didFocus") as |option|}}
     {{option}}

--- a/tests/dummy/app/templates/legacy-demo.hbs
+++ b/tests/dummy/app/templates/legacy-demo.hbs
@@ -3,20 +3,20 @@
   <h2 id="title">Welcome to the demo of ember-power-select (provisional name)</h2>
 
   <p><strong>Trying to reproduce bug with store.findAll('user')</strong></p>
-{{!--
+
   {{#power-select options=model selected=selectedUser onchange=(action (mut selectedUser)) as |user|}}
     {{user.name}}
   {{/power-select}}
 
   <h4>Select of strings without value tracking. You can filter right away.</h4>
-  <p>simpleSelected is: {{simpleSelected}}</p> --}}
+  <p>simpleSelected is: {{simpleSelected}}</p>
 
   {{#power-select options=(readonly simpleOptions) selected=(readonly simpleSelected)
     onchange=(action (mut simpleSelected))
     onfocus=(action "didFocus") as |option|}}
     {{option}}
   {{/power-select}}
-{{!--
+
   <h4>Select of strings with value tracking</h4>
   {{#power-select options=(readonly simpleOptions) selected=(readonly simpleSelected) onchange=(action (mut simpleSelected)) as |option|}}
     {{option}}
@@ -196,5 +196,5 @@
   <br>
   <br>
   <br>
- --}}
+
 </section>

--- a/tests/dummy/app/templates/legacy-demo.hbs
+++ b/tests/dummy/app/templates/legacy-demo.hbs
@@ -3,18 +3,20 @@
   <h2 id="title">Welcome to the demo of ember-power-select (provisional name)</h2>
 
   <p><strong>Trying to reproduce bug with store.findAll('user')</strong></p>
-
+{{!--
   {{#power-select options=model selected=selectedUser onchange=(action (mut selectedUser)) as |user|}}
     {{user.name}}
   {{/power-select}}
 
   <h4>Select of strings without value tracking. You can filter right away.</h4>
-  <p>simpleSelected is: {{simpleSelected}}</p>
+  <p>simpleSelected is: {{simpleSelected}}</p> --}}
 
-  {{#power-select options=(readonly moarNumbers) selected=(readonly simpleSelected) onchange=(action (mut simpleSelected)) as |option|}}
+  {{#power-select options=(readonly moarNumbers) selected=(readonly simpleSelected)
+    onchange=(action (mut simpleSelected))
+    onfocus=(action "didFocus") as |option|}}
     {{option}}
   {{/power-select}}
-
+{{!--
   <h4>Select of strings with value tracking</h4>
   {{#power-select options=(readonly simpleOptions) selected=(readonly simpleSelected) onchange=(action (mut simpleSelected)) as |option|}}
     {{option}}
@@ -194,5 +196,5 @@
   <br>
   <br>
   <br>
-
+ --}}
 </section>

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -25,7 +25,7 @@ test('When you pass a custom search action instead of options, opening the selec
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').text(), 'Type to search', 'The dropdown shows the "type to seach" message');
 });
 
@@ -39,7 +39,7 @@ test('The "type to search" message can be customized passing `searchMessage=some
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').text(), 'Type the name of the thing');
 });
 
@@ -56,7 +56,7 @@ test('The search function can return an array and those options get rendered', f
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("teen"));
   assert.equal($('.ember-power-select-option').length, 7);
 });
@@ -79,7 +79,7 @@ test('The search function can return a promise that resolves to an array and tho
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("teen"));
 
   setTimeout(function() {
@@ -106,7 +106,7 @@ test('While the async search is being performed the "Type to search" dissapears 
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok(/Type to search/.test($('.ember-power-select-dropdown').text()), 'The type to search message is displayed');
   Ember.run(() => typeInSearch("teen"));
   assert.ok(!/Type to search/.test($('.ember-power-select-dropdown').text()), 'The type to search message dissapeared');
@@ -130,7 +130,7 @@ test('When the search resolves to an empty array then the "No results found" mes
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("teen"));
   setTimeout(() => {
     assert.ok(/No results found/.test($('.ember-power-select-option').text()), 'The default "No results" message renders');
@@ -154,7 +154,7 @@ test('When the search resolves to an empty array then the custom "No results" me
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("teen"));
   setTimeout(() => {
     assert.ok(/Meec\. Try again/.test($('.ember-power-select-option').text()), 'The customized "No results" message renders');
@@ -180,7 +180,7 @@ test('When the search resolves to an empty array then the custom alternate block
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("teen"));
   setTimeout(() => {
     assert.equal($('.ember-power-select-dropdown .foo-bar').length, 1, 'The alternate block message gets rendered');
@@ -203,7 +203,7 @@ test('When one search is fired before the previous one resolved, the "Loading" c
       {{number}}
     {{/power-select}}
   `);
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("tee"));
 
   setTimeout(function() {
@@ -236,7 +236,7 @@ test('When the search resolves, the first element is highlighted like with regul
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("teen"));
 
   setTimeout(function() {
@@ -258,12 +258,15 @@ test('Closing a component with a custom search cleans the search box and the res
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("teen"));
   assert.equal($('.ember-power-select-option').length, 7, 'Results are filtered');
   assert.equal($('.ember-power-select-search input').val(), 'teen');
-  Ember.run(() => this.$('#different-node').click());
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => {
+    let event = new window.Event('mousedown');
+    this.$('#different-node')[0].dispatchEvent(event);
+  });
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').length, 1, 'Results have been cleared');
   assert.equal($('.ember-power-select-option').text().trim(), 'Type to search');
   assert.equal($('.ember-power-select-search input').val(), '', 'The searchbox was cleared');
@@ -289,7 +292,7 @@ test('When received both options and search, those options are shown when the dr
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').length, 20, 'All the options are shown');
   Ember.run(() => typeInSearch("teen"));
   assert.equal($('.ember-power-select-option').length, 21, 'All the options are shown and also the loading message');
@@ -318,7 +321,7 @@ test('Don\'t return from the search action and update the options instead also w
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').length, 20, 'All the options are shown');
   Ember.run(() => typeInSearch("teen"));
 

--- a/tests/integration/components/power-select/customization-with-compoments-test.js
+++ b/tests/integration/components/power-select/customization-with-compoments-test.js
@@ -40,7 +40,7 @@ test('the list of options can be customized using optionsComponent', function(as
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   let text = $('.ember-power-select-options').text().trim();
   assert.ok(/Countries:/.test(text), 'The given component is rendered');
   assert.ok(/3\. Russia/.test(text), 'The component has access to the options');

--- a/tests/integration/components/power-select/disabled-test.js
+++ b/tests/integration/components/power-select/disabled-test.js
@@ -24,7 +24,7 @@ test('A disabled dropdown doesn\'t responds to mouse/keyboard events', function(
 
   let $select = this.$('.ember-power-select');
   assert.ok($select.hasClass('ember-basic-dropdown--disabled'), 'The select has the disabled class');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is still closed');
   Ember.run(() => triggerKeydown($('.ember-power-select-trigger')[0], 13));
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is still closed');
@@ -53,7 +53,7 @@ test('Options with a disabled field set to true are styled as disabled', functio
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').length, 7, 'There is 7 options');
   assert.equal($('.ember-power-select-option--disabled').length, 3, 'Three of them are disabled');
 });
@@ -68,7 +68,7 @@ test('Disabled options are not highlighted when hovered with the mouse', functio
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option--disabled:eq(0)').trigger('mouseover'));
   assert.ok(!$('.ember-power-select-option--disabled:eq(0)').hasClass('ember-power-select-option--highlighted'), 'The hovered option was not highlighted because it\'s disabled');
 });
@@ -83,7 +83,7 @@ test('Disabled options are skipped when highlighting items with the keyboard', f
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 40));
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 40));
   assert.ok($('.ember-power-select-option--highlighted').text().trim(), 'LV: Latvia' ,'The hovered option was not highlighted because it\'s disabled');

--- a/tests/integration/components/power-select/ember-data-test.js
+++ b/tests/integration/components/power-select/ember-data-test.js
@@ -29,7 +29,7 @@ test('Passing as options of a `store.findAll` works', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').text().trim(), 'Loading options...', 'The loading message appears while the promise is pending');
 
   setTimeout(function() {
@@ -51,7 +51,7 @@ test('Passing as options the result of `store.query` works', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').text().trim(), 'Loading options...', 'The loading message appears while the promise is pending');
 
   setTimeout(function() {

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -31,7 +31,7 @@ test('Click in the trigger of a closed select opens the dropdown', function(asse
 
   assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is not rendered');
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
 });
 
@@ -45,10 +45,10 @@ test('Click in the trigger of an opened select closes the dropdown', function(as
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is not rendered');
 });
 
@@ -62,7 +62,7 @@ test('Search functionality is enabled by default', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-search').length, 1, 'The search box is rendered');
 });
 
@@ -76,7 +76,7 @@ test('The search functionality can be disabled by passing `searchEnabled=false`'
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
   assert.equal($('.ember-power-select-search').length, 0, 'The search box NOT rendered');
 });
@@ -91,7 +91,7 @@ test('The search box gain focus automatically when opened', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok($('.ember-power-select-search input').get(0) === document.activeElement, 'The search box is focused after opening select');
 });
 
@@ -105,7 +105,7 @@ test('Each option of the select is the result of yielding an item', function(ass
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').length, numbers.length, 'There is as many options in the markup as in the supplied array');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'one');
   assert.equal($('.ember-power-select-option:eq(9)').text().trim(), 'ten');
@@ -126,7 +126,7 @@ test('If the passed options is a promise and it\'s not resolved the component sh
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').text().trim(), 'Loading options...', 'The loading message appears while the promise is pending');
   setTimeout(function() {
     assert.ok(!/Loading options/.test($('.ember-power-select-option').text()), 'The loading message is gone');
@@ -149,7 +149,7 @@ test('If the passed options is a promise and it\'s not resolved but the `loading
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
 
   assert.equal($('.ember-power-select-option').length, 0, 'No loading options message is displayed');
   setTimeout(function() {
@@ -169,7 +169,7 @@ test('If a placeholder is provided, it shows while no element is selected', func
   `);
 
   assert.equal($('.ember-power-select-trigger .ember-power-select-placeholder').text().trim(), 'abracadabra', 'The placeholder is rendered when there is no element');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:eq(3)').click());
   assert.equal($('.ember-power-select-trigger .ember-power-select-placeholder').length, 0, 'The placeholder is gone');
   assert.equal($('.ember-power-select-trigger').text().trim(), 'four', 'The selected item replaced it');
@@ -192,7 +192,7 @@ test('If the `selected` value changes the select gets updated, but the `onchange
 
   Ember.run(() => this.set('selected', 'three'));
   assert.equal($('.ember-power-select-trigger').text().trim(), 'three', 'The `three` element is selected');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'three', 'The proper option gets highlighed');
   assert.equal($('.ember-power-select-option--selected').text().trim(), 'three', 'The proper option gets selected');
 });
@@ -209,7 +209,7 @@ test('If the user selects a value and later on the selected value changes from t
   `);
 
   assert.equal($('.ember-power-select-trigger').text().trim(), '', 'Nothing is selected');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:eq(3)').click());
   assert.equal($('.ember-power-select-trigger').text().trim(), 'four', '"four" has been selected');
   Ember.run(() => this.set('selected', 'three'));
@@ -226,7 +226,7 @@ test('If the user passes `renderInPlace=true` the dropdown is added below the tr
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal(this.$('.ember-power-select-dropdown').length, 1, 'The dropdown is inside the component');
 });
 
@@ -241,7 +241,7 @@ test('If the user passes `closeOnSelect=false` the dropdown remains visible afte
   `);
 
   assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is not rendered');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
   Ember.run(() => $('.ember-power-select-option:eq(3)').click());
   assert.equal($('.ember-power-select-trigger').text().trim(), 'four', '"four" has been selected');
@@ -265,7 +265,7 @@ test('If the content of the options is refreshed (starting with empty array prox
 
   this.render(hbs`{{#power-select options=proxy search=(action search) onchange=(action (mut foo)) as |option|}} {{option}} {{/power-select}}`);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("o"));
 
   setTimeout(function() {
@@ -292,7 +292,7 @@ test('If the content of the options is updated (starting with populated array pr
 
   this.render(hbs`{{#power-select options=proxy search=(action search) onchange=(action (mut foo)) as |option|}} {{option}} {{/power-select}}`);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
 
   assert.equal($('.ember-power-select-option').length, 1, 'The dropdown is opened and results shown with initial proxy contents');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'one');
@@ -316,7 +316,7 @@ test('If the content of the selected is refreshed while opened the first element
       {{option}}
     {{/power-select}}
   `);
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 40));
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'two', 'The second options is highlighted');
   Ember.run(() => this.set('numbers', ['foo', 'bar', 'baz']));
@@ -332,7 +332,7 @@ test('If the user passes `dropdownClass` the dropdown content should have that c
       {{option}}
     {{/power-select}}
   `);
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok($('.ember-power-select-dropdown').hasClass('this-is-a-test-class'), 'dropdownClass can be customized');
 });
 
@@ -345,7 +345,7 @@ test('If the user passes `class` the classes of the dropdown are customized usin
     {{/power-select}}
   `);
   assert.ok($('.ember-power-select').hasClass('my-foo'), 'the entire select inherits that class');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok($('.ember-power-select-dropdown').hasClass('my-foo-dropdown'), 'the dropdown derives its class from the given one too');
 });
 
@@ -359,11 +359,14 @@ test('The filtering is reverted after closing the select', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('th'));
   assert.equal($('.ember-power-select-option').length, 2, 'the dropdown has filtered the results');
-  Ember.run(() => this.$('#outside-div').click());
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => {
+    let event = new window.Event('mousedown');
+    this.$('#outside-div')[0].dispatchEvent(event);
+  });
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').length, numbers.length, 'the dropdown has shows all results');
 });
 
@@ -376,7 +379,7 @@ test('It has the appropriate class when it receives a specific dropdown position
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok(this.$('.ember-power-select').hasClass('ember-basic-dropdown--above'), 'It has the class of dropdowns positioned above');
 });
 
@@ -389,11 +392,11 @@ test('The search term is yielded as second argument in single selects', function
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('tw'));
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'tw:two', 'Each option receives the search term');
   Ember.run(() => $('.ember-power-select-option:eq(0)').click());
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('thr'));
   assert.equal($('.ember-power-select-trigger').text().trim(), 'thr:two', 'The trigger also receives the search term');
 });
@@ -405,7 +408,7 @@ test('The dropdowns shows the default "no options" message', function(assert) {
       {{option}}
     {{/power-select}}
   `);
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').length, 1);
   assert.equal($('.ember-power-select-option').text().trim(), 'No results found');
 });
@@ -417,7 +420,7 @@ test('The default "no options" message can be customized passing `noMatchesMessa
       {{option}}
     {{/power-select}}
   `);
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').length, 1);
   assert.equal($('.ember-power-select-option').text().trim(), 'Nope');
 });
@@ -431,7 +434,7 @@ test('The content of the dropdown when there are no options can be completely cu
       <span class="empty-option-foo">Foo bar</span>
     {{/power-select}}
   `);
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option').length, 0, 'No list elements, just the given alternate block');
   assert.equal($('.empty-option-foo').length, 1);
 });
@@ -446,7 +449,7 @@ test('When no `selected` is provided, the first item in the dropdown is highligh
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
   assert.equal($('.ember-power-select-option--highlighted').length, 1, 'One element is highlighted');
   assert.ok($('.ember-power-select-option:eq(0)').hasClass('ember-power-select-option--highlighted'), 'The first one to be precise');
@@ -482,7 +485,7 @@ test('When `selected` option is provided, it is highlighted when the dropdown op
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   const $highlightedOption = $('.ember-power-select-option--highlighted');
   assert.equal($highlightedOption.length, 1, 'One element is highlighted');
   assert.equal($highlightedOption.text().trim(), 'three', 'The third option is highlighted');
@@ -498,7 +501,7 @@ test('When `selected` option is provided, that option is marked as `.selected`',
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   const $selectedOption = $('.ember-power-select-option:contains("three")');
   assert.ok($selectedOption.hasClass('ember-power-select-option--selected'), 'The third option is marked as selected');
 });
@@ -513,7 +516,7 @@ test('The default search strategy matches disregarding diacritics differences an
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('mar'));
   assert.equal($('.ember-power-select-option').length, 2, 'Only 2 results match the search');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'María');
@@ -541,7 +544,7 @@ test('You can pass a custom marcher with `matcher=myFn` to customize the search 
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('on'));
   assert.equal($('.ember-power-select-option').text().trim(), "No results found", 'No number ends in "on"');
   Ember.run(() => typeInSearch('teen'));
@@ -558,7 +561,7 @@ test('When no `selected` is provided, the first item in the dropdown is highligh
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
   assert.equal($('.ember-power-select-option--highlighted').length, 1, 'One element is highlighted');
   assert.ok($('.ember-power-select-option:eq(0)').hasClass('ember-power-select-option--highlighted'), 'The first one to be precise');
@@ -589,7 +592,7 @@ test('When `selected` option is provided, it is highlighted when the dropdown op
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   const $highlightedOption = $('.ember-power-select-option--highlighted');
   assert.equal($highlightedOption.length, 1, 'One element is highlighted');
   assert.equal($highlightedOption.text().trim(), 'ES: Spain', 'The second option is highlighted');
@@ -606,7 +609,7 @@ test('When `selected` option is provided, that option is marked as `.selected`',
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   const $selectedOption = $('.ember-power-select-option:contains("ES: Spain")');
   assert.ok($selectedOption.hasClass('ember-power-select-option--selected'), 'The second option is marked as selected');
 });
@@ -629,7 +632,7 @@ test('The default search strategy matches disregarding diacritics differences an
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('mar'));
   assert.equal($('.ember-power-select-option').length, 2, 'Only 2 results match the search');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'María Murray');
@@ -665,7 +668,7 @@ test('You can pass a custom marcher with `matcher=myFn` to customize the search 
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('s'));
   assert.equal($('.ember-power-select-option').length, 3, 'Only 3 results match the search');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Søren Williams');

--- a/tests/integration/components/power-select/groups-test.js
+++ b/tests/integration/components/power-select/groups-test.js
@@ -24,7 +24,7 @@ test('Options that have a `groupName` and `options` are considered groups and ar
 
   assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is not rendered');
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
 
   let $rootLevelGroups = $('.ember-power-select-dropdown > .ember-power-select-options > .ember-power-select-group');
   let $rootLevelOptions = $('.ember-power-select-dropdown > .ember-power-select-options > .ember-power-select-option');
@@ -50,7 +50,7 @@ test('When filtering, a group title is visible as long as one of it\'s elements 
       {{option}}
     {{/power-select}}
   `);
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('ve'));
   let groupNames = $('.ember-power-select-group-name').toArray().map(e => $(e).text().trim());
   let optionValues = $('.ember-power-select-option').toArray().map(e => $(e).text().trim());
@@ -70,7 +70,7 @@ test('Click on an option of a group select selects the option and closes the dro
       {{option}}
     {{/power-select}}
   `);
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:contains("four")').click());
   assert.equal($('.ember-power-select-trigger').text().trim(), "four", 'The clicked option was selected');
   assert.equal($('.ember-power-select-options').length, 0, 'The dropdown has dissapeared');
@@ -86,7 +86,7 @@ test('Clicking on the title of a group doesn\'t performs any action nor closes t
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => this.$('.ember-power-select-group-name:eq(1)').click());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is still opened');
 });

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -22,7 +22,7 @@ test('Pressing keydown highlights the next option', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'one');
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 40));
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'two', 'The next options is highlighted now');
@@ -38,7 +38,7 @@ test('Pressing keyup highlights the previous option', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'three');
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 38));
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'two', 'The previous options is highlighted now');
@@ -55,7 +55,7 @@ test('When you the last option is highlighted, pressing keydown doesn\'t change 
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'twenty');
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 40));
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'twenty', 'The last option is still the highlighted one');
@@ -72,7 +72,7 @@ test('When you the first option is highlighted, pressing keyup doesn\'t change t
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'one');
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 38));
   assert.equal($('.ember-power-select-option--highlighted').text().trim(), 'one', 'The first option is still the highlighted one');
@@ -94,7 +94,7 @@ test('Pressing ENTER selects the highlighted element, closes the dropdown and fo
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 40));
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 13));
   assert.equal($('.ember-power-select-trigger').text().trim(), 'two', 'The highlighted element was selected');
@@ -112,7 +112,7 @@ test('Pressing TAB closes the select WITHOUT selecting the highlighed element an
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 40));
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 9));
   assert.equal($('.ember-power-select-trigger').text().trim(), '', 'The highlighted element wasn\'t selected');
@@ -190,7 +190,7 @@ test('Pressing ESC while the component is opened closes it and focuses the trigg
     {{/power-select}}
   `);
 
-  Ember.run(() => $('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is opened');
   Ember.run(() => triggerKeydown($('.ember-power-select-trigger')[0], 27));
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is closed');
@@ -216,7 +216,7 @@ test('In single-mode, when the user presses a key being the search input focused
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is opened');
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 13));
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is closed');
@@ -237,7 +237,7 @@ test('in single-mode if the users calls preventDefault on the event received in 
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is opened');
   Ember.run(() => triggerKeydown($('.ember-power-select-search input')[0], 13));
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is still opened');
@@ -262,7 +262,7 @@ test('In multiple-mode, when the user presses a key being the search input focus
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is opened');
   Ember.run(() => triggerKeydown($('.ember-power-select-trigger-multiple-input')[0], 13));
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is closed');
@@ -283,7 +283,7 @@ test('in multiple-mode if the users calls preventDefault on the event received i
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is opened');
   Ember.run(() => triggerKeydown($('.ember-power-select-trigger-multiple-input')[0], 13));
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is still opened');

--- a/tests/integration/components/power-select/mouse-control-test.js
+++ b/tests/integration/components/power-select/mouse-control-test.js
@@ -20,7 +20,7 @@ test('Mouseovering a list item highlights it', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok($('.ember-power-select-option:eq(0)').hasClass('ember-power-select-option--highlighted'), 'The first element is highlighted');
   Ember.run(() => $('.ember-power-select-option:eq(3)').trigger('mouseover'));
   assert.ok($('.ember-power-select-option:eq(3)').hasClass('ember-power-select-option--highlighted'), 'The 4th element is highlighted');
@@ -41,7 +41,7 @@ test('Clicking an item selects it, closes the dropdown and focuses the trigger',
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:eq(3)').click());
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select was closed');
   assert.ok($('.ember-power-select-trigger').get(0) === document.activeElement, 'The trigger is focused');
@@ -57,9 +57,9 @@ test('Clicking the trigger while the select is opened closes it and and focuses 
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is opened');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is closed');
   assert.ok($('.ember-power-select-trigger').get(0) === document.activeElement, 'The trigger is focused');
 });
@@ -98,9 +98,12 @@ test('Clicking anywhere outside the select while opened closes the component and
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The select is opened');
-  Ember.run(() => this.$('#other-thing').click());
+  Ember.run(() => {
+    let event = new window.Event('mousedown');
+    this.$('#other-thing')[0].dispatchEvent(event);
+  });
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is closed');
   assert.ok($('.ember-power-select-trigger').get(0) !== document.activeElement, 'The select is not focused');
 });

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -25,7 +25,7 @@ test('Multiple selects don\'t have a search box', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-search').length, 0, 'There is no search box');
 });
 
@@ -39,7 +39,7 @@ test('When the select opens, the search input in the trigger gets the focus', fu
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok($('.ember-power-select-trigger-multiple-input').get(0) === document.activeElement, 'The search input is focused');
 });
 
@@ -53,7 +53,7 @@ test('Click on an element selects it and closes the dropdown and focuses the tri
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok(this.$('.ember-power-select-trigger-multiple-input').get(0) === document.activeElement, 'The input of the trigger is focused');
   Ember.run(() => $('.ember-power-select-option:eq(1)').click());
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The dropdown is closed');
@@ -76,7 +76,7 @@ test('Selecting an element triggers the onchange action with the list of selecte
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:eq(1)').click());
 });
 
@@ -97,7 +97,7 @@ test('Click an option when there is already another selects both, and triggers t
   `);
 
   assert.equal($('.ember-power-select-multiple-option').length, 1, 'There is 1 option selected');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:eq(1)').click());
   assert.equal($('.ember-power-select-multiple-option').length, 2, 'There is 2 options selected');
   assert.ok(/four/.test($('.ember-power-select-multiple-option:eq(0)').text()), 'The first option is the provided one');
@@ -116,7 +116,7 @@ test('If there is many selections, all those options are styled as `selected`', 
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok($('.ember-power-select-option:eq(1)').hasClass('ember-power-select-option--selected'), 'The second option is styled as selected');
   assert.ok($('.ember-power-select-option:eq(3)').hasClass('ember-power-select-option--selected'), 'The 4th option is styled as selected');
 });
@@ -133,7 +133,7 @@ test('When the popup opens, the first items is highlighed, even if there is only
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal($('.ember-power-select-option--highlighted').length, 1, 'There is one element highlighted');
   assert.equal($('.ember-power-select-option--selected').length, 1, 'There is one element selected');
   assert.equal($('.ember-power-select-option--highlighted.ember-power-select-option--selected').length, 0, 'They are not the same');
@@ -157,7 +157,7 @@ test('Clicking on an option that is already selected unselects it, closes the se
   `);
 
   assert.equal($('.ember-power-select-multiple-option').length, 1, 'There is 1 option selected');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option--selected').click());
   assert.equal($('.ember-power-select-multiple-option').length, 0, 'There is no options selected');
 });
@@ -172,7 +172,7 @@ test('The default filtering works in multiple mode', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('four'));
   assert.equal($('.ember-power-select-option').length, 2, 'Only two items matched the criteria');
 });
@@ -195,7 +195,7 @@ test('The filtering specifying a searchkey works in multiple model', function(as
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('mar'));
   assert.equal($('.ember-power-select-option').length, 2, 'Only 2 results match the search');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'María Murray');
@@ -223,7 +223,7 @@ test('The filtering specifying a custom matcher works in multiple model', functi
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('on'));
   assert.equal($('.ember-power-select-option').text().trim(), "No results found", 'No number ends in "on"');
   Ember.run(() => typeInSearch('teen'));
@@ -248,7 +248,7 @@ test('The search using a custom action works int multiple mode', function(assert
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch("teen"));
 
   setTimeout(function() {
@@ -267,7 +267,7 @@ test('Pressing ENTER when the select is closed opens and nothing is written on t
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 27));
   assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is not rendered');
   assert.ok($('.ember-power-select-trigger-multiple-input').get(0) === document.activeElement, 'The trigger is focused');
@@ -289,7 +289,7 @@ test('Pressing ENTER over a highlighted element selects it', function(assert) {
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 40));
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 13));
   assert.ok(/two/.test($('.ember-power-select-trigger').text().trim()), 'The element was selected');
@@ -310,7 +310,7 @@ test('Pressing ENTER over a highlighted element what is already selected closes 
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 40));
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 13));
   assert.ok(/two/.test($('.ember-power-select-trigger').text().trim()), 'The element is still selected');
@@ -333,7 +333,7 @@ test('Pressing BACKSPACE on the search input when there is text on it does nothi
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('four'));
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 8));
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The dropown is still opened');
@@ -355,7 +355,7 @@ test('Pressing BACKSPACE on the search input when it\'s empty removes the last s
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal(this.$('.ember-power-select-multiple-option').length, 1, 'There is one element selected');
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 8));
   assert.equal(this.$('.ember-power-select-multiple-option').length, 0, 'There is no elements selected');
@@ -374,9 +374,9 @@ test('Pressing BACKSPACE on the search input when it\'s empty removes the last s
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:eq(2)').click());
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.equal(this.$('.ember-power-select-multiple-option').length, 1, 'There is one element selected');
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 8));
   assert.equal(this.$('.ember-power-select-multiple-option').length, 0, 'There is no elements selected');
@@ -395,7 +395,7 @@ test('If the multiple component is focused, pressing KEYDOWN opens it', function
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 27));
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is closed');
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 40));
@@ -412,7 +412,7 @@ test('If the multiple component is focused, pressing KEYUP opens it', function(a
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 27));
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is closed');
   Ember.run(() => triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 38));
@@ -430,7 +430,7 @@ test('The placeholder is only visible when no options are selected', function(as
   `);
 
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), 'Select stuff here', 'There is a placeholder');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:eq(1)').click());
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'The placeholder is gone');
 });
@@ -446,7 +446,7 @@ test('If the placeholder is null the placeholders shouldn\'t be "null" (issue #9
   `);
 
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'Input does not have a placeholder');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:eq(1)').click());
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'Input still does not have a placeholder');
   Ember.run(() => this.$('.ember-power-select-multiple-remove-btn').click());
@@ -461,7 +461,7 @@ test('Selecting and removing should result in desired behavior', function(assert
       {{option}}
     {{/power-select}}
   `);
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => $('.ember-power-select-option:eq(1)').click());
   assert.equal(this.$('.ember-power-select-multiple-option').length, 1, 'Should add selected option');
   Ember.run(() => this.$('.ember-power-select-multiple-remove-btn').click());
@@ -546,11 +546,11 @@ test('The search term is yielded as second argument in single selects', function
     {{/power-select}}
   `);
 
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('tw'));
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'tw:two');
   Ember.run(() => $('.ember-power-select-option:eq(0)').click());
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('thr'));
   assert.ok(/thr:two/.test($('.ember-power-select-trigger').text().trim()), 'The trigger also receives the search term');
 });

--- a/tests/integration/components/power-select/opened-property-test.js
+++ b/tests/integration/components/power-select/opened-property-test.js
@@ -50,6 +50,6 @@ test('when it is opened/closed and the `opened` property is multable, it gets up
   `);
 
   assert.ok(!this.get('opened'), 'The opened property is false');
-  Ember.run(() => this.$('.ember-power-select-trigger').click());
+  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   assert.ok(this.get('opened'), 'The opened property is true now');
 });


### PR DESCRIPTION
Example: Open the select when focused.

```hbs
{{#power-select options=options selected=foo onchange=(action (mut foo)) onfocus=(action "didFocus") as |option|}}
     {{option}}
{{/power-select}}
```

```js
actions: {
  didFocus(select /*, e */) {
    select.actions.open();
  }
}
```

Closes #172 

This also updates `ember-basic-dropdown` to 0.7.0-beta.1, which changes the strategy to open the select from `onclick` to `onmousedown`. This was necessary for this feature but is also aligned with the way real selects works and makes the component feel much snappy :)