### PR TITLE
Empty search, when term is empty and options is promise

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -298,7 +298,13 @@ export default Ember.Component.extend({
     if (isBlank(term)) {
       let options = this.get('options') || [];
       this.activeSearch = null;
-      this.setProperties({ results: options, searchText: term, lastSearchedText: term, loading: false });
+      if (options.then) {
+        options.then((data) => {
+          this.setProperties({ results: data, searchText: term, lastSearchedText: term, loading: false });
+        });
+      } else {
+        this.setProperties({ results: options, searchText: term, lastSearchedText: term, loading: false });
+      }
     } else {
       let searchAction = this.get('search');
       if (searchAction) {

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -531,24 +531,24 @@ test('BUGFIX: Destroy a component why an async search is pending does not cause 
   }, 150);
 });
 
-// test('BUGFIX: When the given options are a promise and a search function is provided, clearing the search must display the results of the original promise', function(assert) {
-//   assert.expect(3);
-//   this.numbersPromise = RSVP.Promise.resolve(numbers);
+test('BUGFIX: When the given options are a promise and a search function is provided, clearing the search must display the results of the original promise', function(assert) {
+  assert.expect(3);
+  this.numbersPromise = RSVP.Promise.resolve(numbers);
 
-//   this.searchFn = function(term) {
-//     return numbers.filter(str => str.indexOf(term) > -1);
-//   };
+  this.searchFn = function(term) {
+    return numbers.filter(str => str.indexOf(term) > -1);
+  };
 
-//   this.render(hbs`
-//     {{#power-select options=numbersPromise search=searchFn selected=foo onchange=(action (mut foo)) as |number|}}
-//       {{number}}
-//     {{/power-select}}
-//   `);
+  this.render(hbs`
+   {{#power-select options=numbersPromise search=searchFn selected=foo onchange=(action (mut foo)) as |number|}}
+     {{number}}
+   {{/power-select}}
+  `);
 
-//   clickTrigger();
-//   assert.equal($('.ember-power-select-option').length, 20, 'There is 20 options');
-//   typeInSearch("teen");
-//   assert.equal($('.ember-power-select-option').length, 7, 'There is 7 options');
-//   typeInSearch("");
-//   assert.equal($('.ember-power-select-option').length, 20, 'There is 20 options again§');
-// });
+  clickTrigger();
+  assert.equal($('.ember-power-select-option').length, 20, 'There is 20 options');
+  typeInSearch("teen");
+  assert.equal($('.ember-power-select-option').length, 7, 'There is 7 options');
+  typeInSearch("");
+  assert.equal($('.ember-power-select-option').length, 20, 'There is 20 options again§');
+});


### PR DESCRIPTION
If options passed to the component, is a promise and search is enabled via `search=(action "search")` component do not return initial results, when term is empty.

```javascript
options: computed(function() {
  return Ember.RSVP.Promise.resolve(function() {
    return [{id: 1, text: 'demo'}, { id: 2, text: 'demo2' }];
  });
});
```

It will work on initial search, but if you remove search term, it will show empty results.