### PR TITLE
Added selectedItemComponent

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -31,6 +31,7 @@ export default Ember.Component.extend({
   searchPlaceholder: fallbackIfUndefined(null),
   allowClear: fallbackIfUndefined(false),
   triggerComponent: fallbackIfUndefined('power-select/trigger'),
+  selectedItemComponent: fallbackIfUndefined(null),
   optionsComponent: fallbackIfUndefined('power-select/options'),
   beforeOptionsComponent: fallbackIfUndefined('power-select/before-options'),
   afterOptionsComponent: fallbackIfUndefined(null),

--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -15,6 +15,7 @@
       noMatchesMessage=noMatchesMessage
       searchMessage=searchMessage
       triggerComponent=triggerComponent
+      selectedItemComponent=selectedItemComponent
       beforeOptionsComponent=beforeOptionsComponent
       optionsComponent=optionsComponent
       afterOptionsComponent=afterOptionsComponent
@@ -54,6 +55,7 @@
       noMatchesMessage=noMatchesMessage
       searchMessage=searchMessage
       triggerComponent=triggerComponent
+      selectedItemComponent=selectedItemComponent
       beforeOptionsComponent=beforeOptionsComponent
       optionsComponent=optionsComponent
       afterOptionsComponent=afterOptionsComponent

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -3,7 +3,11 @@
     {{#unless disabled}}
       <span aria-label="remove element" class="ember-power-select-multiple-remove-btn" onmousedown={{action "removeOption" opt}}>&times;</span>
     {{/unless}}
-    {{yield opt searchText}}
+    {{#if selectedItemComponent}}
+      {{component selectedItemComponent selected=opt searchText=searchText}}
+    {{else}}
+      {{yield opt searchText}}
+    {{/if}}
   </span>
 {{/each}}
 <input type="search" class="ember-power-select-trigger-multiple-input" tabindex="0" autocomplete="off"

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -43,7 +43,8 @@
     )) as |select|}}
     {{#component triggerComponent options=(readonly results) selected=(readonly selected) searchText=(readonly searchText)
       placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly highlighted) allowClear=(readonly allowClear)
-      select=(readonly select) extra=(readonly extra) closeOnSelect=(readonly closeOnSelect) onkeydown=(readonly onkeydown) as |opt term|}}
+      select=(readonly select) extra=(readonly extra) closeOnSelect=(readonly closeOnSelect) onkeydown=(readonly onkeydown)
+    selectedItemComponent=(readonly selectedItemComponent) as |opt term|}}
       {{yield opt term}}
     {{/component}}
   {{/with}}

--- a/addon/templates/components/power-select/trigger.hbs
+++ b/addon/templates/components/power-select/trigger.hbs
@@ -1,5 +1,9 @@
 {{#if selected}}
-  {{yield selected searchText}}
+  {{#if selectedItemComponent}}
+    {{component selectedItemComponent selected=selected searchText=searchText}}
+  {{else}}
+    {{yield selected searchText}}
+  {{/if}}
   {{#if allowClear}}
     <span class="ember-power-select-clear-btn" onmousedown={{action "clear"}}>&times;</span>
   {{/if}}

--- a/tests/dummy/app/templates/components/selected-item-country.hbs
+++ b/tests/dummy/app/templates/components/selected-item-country.hbs
@@ -1,0 +1,2 @@
+<img src="{{selected.flagUrl}}" class="icon-flag">
+{{selected.name}}

--- a/tests/dummy/app/templates/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/docs/api-reference.hbs
@@ -98,6 +98,11 @@
       <td>The component to render instead of the default one inside the trigger</td>
     </tr>
     <tr>
+        <td>selectedItemComponent</td>
+        <td><code>string</code></td>
+        <td>The component to render to customize just the selected item of the trigger</td>
+    </tr>
+    <tr>
       <td>optionsComponent</td>
       <td><code>string</code></td>
       <td>The component to render instead of the default one inside the list of options</td>

--- a/tests/dummy/app/templates/docs/the-trigger.hbs
+++ b/tests/dummy/app/templates/docs/the-trigger.hbs
@@ -78,7 +78,7 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-  {{#power-select options=countries selected=country triggerComponent="selected-country" searchField="name" onchange=(action (mut country)) as |country|}}
+  {{#power-select options=countries selected=country selectedItemComponent="selected-item-country" searchField="name" onchange=(action (mut country)) as |country|}}
     <div class="country-detailed-info">
       <img src="{{country.flagUrl}}" class="country-flag">
       <div class="country-data-text">

--- a/tests/dummy/app/templates/docs/the-trigger.hbs
+++ b/tests/dummy/app/templates/docs/the-trigger.hbs
@@ -41,16 +41,16 @@
 
 <p>
   Since we have run out of block to pass the the component we need to use other components if we want to
-  go any further. Pass <code>triggerComponent="component-name"</code> to the component.
+  go any further. Pass <code>selectedItemComponent="component-name"</code> to the component.
 </p>
 
 <p>
-  Within that component you have access to <code>selection</code>.
+  Within that component you have access to <code>selected</code>.
 </p>
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-  \{{#power-select options=countries selected=country triggerComponent="selected-country" searchField="name" onchange=(action (mut country)) as |country|}}
+  \{{#power-select options=countries selected=country selectedItemComponent="selected-item-country" searchField="name" onchange=(action (mut country)) as |country|}}
     &lt;div class="country-detailed-info"&gt;
       &lt;img src="\{{country.flagUrl}}" class="country-flag"&gt;
       &lt;div class="country-data-text"&gt;

--- a/tests/integration/components/power-select/customization-with-compoments-test.js
+++ b/tests/integration/components/power-select/customization-with-compoments-test.js
@@ -8,7 +8,7 @@ moduleForComponent('ember-power-select', 'Integration | Component | Ember Power 
 });
 
 test('selected option can be customized using triggerComponent', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   this.countries = countries;
   this.country = countries[1]; // Spain
@@ -19,6 +19,25 @@ test('selected option can be customized using triggerComponent', function(assert
     {{/power-select}}
   `);
 
+  assert.equal($('.ember-power-select-status-icon').length, 0, 'The provided trigger component is not rendered');
+  assert.equal($('.ember-power-select-trigger .icon-flag').length, 1, 'The custom flag appears.');
+  assert.equal($('.ember-power-select-trigger').text().trim(), 'Spain', 'With the country name as the text.');
+
+});
+
+test('selected item option can be customized using selectedItemComponent', function(assert) {
+  assert.expect(3);
+
+  this.countries = countries;
+  this.country = countries[1]; // Spain
+
+  this.render(hbs`
+    {{#power-select options=countries selected=country selectedItemComponent="selected-item-country" onchange=(action (mut foo)) as |country|}}
+      {{country.name}}
+    {{/power-select}}
+  `);
+
+  assert.equal($('.ember-power-select-status-icon').length, 1, 'The provided trigger component is rendered');
   assert.equal($('.ember-power-select-trigger .icon-flag').length, 1, 'The custom flag appears.');
   assert.equal($('.ember-power-select-trigger').text().trim(), 'Spain', 'With the country name as the text.');
 });


### PR DESCRIPTION
In the docs where it was showing you how to customize the trigger, it was really showing you how to customize the selected item. Updated the docs accordingly leaving you with nowhere demoing actually replacing the entire trigger.

I tested the changes with my previous app, remove the code I had hacked and it worked fine. 

I do not have anywhere currently I was using a multiple select and in the docs there was only a simple demo of multi select without any of the customization, so I believe I changed everything correctly to also apply with multi select, but please check them add. All the tests for multiple didn't include any customization since it's just the same as the single.