### PR TITLE
let options component render the parent element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - [FEATURE] All actions (onchange, onkeydown and onfocus) now receive a richer public API object
   that is identical in shape to the one they received before but also contains `highlight(option)`
   and `search(term)` actions
+- [BREAKING] Delegate the rendering of the list's topmost element to `optionsComponent`. This
+  allows a better customization of the list. If you use `optionsComponent` make sure you make it render
+  the topmost element, e.g an `<ul>`.
 
 # 0.7.0-beta.1
 - [BREAKING] Update to ember-basic-dropdown 0.7.0-beta.1. This means that the component is opened/

--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -4,5 +4,5 @@ import layout from '../../templates/components/power-select/options';
 // TODO: Do I really need a component? A recursive template would do ...
 export default Ember.Component.extend({
   layout: layout,
-  tagName: '',
+  tagName: 'ul'
 });

--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -13,26 +13,26 @@
       handleKeydown=(action "handleKeydown" dropdown)
     )) as |select|}}
 
-    <ul class="ember-power-select-options">
       {{#if showLoadingMessage}}
-        <li class="ember-power-select-option">{{loadingMessage}}</li>
+        <ul class="ember-power-select-options"><li class="ember-power-select-option">{{loadingMessage}}</li></ul>
       {{/if}}
       {{#if resultsLength}}
         {{#component optionsComponent options=(readonly results) highlighted=(readonly highlighted)
           selection=(readonly selection) optionsComponent=(readonly optionsComponent) searchText=(readonly searchText)
-          select=(readonly select) extra=(readonly extra) as |option term|}}
+          select=(readonly select) extra=(readonly extra)
+          class="ember-power-select-options" as |option term|}}
           {{yield option term}}
         {{/component}}
       {{else if mustShowSearchMessage}}
-        <li class="ember-power-select-option">{{searchMessage}}</li>
+        <ul class="ember-power-select-options"><li class="ember-power-select-option">{{searchMessage}}</li></ul>
       {{else if results.isFulfilled}}
         {{#if hasInverseBlock}}
           {{yield to="inverse"}}
         {{else if noMatchesMessage}}
-          <li class="ember-power-select-option">{{noMatchesMessage}}</li>
+          <ul class="ember-power-select-options"><li class="ember-power-select-option">{{noMatchesMessage}}</li></ul>
         {{/if}}
       {{/if}}
-    </ul>
+
   {{/with}}
 {{else}}
   {{#with (hash

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -2,12 +2,11 @@
   {{#if opt.groupName}}
     <li class="ember-power-select-group">
       <span class="ember-power-select-group-name">{{opt.groupName}}</span>
-      <ul class="ember-power-select-options ember-power-select-options--nested">
-        {{#component optionsComponent highlighted=(readonly highlighted) selection=(readonly selection)
-          options=(readonly opt.options) optionsComponent=(readonly optionsComponent) select=(readonly select) as |option|}}
-          {{yield option searchText}}
-        {{/component}}
-      </ul>
+      {{#component optionsComponent highlighted=(readonly highlighted) selection=(readonly selection)
+        options=(readonly opt.options) optionsComponent=(readonly optionsComponent) select=(readonly select)
+        class="ember-power-select-options ember-power-select-options--nested" as |option|}}
+        {{yield option searchText}}
+      {{/component}}
     </li>
   {{else}}
     <li class="ember-power-select-option {{ember-power-select-option-classes opt selection highlighted}}"

--- a/addon/templates/components/power-select/single.hbs
+++ b/addon/templates/components/power-select/single.hbs
@@ -18,27 +18,28 @@
         spellcheck="false" role="textbox" oninput={{action select.actions.search value="target.value"}}
         onkeydown={{select.actions.handleKeydown}} placeholder={{searchPlaceholder}}>
       </div>
+
     {{/if}}
-    <ul class="ember-power-select-options">
       {{#if showLoadingMessage}}
-        <li class="ember-power-select-option">{{loadingMessage}}</li>
+        <ul class="ember-power-select-options"><li class="ember-power-select-option">{{loadingMessage}}</li></ul>
       {{/if}}
       {{#if resultsLength}}
         {{#component optionsComponent options=(readonly results) highlighted=(readonly highlighted)
           selection=(readonly selection) optionsComponent=(readonly optionsComponent) searchText=(readonly searchText)
-          select=(readonly select) extra=(readonly extra) as |option term|}}
+          select=(readonly select) extra=(readonly extra)
+          class="ember-power-select-options" as |option term|}}
           {{yield option term}}
         {{/component}}
       {{else if mustShowSearchMessage}}
-        <li class="ember-power-select-option">{{searchMessage}}</li>
+        <ul class="ember-power-select-options"><li class="ember-power-select-option">{{searchMessage}}</li></ul>
       {{else if results.isFulfilled}}
         {{#if hasInverseBlock}}
           {{yield to="inverse"}}
         {{else if noMatchesMessage}}
-          <li class="ember-power-select-option">{{noMatchesMessage}}</li>
+          <ul class="ember-power-select-options"><li class="ember-power-select-option">{{noMatchesMessage}}</li></ul>
         {{/if}}
       {{/if}}
-    </ul>
+
   {{/with}}
 {{else}}
   {{#with (hash


### PR DESCRIPTION
For the loading, no matches and search messages I just wrapped them in the previous `<ul` as it seems the most straightforward way to reuse styles.

Also, I'm setting `class="ember-power-select-options"` from the outer template. This helps to not break tests. I don't think it makes any difference to the passed in component.