### PR TITLE
Remove `noMatchesMessage` option

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -10,7 +10,6 @@ export const defaultOptions = {
   disabled: false,
   placeholder: undefined,
   loadingMessage: "Loading options...",
-  noMatchesMessage: "No results found",
   optionsComponent: 'power-select/options',
   dropdownPosition: 'auto',
   matcher: defaultMatcher,

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -9,7 +9,6 @@
     searchEnabled=searchEnabled
     searchPlaceholder=searchPlaceholder
     loadingMessage=loadingMessage
-    noMatchesMessage=noMatchesMessage
     searchMessage=searchMessage
     selectedComponent=selectedComponent
     optionsComponent=optionsComponent
@@ -21,7 +20,6 @@
     dropdownPosition=dropdownPosition
     closeOnSelect=closeOnSelect
     opened=opened
-    hasInverseBlock=(hasBlock "inverse")
     tabindex=tabindex
     dir=dir
     class=class

--- a/addon/templates/components/power-select/multiple.hbs
+++ b/addon/templates/components/power-select/multiple.hbs
@@ -26,13 +26,8 @@
       {{else if mustShowSearchMessage}}
         <ul class="ember-power-select-options"><li class="ember-power-select-option">{{searchMessage}}</li></ul>
       {{else if results.isFulfilled}}
-        {{#if hasInverseBlock}}
-          {{yield to="inverse"}}
-        {{else if noMatchesMessage}}
-          <ul class="ember-power-select-options"><li class="ember-power-select-option">{{noMatchesMessage}}</li></ul>
-        {{/if}}
+        {{yield to="inverse"}}
       {{/if}}
-
   {{/with}}
 {{else}}
   {{#with (hash

--- a/addon/templates/components/power-select/single.hbs
+++ b/addon/templates/components/power-select/single.hbs
@@ -33,13 +33,8 @@
       {{else if mustShowSearchMessage}}
         <ul class="ember-power-select-options"><li class="ember-power-select-option">{{searchMessage}}</li></ul>
       {{else if results.isFulfilled}}
-        {{#if hasInverseBlock}}
-          {{yield to="inverse"}}
-        {{else if noMatchesMessage}}
-          <ul class="ember-power-select-options"><li class="ember-power-select-option">{{noMatchesMessage}}</li></ul>
-        {{/if}}
+        {{yield to="inverse"}}
       {{/if}}
-
   {{/with}}
 {{else}}
   {{#with (hash

--- a/tests/dummy/app/templates/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/docs/api-reference.hbs
@@ -78,11 +78,6 @@
       </td>
     </tr>
     <tr>
-      <td>noMatchesMessage</td>
-      <td><code>string</code></td>
-      <td>Message shown when a search doesn't find any matching result.</td>
-    </tr>
-    <tr>
       <td>selectedComponent</td>
       <td><code>string</code></td>
       <td>The component to render instead of the default one inside the trigger</td>

--- a/tests/dummy/app/templates/docs/the-list.hbs
+++ b/tests/dummy/app/templates/docs/the-list.hbs
@@ -73,53 +73,11 @@
 
 <p>
   What happens when the collection you pass to the component is empty?
-  By default the component will render a helpful message. This message is the same
-  that will appear after performing a search when there are no matching results.
 </p>
 
-{{#code-sample as |component|}}
-  <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=emptyList selected=selected onchange=(action (mut selected)) as |name|}}
-      \{{name}}
-    \{{/power-select}}
-  </pre>
-  <pre class="code-sample-snippet {{if (eq component.activeTab 'javascript') 'active'}}">
-    export default Ember.Controller.extend({
-      emptyList: []
-    });
-  </pre>
-  <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=emptyList selected=selected onchange=(action (mut selected)) as |name|}}
-      {{name}}
-    {{/power-select}}
-  </div>
-{{/code-sample}}
-
 <p>
-  You can pass a different message using <code>noMatchesMessage="My message"</code>
-</p>
-
-{{#code-sample as |component|}}
-  <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=emptyList noMatchesMessage="404 bro" selected=selected onchange=(action (mut selected)) as |name|}}
-      \{{name}}
-    \{{/power-select}}
-  </pre>
-  <pre class="code-sample-snippet {{if (eq component.activeTab 'javascript') 'active'}}">
-    export default Ember.Controller.extend({
-      emptyList: []
-    });
-  </pre>
-  <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=emptyList noMatchesMessage="404 bro" selected=selected onchange=(action (mut selected)) as |name|}}
-      {{name}}
-    {{/power-select}}
-  </div>
-{{/code-sample}}
-
-<p>
-  Or you can just use the <code>\{{else}}</code> block to just customize a totally
-  different HTML content just like the <code>\{{each}}</code> helper.
+  Like with Ember's <code>\{{each}}</code>helper the component will render the inverse block if
+  provided.
 </p>
 
 {{#code-sample as |component|}}
@@ -158,7 +116,7 @@
 </p>
 <p>
   That means that while the promise doesn't resolve you are in some kind of <em>loading</em>
-  state where you don't have options yet (but you will have results) so you don't want to show the "No results" messages.
+  state where you don't have options yet (but you will have results) so you don't want to render the inverse block.
 </p>
 
 <p>

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -114,54 +114,6 @@ test('While the async search is being performed the "Type to search" dissapears 
   setTimeout(done, 150);
 });
 
-test('When the search resolves to an empty array then the "No results found" message or block appears.', function(assert) {
-  var done = assert.async();
-  assert.expect(1);
-
-  this.searchFn = function() {
-    return new RSVP.Promise(function(resolve) {
-      Ember.run.later(function() { resolve([]); }, 10);
-    });
-  };
-
-  this.render(hbs`
-    {{#power-select search=searchFn onchange=(action (mut foo)) as |number|}}
-      {{number}}
-    {{/power-select}}
-  `);
-
-  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
-  Ember.run(() => typeInSearch("teen"));
-  setTimeout(() => {
-    assert.ok(/No results found/.test($('.ember-power-select-option').text()), 'The default "No results" message renders');
-    done();
-  }, 20);
-});
-
-test('When the search resolves to an empty array then the custom "No results" message appears', function(assert) {
-  var done = assert.async();
-  assert.expect(1);
-
-  this.searchFn = function() {
-    return new RSVP.Promise(function(resolve) {
-      Ember.run.later(function() { resolve([]); }, 10);
-    });
-  };
-
-  this.render(hbs`
-    {{#power-select search=searchFn noMatchesMessage="Meec. Try again" onchange=(action (mut foo)) as |number|}}
-      {{number}}
-    {{/power-select}}
-  `);
-
-  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
-  Ember.run(() => typeInSearch("teen"));
-  setTimeout(() => {
-    assert.ok(/Meec\. Try again/.test($('.ember-power-select-option').text()), 'The customized "No results" message renders');
-    done();
-  }, 20);
-});
-
 test('When the search resolves to an empty array then the custom alternate block renders', function(assert) {
   var done = assert.async();
   assert.expect(1);

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -401,34 +401,10 @@ test('The search term is yielded as second argument in single selects', function
   assert.equal($('.ember-power-select-trigger').text().trim(), 'thr:two', 'The trigger also receives the search term');
 });
 
-test('The dropdowns shows the default "no options" message', function(assert) {
-  this.options = [];
-  this.render(hbs`
-    {{#power-select options=options onchange=(action (mut foo)) as |option|}}
-      {{option}}
-    {{/power-select}}
-  `);
-  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
-  assert.equal($('.ember-power-select-option').length, 1);
-  assert.equal($('.ember-power-select-option').text().trim(), 'No results found');
-});
-
-test('The default "no options" message can be customized passing `noMatchesMessage="other message"`', function(assert) {
-  this.options = [];
-  this.render(hbs`
-    {{#power-select options=options noMatchesMessage="Nope" onchange=(action (mut foo)) as |option|}}
-      {{option}}
-    {{/power-select}}
-  `);
-  Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
-  assert.equal($('.ember-power-select-option').length, 1);
-  assert.equal($('.ember-power-select-option').text().trim(), 'Nope');
-});
-
 test('The content of the dropdown when there are no options can be completely customized using the inverse block', function(assert) {
   this.options = [];
   this.render(hbs`
-    {{#power-select options=options noMatchesMessage="Nope" onchange=(action (mut foo)) as |option|}}
+    {{#power-select options=options onchange=(action (mut foo)) as |option|}}
       {{option}}
     {{else}}
       <span class="empty-option-foo">Foo bar</span>
@@ -541,12 +517,14 @@ test('You can pass a custom marcher with `matcher=myFn` to customize the search 
   this.render(hbs`
     {{#power-select options=numbers matcher=endsWithMatcher onchange=(action (mut foo)) as |option|}}
       {{option}}
+    {{else}}
+      Nothing, bro
     {{/power-select}}
   `);
 
   Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('on'));
-  assert.equal($('.ember-power-select-option').text().trim(), "No results found", 'No number ends in "on"');
+  assert.equal($('.ember-power-select-dropdown').text().trim(), "Nothing, bro", 'No number ends in "on"');
   Ember.run(() => typeInSearch('teen'));
   assert.equal($('.ember-power-select-option').length, 7, 'There is 7 number that end in "teen"');
 });

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -220,12 +220,14 @@ test('The filtering specifying a custom matcher works in multiple model', functi
   this.render(hbs`
     {{#power-select options=numbers matcher=endsWithMatcher onchange=(action (mut foo)) multiple=true as |option|}}
       {{option}}
+    {{else}}
+      Nothing, bro
     {{/power-select}}
   `);
 
   Ember.run(() => this.$('.ember-power-select-trigger').mousedown());
   Ember.run(() => typeInSearch('on'));
-  assert.equal($('.ember-power-select-option').text().trim(), "No results found", 'No number ends in "on"');
+  assert.equal($('.ember-power-select-dropdown').text().trim(), "Nothing, bro", 'No number ends in "on"');
   Ember.run(() => typeInSearch('teen'));
   assert.equal($('.ember-power-select-option').length, 7, 'There is 7 number that end in "teen"');
 });


### PR DESCRIPTION
Not sure about this, might be unpopular and I might never merge it.

Trying to reduce the API as much as possible, I find this one redundant.
It really doesn't add much value because the inverse block is already a
more powerful primitive and forces use to detect the presence of the
inverse block and pass it around.

Obviously this would be breaking and the component would require a bit more boilerplate for the simplest use-case. 

Will leave this here for some days.
