### PR TITLE
Wrap yielded selected item in span

### DIFF
--- a/addon/templates/components/power-select/trigger.hbs
+++ b/addon/templates/components/power-select/trigger.hbs
@@ -2,7 +2,7 @@
   {{#if selectedItemComponent}}
     {{component selectedItemComponent selected=selected lastSearchedText=lastSearchedText}}
   {{else}}
-    {{yield selected lastSearchedText}}
+    <span class="ember-power-select-selected-item">{{yield selected lastSearchedText}}</span>
   {{/if}}
   {{#if allowClear}}
     <span class="ember-power-select-clear-btn" onmousedown={{action select.actions.select null}}>&times;</span>


### PR DESCRIPTION
All text in the trigger is wrapped in some element except the yielded selected item. To allow for styling, wrapped this text in a span.

Did not opt for wrapping in the actual yield when ember-power-select is used, because that yield may also be used in options where is it already wrapped in an [LI element](https://github.com/cibernox/ember-power-select/blob/master/addon%2Ftemplates%2Fcomponents%2Fpower-select%2Foptions.hbs#L23) 