### PR TITLE
Add action to create custom option

### DIFF
--- a/addon/components/power-select/base.js
+++ b/addon/components/power-select/base.js
@@ -60,6 +60,10 @@ export default Ember.Component.extend({
     return countOptions(this.get('results'));
   }),
 
+  createEnabled: computed('oncreate', 'searchText', function() {
+    return this.get('oncreate') && ! Ember.isEmpty(this.get('searchText'));
+  }),
+
   // Actions
   actions: {
     open(dropdown, e) {
@@ -76,6 +80,10 @@ export default Ember.Component.extend({
 
     search(dropdown, term /*, e */) {
       this._doSearch(term);
+    },
+
+    create(dropdown, term) {
+      this.get('oncreate')(term, this.buildPublicAPI(dropdown));
     },
 
     handleKeydown(dropdown, e) {

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -27,6 +27,7 @@
     class=class
     dropdownClass=dropdownClass
     extra=extra
+    oncreate=oncreate
     as |option term|}}
     {{yield option term}}
   {{else}}

--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -12,7 +12,9 @@
       removeOption=(action "removeOption" dropdown)
       handleKeydown=(action "handleKeydown" dropdown)
     )) as |select|}}
-
+      {{#if createEnabled}}
+        <ul class="ember-power-select-options "><li {{action "create" dropdown searchText}} class="ember-power-select-option">Add {{searchText}}...</li></ul>
+      {{/if}}
       {{#if showLoadingMessage}}
         <ul class="ember-power-select-options"><li class="ember-power-select-option">{{loadingMessage}}</li></ul>
       {{/if}}

--- a/addon/templates/components/power-select/single.hbs
+++ b/addon/templates/components/power-select/single.hbs
@@ -12,14 +12,16 @@
       clear=(if allowClear (action "select" dropdown null))
       handleKeydown=(action "handleKeydown" dropdown)
     )) as |select|}}
-    {{#if searchEnabled}}
-      <div class="ember-power-select-search">
-        <input type="search" autocomplete="off" autocorrect="off" autocapitalize="off"
-        spellcheck="false" role="textbox" oninput={{action select.actions.search value="target.value"}}
-        onkeydown={{select.actions.handleKeydown}} placeholder={{searchPlaceholder}}>
-      </div>
-
-    {{/if}}
+      {{#if searchEnabled}}
+        <div class="ember-power-select-search">
+          <input type="search" autocomplete="off" autocorrect="off" autocapitalize="off"
+          spellcheck="false" role="textbox" oninput={{action select.actions.search value="target.value"}}
+          onkeydown={{select.actions.handleKeydown}} placeholder={{searchPlaceholder}}>
+        </div>
+      {{/if}}
+      {{#if createEnabled}}
+        <ul class="ember-power-select-options "><li {{action "create" dropdown searchText}} class="ember-power-select-option">Add {{searchText}}...</li></ul>
+      {{/if}}
       {{#if showLoadingMessage}}
         <ul class="ember-power-select-options"><li class="ember-power-select-option">{{loadingMessage}}</li></ul>
       {{/if}}

--- a/tests/dummy/app/controllers/docs/create-item.js
+++ b/tests/dummy/app/controllers/docs/create-item.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  names: ['Stefan', 'Miguel', 'Tomster', 'Pluto'],
+
+  actions: {
+    createItem(name, dropdown) {
+      this.get('names').pushObject(name);
+      this.set('selected', name);
+      dropdown.actions.close();
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -23,6 +23,7 @@ Router.map(function() {
 
     // ADVANCED CUSTOMIZATION
     this.route('asynchronous-search');
+    this.route('create-item');
 
     // OTHER
     this.route('troubleshooting');

--- a/tests/dummy/app/templates/docs/create-item.hbs
+++ b/tests/dummy/app/templates/docs/create-item.hbs
@@ -1,0 +1,18 @@
+<h1 class="doc-page-title">Create Item functionality</h1>
+
+{{#code-sample as |component|}}
+  <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
+  </pre>
+  <pre class="code-sample-snippet {{if (eq component.activeTab 'javascript') 'active'}}">
+  </pre>
+  <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
+    {{#power-select multiple=false options=names oncreate=(action "createItem") selected=selected onchange=(action (mut selected)) as |name|}}
+      {{name}}
+    {{/power-select}}
+  </div>
+{{/code-sample}}
+
+<div class="doc-page-nav">
+  {{#link-to 'docs.styles' class="doc-page-nav-link-prev"}}&lt; Styles{{/link-to}}
+  {{#link-to 'docs.troubleshooting' class="doc-page-nav-link-next"}}Troubleshooting &gt;{{/link-to}}
+</div>


### PR DESCRIPTION
This is an attempt to allow a public API for creating an option: `{{power-select oncreate=(action "itemCreated") ...}}`. The goal is to have a highlightable (up/down arrows + enter) option that fires the action (`Add xyz...`).

There is no support for keyboard navigation, seems like it would be hard to implement? Also it doesn't work for `multiple=true` (`Uncaught TypeError: Object.defineProperty called on non-object` - no idea why).

The solution in https://github.com/cibernox/ember-power-select/issues/72#issuecomment-160479966 does not work in a general case because for creating a new (fake) option the component needs to know which attributes are displayed in the option template. Using a custom `optionsComponent` that deals with item creation falls short because the `optionsComponent` can't communicate an action to the code using the `power-select`, informing it that an item should be created.

Do you want to support such an `oncreate` action in this addon? It would be very nice to have this kind of functionality ready to use in different parts of the application over a simple API.