### PR TITLE
Enable babel polyfill

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    // Add options here
+    babel: {
+      includePolyfill: true
+    }
   });
 
   /*


### PR DESCRIPTION
This PR enables the babel polyfill through ember-cli-babel. This polyfill is needed to support several ES6 features listed here: https://github.com/babel/ember-cli-babel#features. Previously, the `for (let val of array)` statements in the tests/dummy/app were causing problems in IE 11 (ex: https://github.com/cibernox/ember-power-select/blob/master/tests/dummy/app/controllers/public-pages/cookbook.js#L30). With this fix the docs website works successfully in IE 11.