### PR TITLE
Allow to pass `matchTriggerWidth=false` to let the dropdown grow with the content

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -33,6 +33,7 @@ export default Ember.Component.extend({
   optionsComponent: fallbackIfUndefined('power-select/options'),
   beforeOptionsComponent: fallbackIfUndefined('power-select/before-options'),
   afterOptionsComponent: fallbackIfUndefined(null),
+  matchTriggerWidth: fallbackIfUndefined(true),
 
   // Attrs
   searchText: '',

--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -19,6 +19,7 @@
       beforeOptionsComponent=beforeOptionsComponent
       optionsComponent=optionsComponent
       afterOptionsComponent=afterOptionsComponent
+      matchTriggerWidth=matchTriggerWidth
       matcher=matcher
       searchField=searchField
       renderInPlace=renderInPlace
@@ -59,6 +60,7 @@
       beforeOptionsComponent=beforeOptionsComponent
       optionsComponent=optionsComponent
       afterOptionsComponent=afterOptionsComponent
+      matchTriggerWidth=matchTriggerWidth
       matcher=matcher
       searchField=searchField
       renderInPlace=renderInPlace

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -3,7 +3,7 @@
   dir=(readonly dir)
   tabindex=(readonly tabindex)
   renderInPlace=(readonly renderInPlace)
-  matchTriggerWidth=true
+  matchTriggerWidth=matchTriggerWidth
   disabled=(readonly disabled)
   verticalPosition=(readonly verticalPosition)
   triggerClass=(readonly concatenatedTriggerClasses)

--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -130,7 +130,6 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
 
 // Dropdown
 .ember-power-select-dropdown {
-  width: 100%;
   border-left: $ember-power-select-dropdown-left-border;
   border-right: $ember-power-select-dropdown-right-border;
   line-height: $ember-power-select-line-height;
@@ -157,6 +156,10 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
     border-top-right-radius: $ember-power-select-opened-border-radius;
   }
 }
+.ember-power-select .ember-power-select-dropdown { // Dropdown when rendered in place
+  width: 100%;
+}
+// Options
 .ember-power-select-options {
   list-style: none;
   margin: 0;

--- a/tests/dummy/app/templates/legacy-demo.hbs
+++ b/tests/dummy/app/templates/legacy-demo.hbs
@@ -171,6 +171,13 @@
     {{/power-select}}
   </div>
 
+  <h4>Match trigger width can be disabled</h4>
+  <div style="width: 150px;">
+    {{#power-select options=(readonly simpleOptions) selected=simpleSelected4 onchange=(action (mut simpleSelected4)) matchTriggerWidth=false as |opt|}}
+      {{opt}}
+    {{/power-select}}
+  </div>
+
   <br>
   <br>
   <br>

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -152,6 +152,13 @@
         passed to this component, this is the only one desiged to be mutable.
       </td>
     </tr>
+    <tr>
+      <td>matchTriggerWidth</td>
+      <td><code>boolean (defaults to true)</code></td>
+      <td>
+        When enabled (and it's enabled by default) the dropdown with match the width of the trigger.
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Disclaimer: It doesn't looks nice with the default styles.