### PR TITLE
Seperated handleKeyDown into seperate overridable methods

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -170,17 +170,13 @@ export default Ember.Component.extend({
       if (onkeydown) { onkeydown(this.buildPublicAPI(dropdown), e); }
       if (e.defaultPrevented) { return; }
       if (e.keyCode === 38 || e.keyCode === 40) { // Up & Down
-        if (dropdown.isOpen) {
-          e.preventDefault();
-          const newHighlighted = this.advanceSelectableOption(this.get('highlighted'), e.keyCode === 40 ? 1 : -1);
-          this.send('highlight', dropdown, newHighlighted, e);
-        } else {
-          dropdown.actions.open(e);
-        }
-      } else if (dropdown.isOpen && e.keyCode === 13) {  // ENTER
-        this.send('choose', dropdown, this.get('highlighted'), e);
-      } else if (e.keyCode === 9 || e.keyCode === 27) {  // Tab or ESC
-        dropdown.actions.close(e);
+        this._handleKeyUpDown(dropdown, e);
+      } else if (e.keyCode === 13) {  // ENTER
+        this._handleKeyEnter(dropdown, e);
+      } else if (e.keyCode === 9) {   //Tab
+        this._handleKeyTab(dropdown, e);
+      } else if (e.keyCode === 27) {  // ESC
+        this._handleKeyESC(dropdown, e);
       } else if (e.keyCode >= 48 && e.keyCode <= 90 || e.keyCode === 32) { // Keys 0-9, a-z or SPACE
         this._handleTriggerTyping(dropdown, e);
       }
@@ -223,7 +219,31 @@ export default Ember.Component.extend({
       if (action) { action(this.buildPublicAPI(dropdown), e); }
       if (e) { this.set('openingEvent', null); }
       this.send('highlight', dropdown, null, e);
-    },
+    }
+  },
+
+  _handleKeyUpDown(dropdown, e) {
+    if (dropdown.isOpen) {
+      e.preventDefault();
+      const newHighlighted = this.advanceSelectableOption(this.get('highlighted'), e.keyCode === 40 ? 1 : -1);
+      this.send('highlight', dropdown, newHighlighted, e);
+    } else {
+      dropdown.actions.open(e);
+    }
+  },
+
+  _handleKeyEnter(dropdown, e) {
+    if (dropdown.isOpen) {
+      this.send('choose', dropdown, this.get('highlighted'), e);
+    }
+  },
+
+  _handleKeyTab(dropdown, e) {
+    dropdown.actions.close(e);
+  },
+
+  _handleKeyESC(dropdown, e) {
+    dropdown.actions.close(e);
   },
 
   // Methods


### PR DESCRIPTION
I would like to implement a selectOnTab property to allow the option to be selected when tabbed. It appeared I had to override the entire handleKeyDown action, but this was problematic based on the action keydown, if I did my code first, the action wouldn't fire.

It would be easier to just override the key I wanted to handle. To do this I split out the handling of each key into a method that could be overridden in an extended class.

This pull request does nothing but split the handling into those methods.

Once accepted I will follow up with a PR for implementing the selectOnTab. I did not include it in this request as I think this request would be useful to anyone extending the class and gives you the opportunity to not to take the selectOnTab functionally while still giving me the ability to implement it.