### PR TITLE
Fix Backspace on multiple select when options are objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+- [BUGFIX] Pressing Backspace to delete the last selected option in multiple select when options are not
+  plain strings now works as expected. It makes `searchField` mandatory, and asserts its presence.
 - [INTERNAL] Refactor internals to don't force people providing custom components for slots to
   implement that much logic on it. Also logic for the `closeOnSelect` configuration lies in a single place.
 

--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -33,9 +33,10 @@ export default Ember.Component.extend({
 
     handleKeydown(e) {
       const { highlighted, onkeydown, select, searchText} = this.getProperties('highlighted', 'onkeydown', 'select', 'searchText');
-      const selected = Ember.A((this.get('selected') || []));
       if (onkeydown) { onkeydown(select, e); }
       if (e.defaultPrevented) { return; }
+
+      const selected = Ember.A((this.get('selected') || []));
       if (e.keyCode === 13 && select.isOpen) {
         if (selected.indexOf(highlighted) === -1) {
           select.actions.choose(buildNewSelection([highlighted, selected], { multiple: true }), e);
@@ -44,7 +45,13 @@ export default Ember.Component.extend({
         const lastSelection = get(selected, 'lastObject');
         if (lastSelection) {
           select.actions.select(buildNewSelection([lastSelection, selected], { multiple: true }), e);
-          select.actions.search(lastSelection);
+          if (typeof lastSelection === 'string') {
+            select.actions.search(lastSelection);
+          } else {
+            let searchField = this.get('searchField');
+            Ember.assert('`{{power-select-multiple}}` requires a `searchField` when the options are not strings', searchField);
+            select.actions.search(get(lastSelection, searchField));
+          }
         }
       } else {
         select.actions.handleKeydown(e);

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -46,7 +46,7 @@
     {{#component triggerComponent options=(readonly results) selected=(readonly selected) searchText=(readonly searchText)
       placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly highlighted) allowClear=(readonly allowClear)
       select=(readonly select) extra=(readonly extra) onkeydown=(readonly onkeydown)
-    selectedItemComponent=(readonly selectedItemComponent) as |opt term|}}
+      selectedItemComponent=(readonly selectedItemComponent) searchField=(readonly searchField) as |opt term|}}
       {{yield opt term}}
     {{/component}}
   {{/with}}

--- a/tests/dummy/app/templates/legacy-demo.hbs
+++ b/tests/dummy/app/templates/legacy-demo.hbs
@@ -2,7 +2,11 @@
   <input type="text" value="sample input">
   <h2 id="title">Welcome to the demo of ember-power-select (provisional name)</h2>
 
-  <p><strong>Trying to reproduce bug with store.findAll('user')</strong></p>
+  {{#power-select-multiple options=complexOptions selected=choosenCountry onchange=(action (mut choosenCountry)) searchField='name' as |country|}}
+    {{country.name}}
+  {{/power-select-multiple}}
+
+  {{!-- <p><strong>Trying to reproduce bug with store.findAll('user')</strong></p>
 
   {{#power-select options=model selected=selectedUser onchange=(action (mut selectedUser)) as |user|}}
     {{user.name}}
@@ -196,5 +200,5 @@
   <br>
   <br>
   <br>
-
+ --}}
 </section>

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { typeInSearch, triggerKeydown, clickTrigger } from '../../../helpers/ember-power-select';
-import { numbers } from '../constants';
+import { numbers, countries } from '../constants';
 
 const { RSVP } = Ember;
 
@@ -355,6 +355,30 @@ test('Pressing BACKSPACE on the search input when it\'s empty removes the last s
   triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 8);
   assert.equal(this.$('.ember-power-select-multiple-option').length, 0, 'There is no elements selected');
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').val(), 'two', 'The text of the seach input is two now');
+  assert.equal($('.ember-power-select-dropdown').length, 1, 'The dropown is still opened');
+  assert.equal($('.ember-power-select-option').length, 1, 'The list has been filtered');
+});
+
+test('Pressing BACKSPACE on the search input when it\'s empty removes the last selection and performs a search for that text immediatly (when options are not strings)', function(assert) {
+  assert.expect(7);
+
+  this.contries = countries;
+  this.country = [countries[2], countries[4]];
+  this.didChange = (val, dropdown) => {
+    assert.deepEqual(val, [countries[2]], 'The selected item was unselected');
+    this.set('country', val);
+    assert.ok(dropdown.actions.close, 'The dropdown API is received as second argument');
+  };
+  this.render(hbs`
+    {{#power-select-multiple options=contries selected=country onchange=didChange searchField="name" as |c|}}
+      {{c.name}}
+    {{/power-select-multiple}}
+  `);
+  clickTrigger();
+  assert.equal(this.$('.ember-power-select-multiple-option').length, 2, 'There is two elements selected');
+  triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 8);
+  assert.equal(this.$('.ember-power-select-multiple-option').length, 1, 'There is one element selected');
+  assert.equal(this.$('.ember-power-select-trigger-multiple-input').val(), 'Latvia', 'The text of the seach input is two "Latvia"');
   assert.equal($('.ember-power-select-dropdown').length, 1, 'The dropown is still opened');
   assert.equal($('.ember-power-select-option').length, 1, 'The list has been filtered');
 });


### PR DESCRIPTION
When pressed backspace to delete the last option, the component would search `[object Object]`. Now it requires `searchField` and works as expected.