### PR TITLE
Add a link to ember-power-select-with-create

### DIFF
--- a/tests/dummy/app/templates/addons/index.hbs
+++ b/tests/dummy/app/templates/addons/index.hbs
@@ -28,4 +28,5 @@
 <ul>
   <li><a href="https://github.com/cibernox/ember-power-select-blockless">Ember Power Select Blockless</a></li>
   <li><a href="https://github.com/cibernox/ember-power-select-typeahead">Ember Power Select Typeahead</a></li>
+  <li><a href="https://github.com/cibernox/ember-power-select-with-create">Ember Power Select With Create</a></li>
 </ul>


### PR DESCRIPTION
Should be merged after the following is done:
 - ember-power-select
   - [x] Release either `v0.7.0` or `v0.7.0-beta.6`
 - cibernox/ember-power-select-with-create#1
   - [x] Update dependency in `package.json`
   - [x] Configure Travis
   - [x] Add install instructions to README (cibernox/ember-power-select-with-create#2)
   - [ ] Release `v0.1.2`