### PR TITLE
Fix alignment of selected items in power-select-multiple for RTL layout

### DIFF
--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -232,6 +232,12 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
 .ember-power-select[dir=rtl] {
   .ember-power-select-trigger {
     padding: $ember-power-select-trigger-rtl-padding;
+    .ember-power-select-multiple-option {
+      float: initial;
+    }
+    .ember-power-select-trigger-multiple-input {
+      float: initial;
+    }
   }
   .ember-power-select-status-icon {
     left: 5px;

--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -233,10 +233,10 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
   .ember-power-select-trigger {
     padding: $ember-power-select-trigger-rtl-padding;
     .ember-power-select-multiple-option {
-      float: initial;
+      float: right;
     }
     .ember-power-select-trigger-multiple-input {
-      float: initial;
+      float: right;
     }
   }
   .ember-power-select-status-icon {


### PR DESCRIPTION
added css classes for `ember-power-select-multiple-option` and `ember-power-select-trigger-multiple-input` in RTL layout to align them to the right, as discussed in #331 