### PR TITLE
BUGFIX Pressing ENTER when no option is highlighted doesn't invoke onchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+- [BUGFIX] Ensure that pressing enter when there is no highlighted element (p.e after a search without results)
+  closes the component without calling the onchange function.
 - [BUGFIX] Update ember-basic-dropdown to 0.8.5+ fixes positioning issues in IE11 and fatal error in browsers without
   MutationObserver (effectively only ie10 )
 - [BUGFIX] the "publicAPI" object passed as penultimate object to the public actions includes a `highlighted`

--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -40,17 +40,17 @@ export default Ember.Component.extend({
     },
 
     handleKeydown(e) {
-      const { highlighted, onkeydown, select, searchText} = this.getProperties('highlighted', 'onkeydown', 'select', 'searchText');
+      let { highlighted, onkeydown, select, searchText} = this.getProperties('highlighted', 'onkeydown', 'select', 'searchText');
       if (onkeydown) { onkeydown(select, e); }
       if (e.defaultPrevented) { return; }
 
-      const selected = Ember.A((this.get('selected') || []));
-      if (e.keyCode === 13 && select.isOpen) {
+      let selected = Ember.A((this.get('selected') || []));
+      if (e.keyCode === 13 && select.isOpen && highlighted !== undefined) {
         if (selected.indexOf(highlighted) === -1) {
           select.actions.choose(buildNewSelection([highlighted, selected], { multiple: true }), e);
         }
       } else if (e.keyCode === 8 && isBlank(searchText)) {
-        const lastSelection = get(selected, 'lastObject');
+        let lastSelection = get(selected, 'lastObject');
         if (lastSelection) {
           select.actions.select(buildNewSelection([lastSelection, selected], { multiple: true }), e);
           if (typeof lastSelection === 'string') {

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { triggerKeydown, clickTrigger } from '../../../helpers/ember-power-select';
+import { triggerKeydown, clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
 import { numbers } from '../constants';
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Keyboard control)', {
@@ -94,6 +94,26 @@ test('Pressing ENTER selects the highlighted element, closes the dropdown and fo
   triggerKeydown($('.ember-power-select-search input')[0], 40);
   triggerKeydown($('.ember-power-select-search input')[0], 13);
   assert.equal($('.ember-power-select-trigger').text().trim(), 'two', 'The highlighted element was selected');
+  assert.equal($('.ember-power-select-dropdown').length, 0, 'The dropdown is closed');
+  assert.ok($('.ember-power-select-trigger').get(0) === document.activeElement, 'The trigger is focused');
+});
+
+test('Pressing ENTER when there is no highlighted element, closes the dropdown and focuses the trigger without calling the onchange function', function(assert) {
+  assert.expect(3);
+  this.numbers = numbers;
+  this.handleChange = () => {
+    assert.ok(false, 'The handle change should not be called');
+  };
+  this.render(hbs`
+    {{#power-select options=numbers selected=foo onchange=(action handleChange) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  typeInSearch('asjdnah');
+  assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'No results found');
+  triggerKeydown($('.ember-power-select-search input')[0], 13);
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The dropdown is closed');
   assert.ok($('.ember-power-select-trigger').get(0) === document.activeElement, 'The trigger is focused');
 });

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -594,3 +594,23 @@ test('The search input is cleared when the component is closed', function(assert
   });
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').val(), '');
 });
+
+test('When hitting ENTER after a search with no results, the component is closed but the onchange function is not invoked', function(assert) {
+  assert.expect(3);
+  this.numbers = numbers;
+  this.handleChange = () => {
+    assert.ok(false, 'The handle change should not be called');
+  };
+  this.render(hbs`
+    {{#power-select-multiple options=numbers selected=foo onchange=(action handleChange) as |option|}}
+      {{option}}
+    {{/power-select-multiple}}
+  `);
+
+  clickTrigger();
+  typeInSearch('asjdnah');
+  assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'No results found');
+  triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 13);
+  assert.equal($('.ember-power-select-dropdown').length, 0, 'The dropdown is closed');
+  assert.ok(this.$('.ember-power-select-trigger-multiple-input')[0] === document.activeElement, 'The input is focused');
+});


### PR DESCRIPTION
Closes #257