### PR TITLE
Stop using array proxy

### DIFF
--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -69,6 +69,7 @@ export default Ember.Component.extend({
 
   // Methods
   handleClose() {
+    this.set('searchText', ''); // This line shouldn't be necessary. Why is it?
     this.get('select.actions.search')('');
   }
 });

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -105,9 +105,10 @@ export default Ember.Component.extend({
         options.then(results => this.set('results', results));
         return this.previousResults || [];
       }
+      let newResults = searchAction ? options : this.filter(options, this.get('searchText'));
       this.setProperties({ loading: false, currentlyHighlighted: undefined });
       this.previousResults = newResults;
-      return searchAction ? options : this.filter(options, this.get('searchText'));
+      return newResults;
     },
     set(_, newResults) {
       this.previousResults = newResults;

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -4,8 +4,6 @@ import { defaultMatcher, indexOfOption, optionAtIndex, filterOptions, countOptio
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 
 const { computed, run, get, isBlank } = Ember;
-// const Promise = RSVP.Promise;
-// const PromiseArray = Ember.ArrayProxy.extend(Ember.PromiseProxyMixin);
 
 export default Ember.Component.extend({
   // HTML

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -3,9 +3,9 @@ import layout from '../templates/components/power-select';
 import { defaultMatcher, indexOfOption, optionAtIndex, filterOptions, countOptions } from '../utils/group-utils';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 
-const { RSVP, computed, run, get, isBlank } = Ember;
-const Promise = RSVP.Promise;
-const PromiseArray = Ember.ArrayProxy.extend(Ember.PromiseProxyMixin);
+const { computed, run, get, isBlank } = Ember;
+// const Promise = RSVP.Promise;
+// const PromiseArray = Ember.ArrayProxy.extend(Ember.PromiseProxyMixin);
 
 export default Ember.Component.extend({
   // HTML
@@ -91,33 +91,56 @@ export default Ember.Component.extend({
     return this.get('searchText.length') === 0 && !!this.get('search') && !!this.get('searchMessage') && this.get('results.length') === 0;
   }),
 
-  mustShowNoMessages: computed('results.{isFulfilled,length}', function() {
-    return this.get('results.isFulfilled') && this.get('results.length') === 0;
+  mustShowNoMessages: computed('results.length', 'loading', function() {
+    return !this.get('loading') && this.get('results.length') === 0;
   }),
 
-  results: computed('options.[]', 'searchText', function() {
-    const { options, searchText, previousResults = Ember.A() } = this.getProperties('options', 'searchText', 'previousResults'); // jshint ignore:line
-    let promise;
-    if (isBlank(searchText)) {
-      promise = Promise.resolve(options).then(opts => Ember.A(opts || []));
-    } else if (this.searchReturnedUndefined) {
-      this.searchReturnedUndefined = null;
-      promise = Promise.resolve(options).then(opts => Ember.A(opts || []));
-    } else if (this.get('search')) {
-      let result = this.get('search')(searchText);
-      if (!result) {
-        promise = Promise.resolve(previousResults);
-        this.searchReturnedUndefined = true;
+  // results: computed('options.[]', 'searchText', function() {
+  //   const { options, searchText, previousResults = Ember.A() } = this.getProperties('options', 'searchText', 'previousResults'); // jshint ignore:line
+  //   let promise;
+  //   if (isBlank(searchText)) {
+  //     promise = Promise.resolve(options).then(opts => Ember.A(opts || []));
+  //   } else if (this.searchReturnedUndefined) {
+  //     this.searchReturnedUndefined = null;
+  //     promise = Promise.resolve(options).then(opts => Ember.A(opts || []));
+  //   } else if (this.get('search')) {
+  //     let result = this.get('search')(searchText);
+  //     if (!result) {
+  //       promise = Promise.resolve(previousResults);
+  //       this.searchReturnedUndefined = true;
+  //     } else {
+  //       this.searchReturnedUndefined = false;
+  //       let search = this.activeSearch = Promise.resolve(result);
+  //       promise = search.then(opts => search !== this.activeSearch ? previousResults : Ember.A(opts));
+  //     }
+  //   } else {
+  //     promise = Promise.resolve(options).then(opts => this.filter(Ember.A(opts), this.get('searchText')));
+  //   }
+  //   promise.then(opts => this.setProperties({ currentlyHighlighted: undefined, previousResults: opts }));
+  //   return PromiseArray.create({ promise, content: previousResults });
+  // }),
+  loading: false,
+  previousResults: null,
+  results: computed('options.[]', {
+    get() {
+      let options = this.get('options') || [];
+      let searchAction = this.get('search');
+      if (options.then) {
+        this.set('loading', true);
+        options.then(results => this.set('results', results));
+        return this.previousResults || [];
       } else {
-        this.searchReturnedUndefined = false;
-        let search = this.activeSearch = Promise.resolve(result);
-        promise = search.then(opts => search !== this.activeSearch ? previousResults : Ember.A(opts));
+        this.set('loading', false);
+        let newResults = searchAction ? options : this.filter(options, this.get('searchText'));
+        this.previousResults = newResults;
+        return newResults;
       }
-    } else {
-      promise = Promise.resolve(options).then(opts => this.filter(Ember.A(opts), this.get('searchText')));
+    },
+    set(_, newResults) {
+      this.previousResults = newResults;
+      this.set('loading', false);
+      return newResults;
     }
-    promise.then(opts => this.setProperties({ currentlyHighlighted: undefined, previousResults: opts }));
-    return PromiseArray.create({ promise, content: previousResults });
   }),
 
   highlighted: computed('results.[]', 'currentlyHighlighted', 'selected', function() {
@@ -284,5 +307,28 @@ export default Ember.Component.extend({
 
   _doSearch(dropdown, term) {
     this.set('searchText', term);
+    let options = this.get('options') || [];
+    if (isBlank(term)) {
+      this.set('loading', false);
+      return this.set('results', options);
+    }
+    let searchAction = this.get('search');
+    if (searchAction) {
+      let newResults = searchAction(term);
+      if (!newResults) { return; }
+      if (newResults.then) {
+        this.activeSearch = newResults;
+        this.set('loading', true);
+        newResults.then((items) => {
+          if (this.activeSearch === newResults) {
+            this.set('results', items);
+          }
+        });
+      } else {
+        this.set('results', newResults);
+      }
+    } else {
+      this.set('results', this.filter(options, term));
+    }
   }
 });

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -38,9 +38,10 @@ export default Ember.Component.extend({
 
   // Attrs
   searchText: '',
-  searchReturnedUndefined: false,
   activeSearch: null,
   openingEvent: null,
+  loading: false,
+  previousResults: null,
 
   // Lifecycle hooks
   init() {
@@ -95,32 +96,6 @@ export default Ember.Component.extend({
     return !this.get('loading') && this.get('results.length') === 0;
   }),
 
-  // results: computed('options.[]', 'searchText', function() {
-  //   const { options, searchText, previousResults = Ember.A() } = this.getProperties('options', 'searchText', 'previousResults'); // jshint ignore:line
-  //   let promise;
-  //   if (isBlank(searchText)) {
-  //     promise = Promise.resolve(options).then(opts => Ember.A(opts || []));
-  //   } else if (this.searchReturnedUndefined) {
-  //     this.searchReturnedUndefined = null;
-  //     promise = Promise.resolve(options).then(opts => Ember.A(opts || []));
-  //   } else if (this.get('search')) {
-  //     let result = this.get('search')(searchText);
-  //     if (!result) {
-  //       promise = Promise.resolve(previousResults);
-  //       this.searchReturnedUndefined = true;
-  //     } else {
-  //       this.searchReturnedUndefined = false;
-  //       let search = this.activeSearch = Promise.resolve(result);
-  //       promise = search.then(opts => search !== this.activeSearch ? previousResults : Ember.A(opts));
-  //     }
-  //   } else {
-  //     promise = Promise.resolve(options).then(opts => this.filter(Ember.A(opts), this.get('searchText')));
-  //   }
-  //   promise.then(opts => this.setProperties({ currentlyHighlighted: undefined, previousResults: opts }));
-  //   return PromiseArray.create({ promise, content: previousResults });
-  // }),
-  loading: false,
-  previousResults: null,
   results: computed('options.[]', {
     get() {
       let options = this.get('options') || [];
@@ -129,12 +104,10 @@ export default Ember.Component.extend({
         this.set('loading', true);
         options.then(results => this.set('results', results));
         return this.previousResults || [];
-      } else {
-        this.setProperties({ loading: false, currentlyHighlighted: undefined });
-        let newResults = searchAction ? options : this.filter(options, this.get('searchText'));
-        this.previousResults = newResults;
-        return newResults;
       }
+      this.setProperties({ loading: false, currentlyHighlighted: undefined });
+      this.previousResults = newResults;
+      return searchAction ? options : this.filter(options, this.get('searchText'));
     },
     set(_, newResults) {
       this.previousResults = newResults;

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -130,7 +130,7 @@ export default Ember.Component.extend({
         options.then(results => this.set('results', results));
         return this.previousResults || [];
       } else {
-        this.set('loading', false);
+        this.setProperties({ loading: false, currentlyHighlighted: undefined });
         let newResults = searchAction ? options : this.filter(options, this.get('searchText'));
         this.previousResults = newResults;
         return newResults;
@@ -138,7 +138,7 @@ export default Ember.Component.extend({
     },
     set(_, newResults) {
       this.previousResults = newResults;
-      this.set('loading', false);
+      this.setProperties({ loading: false, currentlyHighlighted: undefined });
       return newResults;
     }
   }),

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -22,7 +22,7 @@
           <ul class="ember-power-select-options" role="listbox"><li class="ember-power-select-option" role="option">{{noMatchesMessage}}</li></ul>
         {{/if}}
       {{else}}
-        {{#component optionsComponent options=(readonly results) allOptions=(readonly results) highlighted=(readonly highlighted)
+        {{#component optionsComponent options=(readonly results) loading=(readonly loading) allOptions=(readonly results) highlighted=(readonly highlighted)
           selected=(readonly selected) optionsComponent=(readonly optionsComponent) searchText=(readonly searchText)
           select=(readonly select) extra=(readonly extra) loadingMessage=(readonly loadingMessage)
           class="ember-power-select-options" as |option term|}}

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -1,4 +1,4 @@
-{{#if options.isPending}}
+{{#if loading}}
   {{#if loadingMessage}}
     <li class="ember-power-select-option" role="option">{{loadingMessage}}</li>
   {{/if}}

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -588,6 +588,7 @@ test('The search input is cleared when the component is closed', function(assert
   typeInSearch('asjdnah');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'No results found');
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').val(), 'asjdnah');
+  debugger;
   Ember.run(() => {
     let event = new window.Event('mousedown');
     this.$('#other-thing')[0].dispatchEvent(event);

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -588,7 +588,6 @@ test('The search input is cleared when the component is closed', function(assert
   typeInSearch('asjdnah');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'No results found');
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').val(), 'asjdnah');
-  debugger;
   Ember.run(() => {
     let event = new window.Event('mousedown');
     this.$('#other-thing')[0].dispatchEvent(event);


### PR DESCRIPTION
Since `ArrayProxy` is being deprecated (probably) this stops using it. This also helps tackle some unnecessary re-renders discovered and reported in #249 

