### PR TITLE
Don't automatically clear the search on close.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Master
 
+# 0.8.0-beta.11
+- [BUGFIX] Not it's responsability of the component holding the searchbox to clear (or not) clear the
+  search when the component is closed. The default components (single/multiple) do it.
+
 # 0.8.0-beta.10
 - [BUGFIX] Trigger should use clearfix so when the amount of options selected (multiple selects) overflows
   the available width is grows.

--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -9,6 +9,14 @@ export default Ember.Component.extend({
   tagName: '',
   layout,
 
+  // Lifecycle hooks
+  didReceiveAttrs({ oldAttrs, newAttrs }) {
+    this._super(...arguments);
+    if (oldAttrs && oldAttrs.select && oldAttrs.select.isOpen && !newAttrs.select.isOpen) {
+      this.handleClose();
+    }
+  },
+
   // CPs
   triggerMultipleInputStyle: computed('searchText.length', 'selected.length', function() {
     if (this.get('selected.length') === 0) {
@@ -57,5 +65,10 @@ export default Ember.Component.extend({
         select.actions.handleKeydown(e);
       }
     }
+  },
+
+  // Methods
+  handleClose() {
+    this.get('select.actions.search')('');
   }
 });

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -207,7 +207,6 @@ export default Ember.Component.extend({
   handleClose(dropdown, e) {
     const action = this.get('onclose');
     if (action) { action(this.buildPublicAPI(dropdown), e); }
-    this.send('search', dropdown, '', e);
     this.send('highlight', dropdown, null, e);
   },
 

--- a/addon/components/power-select/before-options.js
+++ b/addon/components/power-select/before-options.js
@@ -11,6 +11,11 @@ export default Ember.Component.extend({
     Ember.run.schedule('afterRender', () => Ember.$('.ember-power-select-search input').focus());
   },
 
+  willDestroy() {
+    this._super(...arguments);
+    this.get('select.actions.search')('');
+  },
+
   // Actions
   actions: {
     handleKeydown(e) {

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -573,3 +573,24 @@ test('The search term is yielded as second argument in single selects', function
   typeInSearch('thr');
   assert.ok(/thr:two/.test($('.ember-power-select-trigger').text().trim()), 'The trigger also receives the search term');
 });
+
+test('The search input is cleared when the component is closed', function(assert) {
+  assert.expect(3);
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select-multiple options=numbers selected=foo onchange=(action (mut foo)) as |option|}}
+      {{option}}
+    {{/power-select-multiple}}
+    <div id="other-thing">Other div</div>
+  `);
+
+  clickTrigger();
+  typeInSearch('asjdnah');
+  assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'No results found');
+  assert.equal(this.$('.ember-power-select-trigger-multiple-input').val(), 'asjdnah');
+  Ember.run(() => {
+    let event = new window.Event('mousedown');
+    this.$('#other-thing')[0].dispatchEvent(event);
+  });
+  assert.equal(this.$('.ember-power-select-trigger-multiple-input').val(), '');
+});


### PR DESCRIPTION
Depending on the use case, the user might not want the search to be cleared (by examples
when building a typeahead component). Probably is a responsability of the component containing
the input deciding to clear or not when the component is cleared.