### PR TITLE
_doSearch should handle options as a promise.

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -337,7 +337,14 @@ export default Ember.Component.extend({
       if (searchAction) {
         this._performSearch(searchAction, term);
       } else {
-        this.setProperties({ results: this.filter(this.get('options'), term), searchText: term, lastSearchedText: term });
+        let options = this.get('options');
+        if (options.then) {
+          options.then((data) => {
+            this.setProperties({ results: this.filter(data, term), searchText: term, lastSearchedText: term });
+          });
+        } else {
+          this.setProperties({ results: this.filter(this.get('options'), term), searchText: term, lastSearchedText: term });
+        }
       }
     }
   },

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -343,7 +343,7 @@ export default Ember.Component.extend({
             this.setProperties({ results: this.filter(data, term), searchText: term, lastSearchedText: term });
           });
         } else {
-          this.setProperties({ results: this.filter(this.get('options'), term), searchText: term, lastSearchedText: term });
+          this.setProperties({ results: this.filter(options, term), searchText: term, lastSearchedText: term });
         }
       }
     }

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -772,3 +772,30 @@ test('The trigger of the select has a id derived from the element id of the comp
   `);
   assert.ok(/^ember-power-select-trigger-ember\d+$/.test(this.$('.ember-power-select-trigger').attr('id'), 'The trigger has the proper id'));
 });
+
+test('If the passed options is a promise that is resolved, searching should filter the results from a promise', function(assert) {
+  let done = assert.async();
+  assert.expect(5);
+
+  this.numbersPromise = new RSVP.Promise(function(resolve) {
+    Ember.run.later(function() {resolve(numbers); }, 100);
+  });
+
+  this.render(hbs`
+    {{#power-select options=numbersPromise onchange=(action (mut foo)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  setTimeout(function() {
+    clickTrigger();
+    typeInSearch("o");
+
+    assert.equal($('.ember-power-select-option').length, 4, 'The dropdown is opened and results shown.');
+    assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'one');
+    assert.equal($('.ember-power-select-option:eq(1)').text().trim(), 'two');
+    assert.equal($('.ember-power-select-option:eq(2)').text().trim(), 'four');
+    assert.equal($('.ember-power-select-option:eq(3)').text().trim(), 'fourteen');
+    done();
+  }, 150);
+});


### PR DESCRIPTION
`this.get('options')` could return a promise, so `_doSearch` is updated to handle it. Otherwise, `_doSearch` could be triggered and improperly excute `this.filter` on a promise, instead of a promises fulfilled value.