### PR TITLE
Allow the custom matchers to return numbers apart from booleans

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -261,13 +261,14 @@ export default Ember.Component.extend({
   },
 
   filter(options, term) {
-    let matcher;
-    if (this.get('searchField')) {
-      matcher = (option, text) => this.get('matcher')(get(option, this.get('searchField')), text);
+    let optionMatcher;
+    let { matcher, searchField } = this.getProperties('matcher', 'searchField');
+    if (searchField) {
+      optionMatcher = (option, text) => matcher(get(option, searchField), text);
     } else {
-      matcher = (option, text) => this.get('matcher')(option, text);
+      optionMatcher = (option, text) => matcher(option, text);
     }
-    return filterOptions(options || [], term, matcher);
+    return filterOptions(options || [], term, optionMatcher);
   },
 
   buildPublicAPI(dropdown) {

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -82,8 +82,13 @@ export function filterOptions(options, text, matcher) {
       if (get(suboptions, 'length') > 0) {
         opts.push({ groupName: entry.groupName, options: suboptions });
       }
-    } else if (matcher(entry, text)) {
-      opts.push(entry);
+    } else {
+      let matchResult = matcher(entry, text);
+      if (typeof matchResult === 'number') {
+        if (matchResult >= 0) { opts.push(entry); }
+      } else if (matchResult) {
+        opts.push(entry);
+      }
     }
   }
   return opts;
@@ -942,5 +947,5 @@ export function stripDiacritics(text) {
 }
 
 export function defaultMatcher(value, text) {
-  return text === '' || stripDiacritics(value).toUpperCase().indexOf(stripDiacritics(text).toUpperCase()) > -1;
+  return stripDiacritics(value).toUpperCase().indexOf(stripDiacritics(text).toUpperCase());
 }

--- a/tests/dummy/app/templates/public-pages/docs/the-search.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/the-search.hbs
@@ -89,7 +89,8 @@
   Sometimes the default matcher is not enough for you, for example if you need to match against several
   fields or you need to perform fuzzy matching. If that is the case just pass your own matcher
   function. It will receive the option and the search term and you can do whatever you feel like
-  inside as long as it returns <code>true</code> or <code>false</code>.
+  inside as long as it returns <code>-1</code> if it doesn't match and a positive number if it does.
+  Returning a boolean works too, but might be removed in the near future.
 </p>
 
 {{#code-sample as |component|}}

--- a/tests/unit/utils/group-utils-test.js
+++ b/tests/unit/utils/group-utils-test.js
@@ -60,7 +60,7 @@ test('#optionAtIndex knows how to transverse groups', function(assert) {
   assert.equal(optionAtIndex(groupedOptions, -1), undefined);
 });
 
-test('#filterOptions generates new options respecting groups', function(assert) {
+test('#filterOptions generates new options respecting groups when the matches returns a boolean', function(assert) {
   const matcher = function(value, searchText) {
     return new RegExp(searchText, 'i').test(value);
   };
@@ -84,6 +84,32 @@ test('#filterOptions generates new options respecting groups', function(assert) 
 
   assert.deepEqual(filterOptions(groupedOptions, 'imposible', matcher), []);
   assert.deepEqual(filterOptions(groupedOptions, '', matcher), groupedOptions);
+});
+
+test('#filterOptions generates new options respecting groups when the matches returns a number, taking negative numbers as "not found" and positive as matches', function(assert) {
+  const matcher = function(value, searchText) {
+    return value.indexOf(searchText);
+  };
+  assert.deepEqual(filterOptions(groupedOptions, 'zero', matcher), [{ groupName: "Smalls", options: ["zero"] }]);
+  assert.deepEqual(filterOptions(groupedOptions, 'ele', matcher), [
+    { groupName: "Bigs", options: [
+        { groupName: "Really big", options: ["eleven"] },
+      ]
+    }
+  ]);
+  assert.deepEqual(filterOptions(groupedOptions, 't', matcher), [
+    { groupName: "Smalls", options: ["two","three"] },
+    { groupName: "Bigs", options: [
+        { groupName: "Fairly big", options: ["eight"] },
+        { groupName: "Really big", options: [ "ten", "twelve" ] },
+        "thirteen"
+      ]
+    },
+    "one thousand"
+  ]);
+
+  assert.deepEqual(filterOptions(groupedOptions, 'imposible', matcher), [], 'when nothing matches, an empty array is returned');
+  assert.deepEqual(filterOptions(groupedOptions, '', matcher), groupedOptions, 'when all matches, all options ');
 });
 
 test('#stripDiacritics returns the given string with diacritics normalized into simple letters', function(assert) {


### PR DESCRIPTION
This will be the preferred option in the near future. It will allow to prioritize results when typing on the trigger instead of on the searchbox.