### PR TITLE
Add FastClick compatibility

### DIFF
--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -25,6 +25,7 @@
       aria-disabled={{opt.disabled}}
       aria-current={{eq opt highlighted}}
       onmouseup={{action select.actions.choose (ember-power-select-build-selection opt selected multiple=multiple)}}
+      onclick={{action select.actions.choose (ember-power-select-build-selection opt selected multiple=multiple)}}
       onmouseover={{action select.actions.highlight opt}} role="option">
       {{yield opt lastSearchedText}}
     </li>


### PR DESCRIPTION
[FastClick](https://github.com/ftlabs/fastclick) does not seem to handle `"mousedown"` events properly. Adding the `"onclick"` event allows the add-on to be used on mobile devices in combination with [FastClick](https://github.com/ftlabs/fastclick).

Depends on https://github.com/cibernox/ember-basic-dropdown/pull/53 to be accepted in ember-basic-dropdown. Otherwise the dropdown won't even open to allow for selecting an option.

Solves issue #248 described in ember-power-select "Incompatibility with fastclick?".
https://github.com/cibernox/ember-power-select/issues/248

Example of the issue:
![demo](https://cloud.githubusercontent.com/assets/3015394/13551626/5bda8d86-e340-11e5-9dbe-74126d6f3983.gif)