### PR TITLE
Deprecate returning a boolean from custom matchers.

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -120,6 +120,15 @@ export default Ember.Component.extend({
     }
   }),
 
+  optionMatcher: computed('searchField', 'matcher', function() {
+    let { matcher, searchField } = this.getProperties('matcher', 'searchField');
+    if (searchField) {
+      return (option, text) => matcher(get(option, searchField), text);
+    } else {
+      return (option, text) => matcher(option, text);
+    }
+  }),
+
   highlighted: computed('results.[]', 'currentlyHighlighted', 'selected', function() {
     return this.get('currentlyHighlighted') || this.defaultHighlighted();
   }),
@@ -295,14 +304,7 @@ export default Ember.Component.extend({
   },
 
   filter(options, term) {
-    let optionMatcher;
-    let { matcher, searchField } = this.getProperties('matcher', 'searchField');
-    if (searchField) {
-      optionMatcher = (option, text) => matcher(get(option, searchField), text);
-    } else {
-      optionMatcher = (option, text) => matcher(option, text);
-    }
-    return filterOptions(options || [], term, optionMatcher);
+    return filterOptions(options || [], term, this.get('optionMatcher'));
   },
 
   defaultHighlighted() {

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -70,7 +70,7 @@ export function optionAtIndex(originalCollection, index) {
     }
   })(originalCollection);
 }
-
+let deprecatedMatchers = {};
 export function filterOptions(options, text, matcher) {
   const sanitizedOptions =  options.objectAt ? options : Ember.A(options);
   const opts = Ember.A();
@@ -87,6 +87,15 @@ export function filterOptions(options, text, matcher) {
       if (typeof matchResult === 'number') {
         if (matchResult >= 0) { opts.push(entry); }
       } else if (matchResult) {
+        let matcherToString = matcher.toString();
+        if (!deprecatedMatchers[matcherToString]) {
+          deprecatedMatchers[matcherToString] = true;
+          Ember.deprecate(
+            `Your custom matcher returned ${matchResult}. This is deprecated, custom matchers must return a number. Return any negative number when there was no match and return 0+ for positive matches. This will allow EPS to prioritize results`,
+            false,
+            { id: 'ember-power-select-matcher-return-number', until: '0.10' }
+          );
+        }
         opts.push(entry);
       }
     }

--- a/tests/dummy/app/controllers/public-pages/docs/the-search.js
+++ b/tests/dummy/app/controllers/public-pages/docs/the-search.js
@@ -28,6 +28,6 @@ export default Ember.Controller.extend({
   ],
 
   myMatcher(person, term) {
-    return term === '' || person.name.indexOf(term) > -1 || person.surname.indexOf(term) > -1;
+    return (person.name + ' ' + person.surname).indexOf(term);
   }
 });

--- a/tests/dummy/app/templates/public-pages/docs/the-search.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/the-search.hbs
@@ -162,7 +162,7 @@
       ],
 
       myMatcher(person, term) {
-        return term === '' || person.name.indexOf(term) > -1 || person.surname.indexOf(term) > -1;
+        return return (person.name + ' ' + person.surname).indexOf(term);
       }
     });
   </pre>

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -579,7 +579,7 @@ test('You can pass a custom marcher with `matcher=myFn` to customize the search 
 
   this.numbers = numbers;
   this.endsWithMatcher = function(option, text) {
-    return text === '' || option.slice(text.length * -1) === text;
+    return option.slice(text.length * -1) === text ? 0 : -1;
   };
 
   this.render(hbs`
@@ -702,8 +702,8 @@ test('You can pass a custom marcher with `matcher=myFn` to customize the search 
     { name: 'Lisa',   surname: 'Simpson' },
   ];
 
-  this.nameOrSurnameNoDiacriticsCaseSensitive = function(value, text) {
-    return text === '' || value.name.indexOf(text) > -1 || value.surname.indexOf(text) > -1;
+  this.nameOrSurnameNoDiacriticsCaseSensitive = function(person, term) {
+    return (person.name + ' ' + person.surname).indexOf(term);
   };
 
   this.render(hbs`

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -209,7 +209,7 @@ test('The filtering specifying a custom matcher works in multiple model', functi
 
   this.numbers = numbers;
   this.endsWithMatcher = function(value, text) {
-    return text === '' || value.slice(text.length * -1) === text;
+    return value.slice(text.length * -1) === text ? 0 : -1;
   };
 
   this.render(hbs`

--- a/tests/unit/utils/group-utils-test.js
+++ b/tests/unit/utils/group-utils-test.js
@@ -62,7 +62,7 @@ test('#optionAtIndex knows how to transverse groups', function(assert) {
 
 test('#filterOptions generates new options respecting groups when the matches returns a boolean', function(assert) {
   const matcher = function(value, searchText) {
-    return new RegExp(searchText, 'i').test(value);
+    return new RegExp(searchText, 'i').test(value) ? 0 : -1;
   };
   assert.deepEqual(filterOptions(groupedOptions, 'zero', matcher), [{ groupName: "Smalls", options: ["zero"] }]);
   assert.deepEqual(filterOptions(groupedOptions, 'ele', matcher), [


### PR DESCRIPTION
That was soft-deprecated but now it emits a deprecation warning.