### PR TITLE
Completely control focus from within the beforeOptionsComponent

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -4,6 +4,7 @@ import { defaultMatcher, indexOfOption, optionAtIndex, filterOptions, countOptio
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 
 const { computed, run, get, isBlank } = Ember;
+const EventSender = Ember.Object.extend(Ember.Evented);
 
 export default Ember.Component.extend({
   // HTML
@@ -124,6 +125,10 @@ export default Ember.Component.extend({
     return countOptions(this.get('results'));
   }),
 
+  eventSender: computed(function() {
+    return EventSender.create();
+  }),
+
   // Actions
   actions: {
     highlight(dropdown, option) {
@@ -174,6 +179,7 @@ export default Ember.Component.extend({
       if (action) {
         action(this.buildPublicAPI(dropdown), event);
       }
+      this.get('eventSender').trigger('focus');
     },
 
     // It is not evident what is going on here, so I'll explain why.

--- a/addon/components/power-select/before-options.js
+++ b/addon/components/power-select/before-options.js
@@ -18,10 +18,8 @@ export default Ember.Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    this.input = document.querySelector('.ember-power-select-search input');
-    if (this.input) {
-      Ember.run.schedule('afterRender', this.input, 'focus');
-    }
+    this.focusInput();
+    this.get('eventSender').on('focus', this, this.focusInput);
   },
 
   willDestroy() {
@@ -29,6 +27,7 @@ export default Ember.Component.extend({
     if (this.get('searchEnabled')) {
       this.get('select.actions.search')('');
     }
+    this.get('eventSender').off('focus', this, this.focusInput);
   },
 
   // Actions
@@ -49,5 +48,12 @@ export default Ember.Component.extend({
   // Methods
   updateInput(value) {
     updateInput(this.input, value);
+  },
+
+  focusInput() {
+    this.input = self.document.querySelector('.ember-power-select-search input');
+    if (this.input) {
+      run.scheduleOnce('afterRender', this.input, 'focus');
+    }
   }
 });

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -27,7 +27,14 @@
       search=(action "search" dropdown)
       handleKeydown=(action "handleKeydown" dropdown)
     )) as |select|}}
-      {{component beforeOptionsComponent searchText=(readonly searchText) onkeydown=(readonly onkeydown) select=(readonly select) searchPlaceholder=(readonly searchPlaceholder) searchEnabled=(readonly searchEnabled) highlighted=(readonly highlighted)}}
+      {{component beforeOptionsComponent
+        searchText=(readonly searchText)
+        onkeydown=(readonly onkeydown)
+        select=(readonly select)
+        searchPlaceholder=(readonly searchPlaceholder)
+        searchEnabled=(readonly searchEnabled)
+        highlighted=(readonly highlighted)
+        eventSender=eventSender}}
       {{#if mustShowSearchMessage}}
         <ul class="ember-power-select-options" role="listbox"><li class="ember-power-select-option" role="option">{{searchMessage}}</li></ul>
       {{else if mustShowNoMessages}}


### PR DESCRIPTION
Ember-basic-dropdown no longer call preventDefault on mousedown events
on the trigger. That means that the trigger will get the focus normally.
The beforeOptionsComponent used to docus the input inside when rendered.

The problem was that the trigger gets the focus after the component has
been rendered and steals the focus back.

With this change, the beforeOptionsComponent receives an event when the trigger
is focused, and can then safely set the focus to the input.