### PR TITLE
Disabled placeholder of multiple selects in internet explorer 10 & 11

### DIFF
--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -5,7 +5,8 @@ import updateInput from '../../utils/update-input-value';
 
 const { computed, get, isBlank, run } = Ember;
 const { htmlSafe } = Ember.String;
-
+const ua = window.navigator.userAgent;
+const isIE = ua.indexOf('MSIE ') > -1 || ua.indexOf('Trident/') > -1;
 export default Ember.Component.extend({
   tagName: '',
   layout,
@@ -37,6 +38,7 @@ export default Ember.Component.extend({
   }),
 
   maybePlaceholder: computed('placeholder', 'selected.length', function() {
+    if (isIE) { return null; }
     const selected = this.get('selected');
     return (!selected || get(selected, 'length') === 0) ? (this.get('placeholder') || '') : '';
   }),

--- a/tests/dummy/app/templates/public-pages/docs/multiple-selection.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/multiple-selection.hbs
@@ -11,6 +11,7 @@
     \{{#power-select-multiple
       options=names
       selected=name
+      placeholder="Select some names..."
       onchange=(action (mut name))
       as |name|
     }}
@@ -26,6 +27,7 @@
     {{#power-select-multiple
       options=names
       selected=name
+      placeholder="Select some names..."
       onchange=(action (mut name))
       as |name|
     }}


### PR DESCRIPTION
There is some kind of bug in IE that causes the input to gain the focus over and
over when it has placeholder.

This solution is less than ideal, but it's better to not have placeholder than
to have a select that you can't close.