### PR TITLE
Make multiple select repect defalt values

### DIFF
--- a/addon/components/power-select-multiple.js
+++ b/addon/components/power-select-multiple.js
@@ -1,11 +1,28 @@
 import Ember from 'ember';
 import layout from '../templates/components/power-select-multiple';
+import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 
 export default Ember.Component.extend({
   layout,
-  triggerComponent: 'power-select-multiple/trigger',
-  beforeOptionsComponent: null,
-  optionsComponent: 'power-select-multiple/options',
+  // Config
+  disabled: fallbackIfUndefined(false),
+  placeholder: fallbackIfUndefined(null),
+  loadingMessage: fallbackIfUndefined('Loading options...'),
+  noMatchesMessage: fallbackIfUndefined('No results found'),
+  dropdownPosition: fallbackIfUndefined('auto'),
+  searchField: fallbackIfUndefined(null),
+  search: fallbackIfUndefined(null),
+  closeOnSelect: fallbackIfUndefined(true),
+  dropdownClass: fallbackIfUndefined(null),
+  triggerClass: fallbackIfUndefined(null),
+  dir: fallbackIfUndefined(null),
+  opened: fallbackIfUndefined(false),
+  searchEnabled: fallbackIfUndefined(true),
+  searchMessage: fallbackIfUndefined("Type to search"),
+  searchPlaceholder: fallbackIfUndefined(null),
+  triggerComponent: fallbackIfUndefined('power-select-multiple/trigger'),
+  beforeOptionsComponent: fallbackIfUndefined(null),
+  optionsComponent: fallbackIfUndefined('power-select-multiple/options'),
 
   // CPs
   selectedComponent: Ember.computed.deprecatingAlias('triggerComponent', { id: 'power-select-multiple-selected-component', until: '0.9'}),

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -1,21 +1,15 @@
 import Ember from 'ember';
 import layout from '../templates/components/power-select';
 import { defaultMatcher, indexOfOption, optionAtIndex, filterOptions, countOptions } from '../utils/group-utils';
+import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 
 const { RSVP, computed, run, get, isBlank } = Ember;
 const Promise = RSVP.Promise;
 const PromiseArray = Ember.ArrayProxy.extend(Ember.PromiseProxyMixin);
 
-function fallbackIfUndefined(fallback) {
-  return computed({
-    get() { return fallback; },
-    set(_, v) { return v === undefined ? fallback : v; }
-  });
-}
-
 export default Ember.Component.extend({
   // HTML
-  layout: layout,
+  layout,
   tagName: fallbackIfUndefined(''),
 
   // Config

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -26,14 +26,14 @@ export default Ember.Component.extend({
   triggerClass: fallbackIfUndefined(null),
   dir: fallbackIfUndefined(null),
   opened: fallbackIfUndefined(false),
-  triggerComponent: fallbackIfUndefined('power-select/trigger'),
-  optionsComponent: fallbackIfUndefined('power-select/options'),
-  beforeOptionsComponent: fallbackIfUndefined('power-select/before-options'),
-  afterOptionsComponent: fallbackIfUndefined(null),
   searchEnabled: fallbackIfUndefined(true),
   searchMessage: fallbackIfUndefined("Type to search"),
   searchPlaceholder: fallbackIfUndefined(null),
   allowClear: fallbackIfUndefined(false),
+  triggerComponent: fallbackIfUndefined('power-select/trigger'),
+  optionsComponent: fallbackIfUndefined('power-select/options'),
+  beforeOptionsComponent: fallbackIfUndefined('power-select/before-options'),
+  afterOptionsComponent: fallbackIfUndefined(null),
 
   // Attrs
   searchText: '',

--- a/addon/utils/computed-fallback-if-undefined.js
+++ b/addon/utils/computed-fallback-if-undefined.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default function computedFallbackIfUndefined(fallback) {
+  return Ember.computed({
+    get() { return fallback; },
+    set(_, v) { return v === undefined ? fallback : v; }
+  });
+}


### PR DESCRIPTION
This allows to forwards all attributes to `{{power-select-multiple}}` and be sure they will fallback to the default values when given undefined.