### PR TITLE
Feature/code samples length

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+If you would like to contribute, you can fork the project, edit, and make a
+pull request.
+
+## Tests
+
+Please make sure that the test pass by running `ember test`. If you had a new
+functionality, add tests for it.
+
+## Update the website & documentation
+
+The documentation website lives under `tests/dummy`. It is a simple
+ember app. You can run the website locally:
+
+```
+npm install
+bower install
+ember serve
+# visit localhost:4200
+```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ wouldn't work in IE9+. If you find any problem please file an issue.
 In testing it requires phantomjs 2.0+. This component also provides some convenient [test helpers](http://www.ember-power-select.com/docs/test-helpers)
 to interact with the component in acceptance tests.
 
+## Contributing
+
+Any contribution is welcome. Please read our [guidelines](CONTRIBUTING.md).
+
 ## Troubleshooting
 
 If something doesn't work visit the [Troubleshooting](http://www.ember-power-select.com/docs/troubleshooting)

--- a/tests/dummy/app/templates/public-pages/cookbook/debounce-searches.hbs
+++ b/tests/dummy/app/templates/public-pages/cookbook/debounce-searches.hbs
@@ -12,7 +12,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet template {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select search=(action "searchRepo") selected=selected onchange=(action (mut selected)) as |repo|}}
+    \{{#power-select
+      search=(action "searchRepo")
+      selected=selected
+      onchange=(action (mut selected))
+      as |repo|
+    }}
       \{{repo.full_name}}
     \{{/power-select}}
   </pre>
@@ -41,7 +46,12 @@
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
     <div style="margin: 0 auto; max-width: 250px;">
