### PR TITLE
Fix concatenated class CPs

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -72,7 +72,7 @@ export default Ember.Component.extend({
     return classes.join(' ');
   }),
 
-  concatenatedTriggerClasses: computed('class', function() {
+  concatenatedTriggerClasses: computed('triggerClass', function() {
     let classes = ['ember-power-select-trigger'];
     if (this.get('triggerClass')) {
       classes.push(this.get('triggerClass'));
@@ -80,7 +80,7 @@ export default Ember.Component.extend({
     return classes.join(' ');
   }),
 
-  concatenatedDropdownClasses: computed('class', function() {
+  concatenatedDropdownClasses: computed('dropdownClass', function() {
     let classes = ['ember-power-select-dropdown', `ember-power-select-dropdown-${this.elementId}`];
     if (this.get('dropdownClass')) {
       classes.push(this.get('dropdownClass'));


### PR DESCRIPTION
In `power-select.js`, `concatenatedTriggerClasses` and `concatenatedDropdownClasses` didn't depend on `triggerClass` and `dropdownClass` correspondingly, which basically made it impossible to have dynamic values for those properties.