### PR TITLE
[BREAKING CHANGE] Passing `class="my-foo"` doesn't add derived classe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Master
 
+- [BREAKING CHANGE] Passing `class="my-foo"` to the component just customizes the class of the top-most
+  component, but doesn't try to derive classes from it for the trigger and the dropdown. This behavour
+  was unexpected, confusing, didn't work with multiple classes `class="foo bar baz"` and doesn't enables
+  any feature that `triggerClass=` and `dropdownClass=` don't allow already. Ditched.
+
 # 0.9.0-beta.8
 - [BUGFIX] Allow to type in closed multiple selects. Before the default behaviour of keydown events
   was being prevented, disallowing the typing.

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -77,9 +77,6 @@ export default Ember.Component.extend({
     if (this.get('triggerClass')) {
       classes.push(this.get('triggerClass'));
     }
-    if (this.get('class')) {
-      classes.push(`${this.get('class')}-trigger`);
-    }
     return classes.join(' ');
   }),
 
@@ -87,9 +84,6 @@ export default Ember.Component.extend({
     let classes = ['ember-power-select-dropdown', `ember-power-select-dropdown-${this.elementId}`];
     if (this.get('dropdownClass')) {
       classes.push(this.get('dropdownClass'));
-    }
-    if (this.get('class')) {
-      classes.push(`${this.get('class')}-dropdown`);
     }
     return classes.join(' ');
   }),

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -350,8 +350,8 @@ test('If the user passes `dropdownClass` the dropdown content should have that c
   assert.ok($('.ember-power-select-dropdown').hasClass('this-is-a-test-class'), 'dropdownClass can be customized');
 });
 
-test('If the user passes `class` the classes of the dropdown are customized using that', function(assert) {
-  assert.expect(2);
+test('If the user passes `class` the dropdown gets that class', function(assert) {
+  assert.expect(1);
   this.options = [];
   this.render(hbs`
     {{#power-select options=options selected=foo onchange=(action (mut foo)) class="my-foo" as |option|}}
@@ -359,8 +359,6 @@ test('If the user passes `class` the classes of the dropdown are customized usin
     {{/power-select}}
   `);
   assert.ok($('.ember-power-select').hasClass('my-foo'), 'the entire select inherits that class');
-  clickTrigger();
-  assert.ok($('.ember-power-select-dropdown').hasClass('my-foo-dropdown'), 'the dropdown derives its class from the given one too');
 });
 
 test('The filtering is reverted after closing the select', function(assert) {


### PR DESCRIPTION
…s to trigger & dropdown.

It just adds a class to the wrapped div, as expected. The old behaviour was unexpected and
fundamentally flawed when passing strings containing more than one class.