-      {{#power-select search=(action "searchRepo") selected=selected onchange=(action (mut selected)) as |repo|}}
+      {{#power-select
+        search=(action "searchRepo")
+        selected=selected
+        onchange=(action (mut selected))
+        as |repo|
+      }}
         {{repo.full_name}}
       {{/power-select}}
     </div>

--- a/tests/dummy/app/templates/public-pages/cookbook/navigable-select.hbs
+++ b/tests/dummy/app/templates/public-pages/cookbook/navigable-select.hbs
@@ -22,7 +22,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet template {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#navigable-select options=groupedNumbers selected=selectedNumber onchange=(action (mut selectedNumber)) as |option|}}
+    \{{#navigable-
+      select options=groupedNumbers
+      selected=selectedNumber
+      onchange=(action (mut selectedNumber))
+      as |option|
+    }}
       \{{option}}
     \{{/navigable-select}}
   </pre>
@@ -47,7 +52,12 @@
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
     <div style="max-width: 250px;">
-      {{#navigable-select options=groupedNumbers selected=selectedNumber onchange=(action (mut selectedNumber)) as |option|}}
+      {{#navigable-select
+        options=groupedNumbers
+        selected=selectedNumber
+        onchange=(action (mut selectedNumber))
+        as |option|
+      }}
         {{option}}
       {{/navigable-select}}
     </div>
@@ -67,7 +77,12 @@
   The task consists basically in create a grouped select like this:
 </p>
 <div style="margin: 0 auto; max-width: 250px;">
-  {{#power-select options=groupedNumbers selected=selectedNumber onchange=(action (mut selectedNumber)) as |option|}}
+  {{#power-select
+    options=groupedNumbers
+    selected=selectedNumber
+    onchange=(action (mut selectedNumber))
+    as |option|
+  }}
     {{option}}
   {{/power-select}}
 </div>
@@ -117,7 +132,15 @@
 </p>
 
 <pre>
-  \{{#power-select options=currentOptions selected=selected closeOnSelect=false onchange=(action "onchange") optionsComponent='animated-options' search=(action "search") as |levelOrOption|}}
+  \{{#power-
+    select options=currentOptions
+    selected=selected
+    closeOnSelect=false
+    onchange=(action "onchange")
+    optionsComponent='animated-options'
+    search=(action "search")
+    as |levelOrOption|
+  }}
     \{{#if levelOrOption.parentLevel}}
       &lt;strong&gt;&lt; Back&lt;/strong&gt;
     \{{else if levelOrOption.levelName}}

--- a/tests/dummy/app/templates/public-pages/docs/action-handling.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/action-handling.hbs
@@ -26,7 +26,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet template {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select selected=destination options=cities onchange=(action "chooseDestination") as |name|}}
+    \{{#power-select
+      selected=destination
+      options=cities
+      onchange=(action "chooseDestination")
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -45,7 +50,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select selected=destination options=cities onchange=(action "chooseDestination") as |name|}}
+    {{#power-select
+      selected=destination
+      options=cities
+      onchange=(action "chooseDestination")
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>
@@ -59,7 +69,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet template {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select selected=destination options=cities onchange=(action (mut destination)) as |name|}}
+    \{{#power-select
+      selected=destination
+      options=cities
+      onchange=(action (mut destination))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -70,7 +85,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select selected=destination options=cities onchange=(action (mut destination)) as |name|}}
+    {{#power-select
+      selected=destination
+      options=cities
+      onchange=(action (mut destination))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>
@@ -105,7 +125,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet template {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select-multiple selected=selectedCities options=cities onchange=(action (mut selectedCities)) onkeydown=(action "handleKeydown") as |name|}}
+    \{{#power-select-multiple
+      selected=selectedCities
+      options=cities
+      onchange=(action (mut selectedCities))
+      onkeydown=(action "handleKeydown")
+      as |name|
+    }}
       \{{name}}
     \{{/power-select-multiple}}
   </pre>
@@ -125,7 +151,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select-multiple selected=selectedCities options=cities onchange=(action (mut selectedCities)) onkeydown=(action "handleKeydown") as |name|}}
+    {{#power-select-multiple
+      selected=selectedCities
+      options=cities
+      onchange=(action (mut selectedCities))
+      onkeydown=(action "handleKeydown")
+      as |name|
+    }}
       {{name}}
     {{/power-select-multiple}}
   </div>
@@ -146,7 +178,13 @@
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet template {{if (eq component.activeTab 'template') 'active'}}">
     &lt;input type="text" placeholder="Focus me and press TAB to focus the select"&gt;
-    \{{#power-select selected=selected options=cities onchange=(action (mut selected)) onfocus=(action "handleFocus") as |name|}}
+    \{{#power-select
+      selected=selected
+      options=cities
+      onchange=(action (mut selected))
+      onfocus=(action "handleFocus")
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -164,7 +202,13 @@
     <input type="text" placeholder="Focus me and press TAB to focus the select" style="line-height: 2; width: 100%">
     <br>
     <br>
-    {{#power-select selected=selected options=cities onchange=(action (mut selected)) onfocus=(action "handleFocus") as |name|}}
+    {{#power-select
+      selected=selected
+      options=cities
+      onchange=(action (mut selected))
+      onfocus=(action "handleFocus")
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>
@@ -188,7 +232,14 @@
     \{{#if destroyed}}
       The bomb has exploded! Reload to try again :)
     \{{else}}
-      \{{#power-select selected=number options=numbers onchange=(action (mut number)) onopen=(action "startSelfDestroyCountdown") placeholder="Once opened this component will destroy itself in 8 seconds" as |number|}}
+      \{{#power-select
+        selected=number
+        options=numbers
+        onchange=(action (mut number))
+        onopen=(action "startSelfDestroyCountdown")
+        placeholder="Once opened this component will destroy itself in 8 seconds"
+        as |number|
+      }}
         \{{number}}
       \{{/power-select}}
       \{{#if countdown}}&lt;p&gt;This component will be destroyed in \{{counter}} seconds&lt;/p&gt;\{{/if}}
@@ -214,7 +265,14 @@
     {{#if destroyed}}
       The bomb has exploded! Reload to try again :)
     {{else}}
-      {{#power-select selected=number options=numbers onchange=(action (mut number)) onopen=(action "startSelfDestroyCountdown") placeholder="Once opened this component will destroy itself in 8 seconds" as |number|}}
+      {{#power-select
+        selected=number
+        options=numbers
+        onchange=(action (mut number))
+        onopen=(action "startSelfDestroyCountdown")
+        placeholder="Once opened this component will destroy itself in 8 seconds"
+        as |number|
+      }}
         {{number}}
       {{/power-select}}
       {{#if countdown}}<p>This component will be destroyed in {{counter}} seconds</p>{{/if}}

--- a/tests/dummy/app/templates/public-pages/docs/asynchronous-search.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/asynchronous-search.hbs
@@ -24,7 +24,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select search=(action "searchRepo") selected=selected onchange=(action (mut selected)) as |repo|}}
+    \{{#power-select
+      search=(action "searchRepo")
+      selected=selected
+      onchange=(action (mut selected))
+      as |repo|
+    }}
       \{{repo.full_name}}
     \{{/power-select}}
   </pre>
@@ -40,7 +45,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select search=(action "searchRepo") selected=selected onchange=(action (mut selected)) as |repo|}}
+    {{#power-select
+      search=(action "searchRepo")
+      selected=selected
+      onchange=(action (mut selected))
+      as |repo|
+    }}
       {{repo.full_name}}
     {{/power-select}}
     (It might fail if the API limit is exceeded)

--- a/tests/dummy/app/templates/public-pages/docs/groups.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/groups.hbs
@@ -8,7 +8,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=groupedNumbers selected=number onchange=(action (mut number)) as |num|}}
+    \{{#power-select
+      options=groupedNumbers
+      selected=number
+      onchange=(action (mut number))
+      as |num|
+    }}
       \{{num}}
     \{{/power-select}}
   </pre>
@@ -29,7 +34,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=groupedNumbers selected=number onchange=(action (mut number)) as |num|}}
+    {{#power-select
+      options=groupedNumbers
+      selected=number
+      onchange=(action (mut number))
+      as |num|
+    }}
       {{num}}
     {{/power-select}}
   </div>

--- a/tests/dummy/app/templates/public-pages/docs/how-to-use-it.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/how-to-use-it.hbs
@@ -44,7 +44,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet template {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=countries selected=destination onchange=(action "foo") as |country|}}
+    \{{#power-select
+      options=countries
+      selected=destination
+      onchange=(action "foo")
+      as |country|
+    }}
       &lt;img src="\{{country.flagUrl}}" class="icon-flag"&gt; &lt;strong&gt;\{{country.name}}&lt;/strong&gt;
     \{{/power-select}}
   </pre>
@@ -68,7 +73,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=countries selected=destination onchange=(action "foo") as |country|}}
+    {{#power-select
+      options=countries
+      selected=destination
+      onchange=(action "foo")
+      as |country|
+    }}
       <img src="{{country.flagUrl}}" class="icon-flag"> <strong>{{country.name}}</strong>
     {{/power-select}}
   </div>

--- a/tests/dummy/app/templates/public-pages/docs/multiple-selection.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/multiple-selection.hbs
@@ -8,7 +8,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select-multiple options=names selected=name onchange=(action (mut name)) as |name|}}
+    \{{#power-select-multiple
+      options=names
+      selected=name
+      onchange=(action (mut name))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select-multiple}}
   </pre>
@@ -18,7 +23,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select-multiple options=names selected=name onchange=(action (mut name)) as |name|}}
+    {{#power-select-multiple
+      options=names
+      selected=name
+      onchange=(action (mut name))
+      as |name|
+    }}
       {{name}}
     {{/power-select-multiple}}
   </div>

--- a/tests/dummy/app/templates/public-pages/docs/the-list.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/the-list.hbs
@@ -21,7 +21,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=names renderInPlace=true selected=name onchange=(action (mut name)) as |name|}}
+    \{{#power-select
+      options=names
+      renderInPlace=true
+      selected=name
+      onchange=(action (mut name))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -31,7 +37,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=names renderInPlace=true selected=name onchange=(action (mut name)) as |name|}}
+    {{#power-select
+      options=names
+      renderInPlace=true
+      selected=name
+      onchange=(action (mut name))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
     (Looks the same but inspect the DOM to see the difference)
@@ -52,7 +64,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=names verticalPosition='above' selected=name onchange=(action (mut name)) as |name|}}
+    \{{#power-select
+      options=names
+      verticalPosition='above'
+      selected=name
+      onchange=(action (mut name))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -62,7 +80,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=names verticalPosition='above' selected=name onchange=(action (mut name)) as |name|}}
+    {{#power-select
+      options=names
+      verticalPosition='above'
+      selected=name
+      onchange=(action (mut name))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
     (This list of options will always be on top regardless of how much available space there is around)
@@ -79,7 +103,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=emptyList selected=selected onchange=(action (mut selected)) as |name|}}
+    \{{#power-select
+      options=emptyList
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -89,7 +118,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=emptyList selected=selected onchange=(action (mut selected)) as |name|}}
+    {{#power-select
+      options=emptyList
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>
@@ -101,7 +135,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=emptyList noMatchesMessage="404 bro" selected=selected onchange=(action (mut selected)) as |name|}}
+    \{{#power-select
+      options=emptyList
+      noMatchesMessage="404 bro"
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -111,7 +151,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=emptyList noMatchesMessage="404 bro" selected=selected onchange=(action (mut selected)) as |name|}}
+    {{#power-select
+      options=emptyList
+      noMatchesMessage="404 bro"
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>
@@ -124,7 +170,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=emptyList selected=selected onchange=(action (mut selected)) as |name|}}
+    \{{#power-select
+      options=emptyList
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       \{{name}}
     \{{else}}
       &lt;div class="text-center"&gt;
@@ -138,7 +189,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=emptyList selected=selected onchange=(action (mut selected)) as |name|}}
+    {{#power-select
+      options=emptyList
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       {{name}}
     {{else}}
       <div class="text-center">
@@ -170,12 +226,23 @@
     &lt;button onclick=\{{action "refreshCollection"}}&gt;Refresh collection&lt;/button&gt;
 
     Default loading message
-    \{{#power-select options=promise selected=selected onchange=(action (mut selected)) as |name|}}
+    \{{#power-select
+      options=promise
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
 
     Custom loading message
-    \{{#power-select options=promise loadingMessage="Waiting for the server" selected=selected onchange=(action (mut selected)) as |name|}}
+    \{{#power-select
+      options=promise
+      loadingMessage="Waiting for the server"
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -199,12 +266,23 @@
     <button onclick={{action "refreshCollection"}}>Refresh collection</button>
     <br>
     Default loading message
-    {{#power-select options=promise selected=selected onchange=(action (mut selected)) as |name|}}
+    {{#power-select
+      options=promise
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
     <br>
     Custom loading message (press the <code>Refresh Collection</code> button and open this select)
-    {{#power-select options=promise loadingMessage="Waiting for the server...." selected=selected onchange=(action (mut selected)) as |name|}}
+    {{#power-select
+      options=promise
+      loadingMessage="Waiting for the server...."
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>
@@ -225,7 +303,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=countries selected=country onchange=(action (mut country)) as |country|}}
+    \{{#power-
+      select options=countries
+      selected=country
+      onchange=(action (mut country))
+      as |country|
+    }}
       \{{country.name}}
     \{{/power-select}}
   </pre>
@@ -243,7 +326,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=countries selected=country onchange=(action (mut country)) as |country|}}
+    {{#power-select
+      options=countries
+      selected=country
+      onchange=(action (mut country))
+      as |country|
+    }}
       {{country.name}}
     {{/power-select}}
   </div>

--- a/tests/dummy/app/templates/public-pages/docs/the-search.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/the-search.hbs
@@ -11,7 +11,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=names selected=selected onchange=(action (mut selected)) as |name|}}
+    \{{#power-select
+      options=names
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -21,7 +26,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=diacritics selected=selected onchange=(action (mut selected)) as |name|}}
+    {{#power-select
+      options=diacritics
+      selected=selected
+      onchange=(action (mut selected))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>
@@ -37,7 +47,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=countries searchField="name" selected=selected onchange=(action (mut selected)) as |country|}}
+    \{{#power-select
+      options=countries
+      searchField="name"
+      selected=selected
+      onchange=(action (mut selected))
+      as |country|
+    }}
       \{{country.name}}
     \{{/power-select}}
   </pre>
@@ -55,7 +71,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=countries searchField="name" selected=selected onchange=(action (mut selected)) as |country|}}
+    {{#power-select
+      options=countries
+      searchField="name"
+      selected=selected
+      onchange=(action (mut selected))
+      as |country|
+    }}
       {{country.name}}
     {{/power-select}}
   </div>
@@ -72,7 +94,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=people matcher=myMatcher selected=selected onchange=(action (mut selected)) as |person|}}
+    \{{#power-
+      select options=people
+      matcher=myMatcher
+      selected=selected
+      onchange=(action (mut selected))
+      as |person|
+    }}
       \{{person.name}} {{person.surname}}
     \{{/power-select}}
   </pre>
@@ -93,7 +121,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=people matcher=myMatcher selected=selected onchange=(action (mut selected)) as |person|}}
+    {{#power-select
+      options=people
+      matcher=myMatcher
+      selected=selected
+      onchange=(action (mut selected))
+      as |person|
+    }}
       {{person.name}} {{person.surname}}
     {{/power-select}}
   </div>
@@ -109,7 +143,12 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=names selected=selected onchange=(action (mut selected)) as |name term|}}
+    \{{#power-select
+      options=names
+      selected=selected
+      onchange=(action (mut selected))
+      as |name term|
+    }}
       \{{highlight-text name term}}
     \{{/power-select}}
   </pre>
@@ -124,7 +163,12 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=names selected=selected onchange=(action (mut selected)) as |name term|}}
+    {{#power-select
+      options=names
+      selected=selected
+      onchange=(action (mut selected))
+      as |name term|
+    }}
       {{highlight-substr name term}}
     {{/power-select}}
   </div>
@@ -152,7 +196,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=names searchPlaceholder="Type to filter..." selected=person onchange=(action (mut person)) as |name|}}
+    \{{#power-select
+      options=names
+      searchPlaceholder="Type to filter..."
+      selected=person
+      onchange=(action (mut person))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -162,7 +212,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=diacritics searchPlaceholder="Type to filter..." selected=person onchange=(action (mut person)) as |name|}}
+    {{#power-select
+      options=diacritics
+      searchPlaceholder="Type to filter..."
+      selected=person
+      onchange=(action (mut person))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>
@@ -176,7 +232,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=names searchEnabled=false selected=user onchange=(action (mut user)) as |name|}}
+    \{{#power-
+      select options=names
+      searchEnabled=false
+      selected=user
+      onchange=(action (mut user))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -186,7 +248,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=names searchEnabled=false selected=user onchange=(action (mut user)) as |name|}}
+    {{#power-select
+      options=names
+      searchEnabled=false
+      selected=user
+      onchange=(action (mut user))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>

--- a/tests/dummy/app/templates/public-pages/docs/the-trigger.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/the-trigger.hbs
@@ -15,7 +15,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=names disabled=true selected=name onchange=(action (mut name)) as |name|}}
+    \{{#power-select
+      options=names
+      disabled=true
+      selected=name
+      onchange=(action (mut name))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -25,7 +31,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=names disabled=true selected=name onchange=(action (mut name)) as |name|}}
+    {{#power-select
+      options=names
+      disabled=true
+      selected=name
+      onchange=(action (mut name))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>
@@ -50,7 +62,14 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-  \{{#power-select options=countries selected=country selectedItemComponent="selected-item-country" searchField="name" onchange=(action (mut country)) as |country|}}
+  \{{#power-
+    select options=countries
+    selected=country
+    selectedItemComponent="selected-item-country"
+    searchField="name"
+    onchange=(action (mut country))
+    as |country|
+  }}
     &lt;div class="country-detailed-info"&gt;
       &lt;img src="\{{country.flagUrl}}" class="country-flag"&gt;
       &lt;div class="country-data-text"&gt;
@@ -78,7 +97,14 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-  {{#power-select options=countries selected=country selectedItemComponent="selected-item-country" searchField="name" onchange=(action (mut country)) as |country|}}
+  {{#power-select
+    options=countries
+    selected=country
+    selectedItemComponent="selected-item-country"
+    searchField="name"
+    onchange=(action (mut country))
+    as |country|
+  }}
     <div class="country-detailed-info">
       <img src="{{country.flagUrl}}" class="country-flag">
       <div class="country-data-text">
@@ -100,7 +126,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=countries placeholder="Please, select one destination" selected=selected onchange=(action (mut selected)) as |country|}}
+    \{{#power-select
+      options=countries
+      placeholder="Please, select one destination"
+      selected=selected
+      onchange=(action (mut selected))
+      as |country|
+    }}
       \{{country.name}}
     \{{/power-select}}
   </pre>
@@ -118,7 +150,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=countries placeholder="Please, select one destination" selected=selected onchange=(action (mut selected)) as |country|}}
+    {{#power-select
+      options=countries
+      placeholder="Please, select one destination"
+      selected=selected
+      onchange=(action (mut selected))
+      as |country|
+    }}
       {{country.name}}
     {{/power-select}}
   </div>
@@ -134,7 +172,13 @@
 
 {{#code-sample as |component|}}
   <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
-    \{{#power-select options=names selected=name allowClear=true onchange=(action (mut name)) as |name|}}
+    \{{#power-select
+      options=names
+      selected=name
+      allowClear=true
+      onchange=(action (mut name))
+      as |name|
+    }}
       \{{name}}
     \{{/power-select}}
   </pre>
@@ -144,7 +188,13 @@
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
-    {{#power-select options=names selected=name allowClear=true onchange=(action (mut name)) as |name|}}
+    {{#power-select
+      options=names
+      selected=name
+      allowClear=true
+      onchange=(action (mut name))
+      as |name|
+    }}
       {{name}}
     {{/power-select}}
   </div>


### PR DESCRIPTION
As discussed in #289, this PR avoid horizontal scrolls in code example in the website. Since it is the first addon I contributed to and it took me couple minutes to figure out how to run the website, I added a `contributing.hbs` page too.

```hbs
# bad :(
{{#power-select options=countries searchField="name" selected=selected onchange=(action (mut selected)) as |country|}}
  {{country.name}}
{{/power-select}}

# good :)
{{#power-select
  options=countries
  searchField="name"
  selected=selected
  onchange=(action (mut selected))
  as |country|
}}
  {{country.name}}
{{/power-select}}
```