### PR TITLE
Added a variable for line-height units

### DIFF
--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -19,7 +19,7 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
   background-color: $ember-power-select-background-color;
   line-height: $ember-power-select-line-height;
   text-overflow: ellipsis;
-  min-height: #{$ember-power-select-line-height}em;
+  min-height: #{$ember-power-select-line-height};
   user-select: none;
   -webkit-user-select: none;
   color: $ember-power-select-text-color;
@@ -155,7 +155,7 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
   -webkit-user-select: none;
   &:not(.ember-power-select-options--nested) {
     overflow-y: auto;
-    max-height: #{$ember-power-select-number-of-visible-options * $ember-power-select-line-height}em;
+    max-height: #{$ember-power-select-number-of-visible-options * $ember-power-select-line-height};
   }
 }
 

--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -19,7 +19,7 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
   background-color: $ember-power-select-background-color;
   line-height: $ember-power-select-line-height;
   text-overflow: ellipsis;
-  min-height: #{$ember-power-select-line-height};
+  min-height: #{$ember-power-select-line-height}$ember-power-select-line-height-unit;
   user-select: none;
   -webkit-user-select: none;
   color: $ember-power-select-text-color;
@@ -155,7 +155,7 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
   -webkit-user-select: none;
   &:not(.ember-power-select-options--nested) {
     overflow-y: auto;
-    max-height: #{$ember-power-select-number-of-visible-options * $ember-power-select-line-height};
+    max-height: #{$ember-power-select-number-of-visible-options * $ember-power-select-line-height}$ember-power-select-line-height-unit;
   }
 }
 

--- a/app/styles/ember-power-select/variables.scss
+++ b/app/styles/ember-power-select/variables.scss
@@ -58,3 +58,4 @@ $ember-power-select-focus-outline: null !default;
 $ember-power-select-trigger-ltr-padding: 0 16px 0 8px !default;
 $ember-power-select-trigger-rtl-padding: 0 8px 0 16px !default;
 $ember-power-select-multiple-option-padding: 0 4px !default;
+$ember-power-select-line-height-unit: em !default;


### PR DESCRIPTION
Calculations using line-height to determine the height of elements had been hardcoded to use em units, creating an issue for applications not using a unitless value for line-height or not using em units for line-height. 

**Changes:**
Replaced the em units with a variable in ember-power-select.scss and defaulted it to em in the variables. Leaving the variable blank with quotes("") when overriding will allow no unit to be used for the calculations, eliminating redundant units that would create an invalid value if line-height already has a unit. 