### PR TITLE
Ensure the second argument yielded to the block is updated simultaneously with the results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - [BUGFIX] Ensure the second argument yielded to the block is the searchText corresponding to the
   results being displayed. This is formally more correct and also save an expensive re-render that
-  can cause the component to jank in sufficiently bug/complex selects.
+  can cause the component to jank in sufficiently bug/complex selects. This is potentially breaking,
+  but very unlikely.
 
 # 0.8.4
 - [BUGFIX] Ensure that if the component is destroyed while an async search is in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Master
 
+- [BUGFIX] Ensure the second argument yielded to the block is the searchText corresponding to the
+  results being displayed. This is formally more correct and also save an expensive re-render that
+  can cause the component to jank in sufficiently bug/complex selects.
+
 # 0.8.4
 - [BUGFIX] Ensure that if the component is destroyed while an async search is in
   progress it doesn't fail.

--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -40,7 +40,7 @@ export default Ember.Component.extend({
     },
 
     handleKeydown(e) {
-      let { highlighted, onkeydown, select, searchText} = this.getProperties('highlighted', 'onkeydown', 'select', 'searchText');
+      let { highlighted, onkeydown, select } = this.getProperties('highlighted', 'onkeydown', 'select');
       if (onkeydown) { onkeydown(select, e); }
       if (e.defaultPrevented) { return; }
 
@@ -49,7 +49,7 @@ export default Ember.Component.extend({
         if (selected.indexOf(highlighted) === -1) {
           select.actions.choose(buildNewSelection([highlighted, selected], { multiple: true }), e);
         }
-      } else if (e.keyCode === 8 && isBlank(searchText)) {
+      } else if (e.keyCode === 8 && isBlank(e.target.value)) {
         let lastSelection = get(selected, 'lastObject');
         if (lastSelection) {
           select.actions.select(buildNewSelection([lastSelection, selected], { multiple: true }), e);

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -292,16 +292,18 @@ export default Ember.Component.extend({
   },
 
   _doSearch(dropdown, term) {
-    this.set('searchText', term);
     let options = this.get('options') || [];
     if (isBlank(term)) {
       this.activeSearch = null;
-      return this.setProperties({ results: options, loading: false });
+      return this.setProperties({ results: options, searchText: term, loading: false });
     }
     let searchAction = this.get('search');
     if (searchAction) {
       let newResults = searchAction(term);
-      if (!newResults) { return; }
+      if (!newResults) {
+        this.set('searchText', term);
+        return;
+      }
       if (newResults.then) {
         this.activeSearch = newResults;
         this.set('loading', true);
@@ -311,12 +313,16 @@ export default Ember.Component.extend({
             }
             this.set('results', items);
           }
+        }).finally(() => {
+          if (this.activeSearch === newResults) {
+            this.set('searchText', term);
+          }
         });
       } else {
-        this.set('results', newResults);
+        this.setProperties({ results: newResults, searchText: term });
       }
     } else {
-      this.set('results', this.filter(options, term));
+      this.setProperties({ results: this.filter(options, term), searchText: term });
     }
   }
 });

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -36,6 +36,7 @@ export default Ember.Component.extend({
 
   // Attrs
   searchText: '',
+  lastSearchedText: '',
   activeSearch: null,
   openingEvent: null,
   loading: false,
@@ -245,14 +246,14 @@ export default Ember.Component.extend({
     return nextOption;
   },
 
-  filter(options, searchText) {
+  filter(options, term) {
     let matcher;
     if (this.get('searchField')) {
       matcher = (option, text) => this.get('matcher')(get(option, this.get('searchField')), text);
     } else {
       matcher = (option, text) => this.get('matcher')(option, text);
     }
-    return filterOptions(options || [], searchText, matcher);
+    return filterOptions(options || [], term, matcher);
   },
 
   buildPublicAPI(dropdown) {

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -292,16 +292,17 @@ export default Ember.Component.extend({
   },
 
   _doSearch(dropdown, term) {
+    this.set('searchText', term);
     let options = this.get('options') || [];
     if (isBlank(term)) {
       this.activeSearch = null;
-      return this.setProperties({ results: options, searchText: term, loading: false });
+      return this.setProperties({ results: options, lastSearchedText: term, loading: false });
     }
     let searchAction = this.get('search');
     if (searchAction) {
       let newResults = searchAction(term);
       if (!newResults) {
-        this.set('searchText', term);
+        this.set('lastSearchedText', term);
         return;
       }
       if (newResults.then) {
@@ -315,14 +316,14 @@ export default Ember.Component.extend({
           }
         }).finally(() => {
           if (this.activeSearch === newResults) {
-            this.set('searchText', term);
+            this.set('lastSearchedText', term);
           }
         });
       } else {
-        this.setProperties({ results: newResults, searchText: term });
+        this.setProperties({ results: newResults, lastSearchedText: term });
       }
     } else {
-      this.setProperties({ results: this.filter(options, term), searchText: term });
+      this.setProperties({ results: this.filter(options, term), lastSearchedText: term });
     }
   }
 });

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -4,9 +4,9 @@
       <span aria-label="remove element" class="ember-power-select-multiple-remove-btn" onmousedown={{action select.actions.select (ember-power-select-build-selection opt selected multiple=true)}}>&times;</span>
     {{/unless}}
     {{#if selectedItemComponent}}
-      {{component selectedItemComponent selected=opt searchText=searchText}}
+      {{component selectedItemComponent selected=opt lastSearchedText=lastSearchedText}}
     {{else}}
-      {{yield opt searchText}}
+      {{yield opt lastSearchedText}}
     {{/if}}
   </span>
 {{/each}}

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -23,7 +23,7 @@
         {{/if}}
       {{else}}
         {{#component optionsComponent options=(readonly results) loading=(readonly loading) allOptions=(readonly results) highlighted=(readonly highlighted)
-          selected=(readonly selected) optionsComponent=(readonly optionsComponent) searchText=(readonly searchText)
+          selected=(readonly selected) optionsComponent=(readonly optionsComponent) lastSearchedText=(readonly lastSearchedText)
           select=(readonly select) extra=(readonly extra) loadingMessage=(readonly loadingMessage)
           class="ember-power-select-options" as |option term|}}
           {{yield option term}}
@@ -43,7 +43,7 @@
       search=(action "search" registeredDropdown)
       handleKeydown=(action "handleKeydown" registeredDropdown)
     )) as |select|}}
-    {{#component triggerComponent options=(readonly results) selected=(readonly selected) searchText=(readonly searchText)
+    {{#component triggerComponent options=(readonly results) selected=(readonly selected) searchText=(readonly searchText) lastSearchedText=(readonly lastSearchedText)
       placeholder=(readonly placeholder) disabled=(readonly disabled) highlighted=(readonly highlighted) allowClear=(readonly allowClear)
       select=(readonly select) extra=(readonly extra) onkeydown=(readonly onkeydown)
       selectedItemComponent=(readonly selectedItemComponent) searchField=(readonly searchField) as |opt term|}}

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -23,7 +23,7 @@
         {{/if}}
       {{else}}
         {{#component optionsComponent options=(readonly results) loading=(readonly loading) allOptions=(readonly results) highlighted=(readonly highlighted)
-          selected=(readonly selected) optionsComponent=(readonly optionsComponent) lastSearchedText=(readonly lastSearchedText)
+          selected=(readonly selected) optionsComponent=(readonly optionsComponent) searchText=(readonly searchText) lastSearchedText=(readonly lastSearchedText)
           select=(readonly select) extra=(readonly extra) loadingMessage=(readonly loadingMessage)
           class="ember-power-select-options" as |option term|}}
           {{yield option term}}

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -10,14 +10,14 @@
       {{#component optionsComponent highlighted=(readonly highlighted) selected=(readonly selected)
         options=(readonly opt.options) allOptions=(readonly allOptions) optionsComponent=(readonly optionsComponent) select=(readonly select)
         class="ember-power-select-options ember-power-select-options--nested" as |option|}}
-        {{yield option searchText}}
+        {{yield option lastSearchedText}}
       {{/component}}
     </li>
   {{else}}
     <li class="ember-power-select-option {{ember-power-select-option-classes opt selected highlighted}}"
       onmouseup={{action select.actions.choose (ember-power-select-build-selection opt selected multiple=multiple)}}
       onmouseover={{action select.actions.highlight opt}} role="option">
-      {{yield opt searchText}}
+      {{yield opt lastSearchedText}}
     </li>
   {{/if}}
 {{/each}}

--- a/addon/templates/components/power-select/trigger.hbs
+++ b/addon/templates/components/power-select/trigger.hbs
@@ -1,8 +1,8 @@
 {{#if selected}}
   {{#if selectedItemComponent}}
-    {{component selectedItemComponent selected=selected searchText=searchText}}
+    {{component selectedItemComponent selected=selected lastSearchedText=lastSearchedText}}
   {{else}}
-    {{yield selected searchText}}
+    {{yield selected lastSearchedText}}
   {{/if}}
   {{#if allowClear}}
     <span class="ember-power-select-clear-btn" onmousedown={{action select.actions.select null}}>&times;</span>

--- a/tests/dummy/app/controllers/legacy-demo.js
+++ b/tests/dummy/app/controllers/legacy-demo.js
@@ -380,6 +380,7 @@ export default Ember.Controller.extend({
   complexOptionsWithDisabled: contriesWithDisabled,
 
   multipleSelection: ['one','two','three','four','five','six','seven','eight','nine','ten','eleven'],
+  emptyMultipleSelection: [],
 
   groupedOptions: [
     { groupName: "Smalls", options: ["one", "two", "three"] },
@@ -415,8 +416,7 @@ export default Ember.Controller.extend({
     asyncSearch(term) {
       return new Ember.RSVP.Promise(function(resolve) {
         Ember.run.later(function() {
-          var length = term.length;
-          resolve(numbers.filter(str => str.length === length)); // returns the numbers with the same length than the current
+          resolve(numbers.filter(str => str.indexOf(term) > -1));
         }, 1500);
       });
     },

--- a/tests/dummy/app/templates/legacy-demo.hbs
+++ b/tests/dummy/app/templates/legacy-demo.hbs
@@ -2,11 +2,6 @@
   <input type="text" value="sample input">
   <h2 id="title">Welcome to the demo of ember-power-select (provisional name)</h2>
 
-{{#power-select-multiple onopen=(action "onSelectOpen") search=(action "searchFoo") selected=foobar onchange=(action (mut foobar)) as |name|}}
-  {{name}}
-{{/power-select-multiple}}
-
-
 {{!--   {{#power-select-multiple options=complexOptions selected=choosenCountry onchange=(action (mut choosenCountry)) searchField='name' as |country|}}
     {{country.name}}
   {{/power-select-multiple}}
@@ -59,7 +54,12 @@
   <h4>Select clearable</h4>
   {{#power-select options=(readonly complexOptions) searchField="name" allowClear=true selected=name2 onchange=(action (mut name2)) as |option|}}
     {{option.code}}: {{option.name}}
-  {{/power-select}}
+  {{/power-select}} --}}
+
+  <h4>Select multiple [WORK IN PROGRESS]</h4>
+  {{#power-select-multiple options=(readonly simpleOptions) selected=emptyMultipleSelection onchange=(action (mut multipleSelection)) search=(action 'asyncSearch') as |option|}}
+    {{option}}
+  {{/power-select-multiple}}
 
   <h4>Select multiple [WORK IN PROGRESS]</h4>
   {{#power-select-multiple options=(readonly simpleOptions) selected=multipleSelection onchange=(action (mut multipleSelection)) as |option|}}
@@ -205,5 +205,5 @@
   <br>
   <br>
   <br>
- --}}
+
 </section>

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -443,6 +443,64 @@ test('If you delete the last char of the input before the previous promise resol
   }, 300);
 });
 
+test('The yielded search term in single selects is updated only when the async search for it finishes', function(assert) {
+  let done = assert.async();
+  assert.expect(3);
+  this.numbers = numbers;
+  this.searchFn = function(term) {
+    return new RSVP.Promise(function(resolve) {
+      setTimeout(function() {
+        resolve(numbers.filter(str => str.indexOf(term) > -1));
+      }, 100);
+    });
+  };
+
+  this.render(hbs`
+    {{#power-select options=numbers search=searchFn onchange=(action (mut foo)) as |number searchTerm|}}
+      {{number}}:{{searchTerm}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  typeInSearch("teen");
+  setTimeout(function() {
+    assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'thirteen:teen', 'The results and the searchTerm have updated');
+    typeInSearch("four");
+    assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Loading options...', 'There is a search going on');
+    assert.equal($('.ember-power-select-option:eq(1)').text().trim(), 'thirteen:teen', 'The results and the searchTerm are still the same because the search has not finished yet');
+    done();
+  }, 150);
+});
+
+test('The yielded search term in multiple selects is updated only when the async search for it finishes', function(assert) {
+  let done = assert.async();
+  assert.expect(3);
+  this.numbers = numbers;
+  this.searchFn = function(term) {
+    return new RSVP.Promise(function(resolve) {
+      setTimeout(function() {
+        resolve(numbers.filter(str => str.indexOf(term) > -1));
+      }, 100);
+    });
+  };
+
+  this.render(hbs`
+    {{#power-select-multiple options=numbers search=searchFn onchange=(action (mut foo)) as |number searchTerm|}}
+      {{number}}:{{searchTerm}}
+    {{/power-select-multiple}}
+  `);
+
+  clickTrigger();
+  typeInSearch("teen");
+  setTimeout(function() {
+    assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'thirteen:teen', 'The results and the searchTerm have updated');
+    typeInSearch("four");
+    assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Loading options...', 'There is a search going on');
+    assert.equal($('.ember-power-select-option:eq(1)').text().trim(), 'thirteen:teen', 'The results and the searchTerm are still the same because the search has not finished yet');
+    done();
+  }, 150);
+});
+
 test('BUGFIX: Destroy a component why an async search is pending does not cause an error', function(assert) {
   let done = assert.async();
   assert.expect(0); // This test has no assertions. The fact that nothing fails is the proof that it works


### PR DESCRIPTION
Until now, the `searchText` was updated as the user types, synchronously, even if the search was asynchronous.

This behaviour had 2 downsides:

* It might lead to bad results. Imagine this scenario:
```hbs
{{#power-select search=(action "asyncSearch") selected=selected as |user searchTerm|}}
  {{highlight-substring user.fullName searchTerm}}
{{/power-select}}
```

If the user searchers for `ab` and waits, it will see results which the substring `ab` highlighted. However if now the user adds a "c" (resulting in `abc`) the text to be highlighted becomes `abc` immediately even if the search takes 300ms in update the results for those containing `abc`. During this time, it will try to highlight `abc` on results that don't contain that string.
Now, the `searchText` is named `lastSearchedText` and is updated only when the search finalizes.
The currently typed text is still available as `searchText`.
The second argument yielded to the block is the `lastSearchedText`

* The second problem was performance. Even diregarding the fact that for a few milliseconds the results and the searched texts were out of sync, re-rendering the list because the `searchText` changes just to immediately re-render it again because the promise is resolved caused the component to jank significantly. 