### PR TITLE
[BREAKING CHANGE] Use event delegation for a ~20% speed improvement

### DIFF
--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -1,36 +1,67 @@
 import Ember from 'ember';
 import layout from '../../templates/components/power-select/options';
 
+const { get } = Ember;
+
 export default Ember.Component.extend({
+  isTouchDevice: (!!self.window && 'ontouchstart' in self.window),
   layout: layout,
   tagName: 'ul',
   attributeBindings: ['role', 'aria-controls'],
   role: 'listbox',
 
+  // Lifecycle hooks
   init() {
     this._super(...arguments);
     this._touchMoveHandler = this._touchMoveHandler.bind(this);
   },
 
-  // Actions
-  actions: {
-    handleTouchStart(e) {
-      this.element.addEventListener('touchmove', this._touchMoveHandler);
-    },
+  didInsertElement() {
+    this._super(...arguments);
+    if (this.get('role') === 'group') { return; }
+    let chooseOption = e => {
+      if (e.target.dataset.optionIndex) {
+        this.get('select.actions.choose')(this._optionFromIndex(e.target.dataset.optionIndex));
+      }
+    };
+    this.element.addEventListener('mousedown', chooseOption);
+    this.element.addEventListener('mouseover', e => {
+      if (e.target.dataset.optionIndex) {
+        this.get('select.actions.highlight')(this._optionFromIndex(e.target.dataset.optionIndex));
+      }
+    });
 
-    handleTouchEnd(option, e) {
+    if (!this.get('isTouchDevice')) { return; }
+
+    // Add touch event handlers to detect taps
+    this.element.addEventListener('touchstart', () => {
+      this.element.addEventListener('touchmove', this._touchMoveHandler);
+    });
+    this.element.addEventListener('touchend', e => {
       e.preventDefault();
       if (this.hasMoved) {
         this.hasMoved = false;
         return;
       }
-      this.get('select.actions.choose')(option, e);
-    }
+      chooseOption(e);
+    });
+
   },
 
   // Methods
   _touchMoveHandler() {
     this.hasMoved = true;
     this.element.removeEventListener('touchmove', this._touchMoveHandler);
-  }
+  },
+
+  _optionFromIndex(index) {
+    let parts = index.split('.');
+    let options = this.get('options');
+    let option = get(options, parts[0]);
+    for (let i = 1; i < parts.length; i++) {
+      option = get(option.options, parts[i]);
+    }
+    return option;
+  },
+
 });

--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -21,13 +21,13 @@ export default Ember.Component.extend({
     if (this.get('role') === 'group') { return; }
     let chooseOption = e => {
       if (e.target.dataset.optionIndex) {
-        this.get('select.actions.choose')(this._optionFromIndex(e.target.dataset.optionIndex));
+        this.get('select.actions.choose')(this._optionFromIndex(e.target.dataset.optionIndex), e);
       }
     };
     this.element.addEventListener('mousedown', chooseOption);
     this.element.addEventListener('mouseover', e => {
       if (e.target.dataset.optionIndex) {
-        this.get('select.actions.highlight')(this._optionFromIndex(e.target.dataset.optionIndex));
+        this.get('select.actions.highlight')(this._optionFromIndex(e.target.dataset.optionIndex), e);
       }
     });
 

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -47,6 +47,7 @@
       select=(readonly publicAPI)
       extra=(readonly extra)
       id=(readonly optionsId)
+      groupIndex=""
       aria-controls=(readonly triggerId)
       loadingMessage=(readonly loadingMessage)
       class="ember-power-select-options" as |option term|}}

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -14,7 +14,7 @@
         allOptions=(readonly allOptions)
         optionsComponent=(readonly optionsComponent)
         select=(readonly select)
-        indexPrefix=(concat indexPrefix index ".")
+        groupIndex=(concat groupIndex index ".")
         role="group"
         class="ember-power-select-options" as |option|}}
         {{yield option lastSearchedText}}
@@ -25,7 +25,7 @@
       aria-selected={{ember-power-select-is-selected opt selected}}
       aria-disabled={{opt.disabled}}
       aria-current={{eq opt highlighted}}
-      data-option-index="{{indexPrefix}}{{index}}"
+      data-option-index="{{groupIndex}}{{index}}"
       role="option">
       {{yield opt lastSearchedText}}
     </li>

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -3,7 +3,7 @@
     <li class="ember-power-select-option" role="option">{{loadingMessage}}</li>
   {{/if}}
 {{/if}}
-{{#each options as |opt|}}
+{{#each options as |opt index|}}
   {{#if opt.groupName}}
     <li class="ember-power-select-group" role="option">
       <span class="ember-power-select-group-name">{{opt.groupName}}</span>
@@ -14,6 +14,7 @@
         allOptions=(readonly allOptions)
         optionsComponent=(readonly optionsComponent)
         select=(readonly select)
+        indexPrefix=(concat indexPrefix index ".")
         role="group"
         class="ember-power-select-options" as |option|}}
         {{yield option lastSearchedText}}
@@ -24,10 +25,7 @@
       aria-selected={{ember-power-select-is-selected opt selected}}
       aria-disabled={{opt.disabled}}
       aria-current={{eq opt highlighted}}
-      onmouseup={{action select.actions.choose opt}}
-      ontouchstart={{action "handleTouchStart"}}
-      ontouchend={{action "handleTouchEnd" opt}}
-      onmouseover={{action select.actions.highlight opt}}
+      data-option-index="{{indexPrefix}}{{index}}"
       role="option">
       {{yield opt lastSearchedText}}
     </li>

--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -13,6 +13,12 @@ export function nativeMouseDown(selector, options = {}) {
   Ember.run(() => Ember.$(selector)[0].dispatchEvent(event));
 }
 
+export function nativeMouseUp(selector, options = {}) {
+  let event = new window.Event('mouseup', { bubbles: true, cancelable: true, view: window });
+  Object.keys(options).forEach(key => event[key] = options[key]);
+  Ember.run(() => Ember.$(selector)[0].dispatchEvent(event));
+}
+
 export function triggerKeydown(domElement, k) {
   var oEvent = document.createEvent("Events");
   oEvent.initEvent('keydown', true, true);
@@ -58,7 +64,9 @@ export default function() {
     }
 
     // Select the option with the given text
-    click(`.ember-power-select-dropdown-ember${id} .ember-power-select-option:contains("${value}")`);
+    andThen(function() {
+      nativeMouseUp(`.ember-power-select-dropdown-ember${id} .ember-power-select-option:contains("${value}")`);
+    });
   });
 
   Ember.Test.registerAsyncHelper('selectSearch', function(app, cssPath, value) {

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -37,7 +37,7 @@ test('selectChoose selects the option with the given text on an already opened s
   });
 });
 
-test('scott selectChoose helper works with an onopen function that fetches data async on single selects', function(assert) {
+test('the selectChoose helper works with an onopen function that fetches data async on single selects', function(assert) {
   visit('/helpers-testing');
   andThen(function() {
     assert.equal(currentURL(), '/helpers-testing');
@@ -50,7 +50,7 @@ test('scott selectChoose helper works with an onopen function that fetches data 
   });
 });
 
-test('scott selectChoose helper works with an onopen function that fetches data async on multiple selects', function(assert) {
+test('the selectChoose helper works with an onopen function that fetches data async on multiple selects', function(assert) {
   visit('/helpers-testing');
   andThen(function() {
     assert.equal(currentURL(), '/helpers-testing');

--- a/tests/dummy/app/controllers/helpers-testing.js
+++ b/tests/dummy/app/controllers/helpers-testing.js
@@ -37,11 +37,9 @@ export default Ember.Controller.extend({
       });
     },
     onOpenHandle(){
-      new Ember.RSVP.Promise((resolve) => {
-          Ember.run.later(() => {
-            resolve(this.set('optionz', numbers));
-          }, 100);
-      });
+      Ember.run.later(() => {
+        this.set('optionz', numbers);
+      }, 100);
     }
   }
 });

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { typeInSearch, triggerKeydown, clickTrigger } from '../../../helpers/ember-power-select';
+import { typeInSearch, triggerKeydown, clickTrigger, nativeMouseUp } from '../../../helpers/ember-power-select';
 import {
   numbers,
   names,
@@ -165,7 +165,7 @@ test('If a placeholder is provided, it shows while no element is selected', func
 
   assert.equal($('.ember-power-select-trigger .ember-power-select-placeholder').text().trim(), 'abracadabra', 'The placeholder is rendered when there is no element');
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(3)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(3)');
   assert.equal($('.ember-power-select-trigger .ember-power-select-placeholder').length, 0, 'The placeholder is gone');
   assert.equal($('.ember-power-select-trigger').text().trim(), 'four', 'The selected item replaced it');
 });
@@ -205,7 +205,7 @@ test('If the user selects a value and later on the selected value changes from t
 
   assert.equal($('.ember-power-select-trigger').text().trim(), '', 'Nothing is selected');
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(3)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(3)');
   assert.equal($('.ember-power-select-trigger').text().trim(), 'four', '"four" has been selected');
   Ember.run(() => this.set('selected', 'three'));
   assert.equal($('.ember-power-select-trigger').text().trim(), 'three', '"three" has been selected because a change came from the outside');
@@ -238,7 +238,7 @@ test('If the user passes `closeOnSelect=false` the dropdown remains visible afte
   assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is not rendered');
   clickTrigger();
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
-  Ember.run(() => $('.ember-power-select-option:eq(3)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(3)');
   assert.equal($('.ember-power-select-trigger').text().trim(), 'four', '"four" has been selected');
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
 });
@@ -256,7 +256,7 @@ test('If the user passes `closeOnSelect=false` the dropdown remains visible afte
   assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is not rendered');
   clickTrigger();
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
-  Ember.run(() => $('.ember-power-select-option:eq(3)').mouseover());
+  nativeMouseUp('.ember-power-select-option:eq(3)');
   triggerKeydown($('.ember-power-select-search input')[0], 13);
   assert.equal($('.ember-power-select-trigger').text().trim(), 'four', '"four" has been selected');
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
@@ -407,7 +407,7 @@ test('The search term is yielded as second argument in single selects', function
   clickTrigger();
   typeInSearch('tw');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'tw:two', 'Each option receives the search term');
-  Ember.run(() => $('.ember-power-select-option:eq(0)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(0)');
   clickTrigger();
   typeInSearch('thr');
   assert.equal($('.ember-power-select-trigger').text().trim(), 'thr:two', 'The trigger also receives the search term');

--- a/tests/integration/components/power-select/groups-test.js
+++ b/tests/integration/components/power-select/groups-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { typeInSearch, clickTrigger } from '../../../helpers/ember-power-select';
+import { typeInSearch, clickTrigger, nativeMouseUp } from '../../../helpers/ember-power-select';
 import { groupedNumbers } from '../constants';
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Groups)', {
@@ -67,7 +67,7 @@ test('Click on an option of a group select selects the option and closes the dro
     {{/power-select}}
   `);
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:contains("four")').mouseup());
+  nativeMouseUp('.ember-power-select-option:contains("four")');
   assert.equal($('.ember-power-select-trigger').text().trim(), "four", 'The clicked option was selected');
   assert.equal($('.ember-power-select-options').length, 0, 'The dropdown has dissapeared');
 });

--- a/tests/integration/components/power-select/mouse-control-test.js
+++ b/tests/integration/components/power-select/mouse-control-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { clickTrigger } from '../../../helpers/ember-power-select';
+import { clickTrigger, nativeMouseUp } from '../../../helpers/ember-power-select';
 import { numbers } from '../constants';
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Mouse control)', {
@@ -20,7 +20,10 @@ test('Mouseovering a list item highlights it', function(assert) {
 
   clickTrigger();
   assert.equal($('.ember-power-select-option:eq(0)').attr('aria-current'), 'true', 'The first element is highlighted');
-  Ember.run(() => $('.ember-power-select-option:eq(3)').trigger('mouseover'));
+  Ember.run(() => {
+    let event = new window.Event('mouseover', { bubbles: true, cancelable: true, view: window });
+    $('.ember-power-select-option:eq(3)')[0].dispatchEvent(event);
+  });
   assert.equal($('.ember-power-select-option:eq(3)').attr('aria-current'), 'true', 'The 4th element is highlighted');
   assert.equal($('.ember-power-select-option:eq(3)').text().trim(), 'four');
 });
@@ -40,7 +43,7 @@ test('Clicking an item selects it, closes the dropdown and focuses the trigger',
   `);
 
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(3)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(3)');
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select was closed');
   assert.ok($('.ember-power-select-trigger').get(0) === document.activeElement, 'The trigger is focused');
 });

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -608,7 +608,7 @@ test('Typing in the input opens the component and filters the options also with 
   }, 150);
 });
 
-test('The search term is yielded as second argument in single selects', function(assert) {
+test('The search term is yielded as second argument in multiple selects', function(assert) {
   assert.expect(2);
   this.numbers = numbers;
   this.render(hbs`

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { typeInSearch, triggerKeydown, clickTrigger, nativeMouseDown } from '../../../helpers/ember-power-select';
+import { typeInSearch, triggerKeydown, clickTrigger, nativeMouseDown, nativeMouseUp } from '../../../helpers/ember-power-select';
 import { numbers, countries } from '../constants';
 
 const { RSVP } = Ember;
@@ -50,7 +50,7 @@ test('Click on an element selects it and closes the dropdown and focuses the tri
 
   clickTrigger();
   assert.ok(this.$('.ember-power-select-trigger-multiple-input').get(0) === document.activeElement, 'The input of the trigger is focused');
-  Ember.run(() => $('.ember-power-select-option:eq(1)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(1)');
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The dropdown is closed');
   assert.equal($('.ember-power-select-multiple-option').length, 1, 'There is 1 option selected');
   assert.ok(/two/.test($('.ember-power-select-multiple-option').text()), 'The clicked element has been selected');
@@ -72,7 +72,7 @@ test('Selecting an element triggers the onchange action with the list of selecte
   `);
 
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(1)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(1)');
 });
 
 test('Click an option when there is already another selects both, and triggers the onchange action with them', function(assert) {
@@ -93,7 +93,7 @@ test('Click an option when there is already another selects both, and triggers t
 
   assert.equal($('.ember-power-select-multiple-option').length, 1, 'There is 1 option selected');
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(1)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(1)');
   assert.equal($('.ember-power-select-multiple-option').length, 2, 'There is 2 options selected');
   assert.ok(/four/.test($('.ember-power-select-multiple-option:eq(0)').text()), 'The first option is the provided one');
   assert.ok(/two/.test($('.ember-power-select-multiple-option:eq(1)').text()), 'The second option is the one just selected');
@@ -153,7 +153,7 @@ test('Clicking on an option that is already selected unselects it, closes the se
 
   assert.equal($('.ember-power-select-multiple-option').length, 1, 'There is 1 option selected');
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option[aria-selected="true"]').mouseup());
+  nativeMouseUp('.ember-power-select-option[aria-selected="true"]');
   assert.equal($('.ember-power-select-multiple-option').length, 0, 'There is no options selected');
 });
 
@@ -455,7 +455,7 @@ test('Pressing BACKSPACE on the search input when it\'s empty removes the last s
   `);
 
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(2)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(2)');
   clickTrigger();
   assert.equal(this.$('.ember-power-select-multiple-option').length, 1, 'There is one element selected');
   triggerKeydown(this.$('.ember-power-select-trigger-multiple-input')[0], 8);
@@ -511,7 +511,7 @@ test('The placeholder is only visible when no options are selected', function(as
 
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), 'Select stuff here', 'There is a placeholder');
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(1)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(1)');
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'The placeholder is gone');
 });
 
@@ -527,7 +527,7 @@ test('If the placeholder is null the placeholders shouldn\'t be "null" (issue #9
 
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'Input does not have a placeholder');
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(1)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(1)');
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'Input still does not have a placeholder');
   nativeMouseDown('.ember-power-select-multiple-remove-btn');
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'Input still does not have a placeholder');
@@ -542,7 +542,7 @@ test('Selecting and removing should result in desired behavior', function(assert
     {{/power-select-multiple}}
   `);
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(1)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(1)');
   assert.equal(this.$('.ember-power-select-multiple-option').length, 1, 'Should add selected option');
   nativeMouseDown('.ember-power-select-multiple-remove-btn');
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('placeholder'), '', 'Input still does not have a placeholder');
@@ -558,7 +558,7 @@ test('Selecting and removing can also be done with touch events', function(asser
     {{/power-select-multiple}}
   `);
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(1)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(1)');
   assert.equal(this.$('.ember-power-select-multiple-option').length, 1, 'Should add selected option');
   Ember.run(() => {
     let event = new window.Event('touchstart', { bubbles: true, cancelable: true, view: window });
@@ -620,7 +620,7 @@ test('The search term is yielded as second argument in single selects', function
   clickTrigger();
   typeInSearch('tw');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'tw:two');
-  Ember.run(() => $('.ember-power-select-option:eq(0)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(0)');
   clickTrigger();
   typeInSearch('thr');
   assert.ok(/thr:two/.test($('.ember-power-select-trigger').text().trim()), 'The trigger also receives the search term');
@@ -691,6 +691,6 @@ test('The component works when the array of selected elements is mutated in plac
   `);
   clickTrigger();
   Ember.run(() => this.get('selected').pushObject(numbers[3]));
-  Ember.run(() => $('.ember-power-select-option:eq(0)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(0)');
   assert.equal(this.$('.ember-power-select-multiple-option').length, 2, 'Two elements are selected');
 });

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { triggerKeydown, clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
+import { triggerKeydown, clickTrigger, typeInSearch, nativeMouseUp } from '../../../helpers/ember-power-select';
 import { numbers } from '../constants';
 
 
@@ -87,7 +87,7 @@ test('The onchange of single selects action receives the selection and the publi
   `);
 
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(0)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(0)');
 });
 
 test('The onchange of multiple selects action receives the selection and the public API', function(assert) {
@@ -114,7 +114,7 @@ test('The onchange of multiple selects action receives the selection and the pub
   `);
 
   clickTrigger();
-  Ember.run(() => $('.ember-power-select-option:eq(0)').mouseup());
+  nativeMouseUp('.ember-power-select-option:eq(0)');
 });
 
 test('The onkeydown of single selects action receives the public API and the keydown event', function(assert) {


### PR DESCRIPTION
[NO MERGE] 

This allows to only add two events per dropdown, instead of 2 events per each element of the list.

In a heavy element with ~300 options render time goes from 250~300ms to something closer to 190~240.

This is preparation for adding touch devices.
 
Touch events would make render times linearly worse but with this approach they shouldn't have a performance penalty, and this should allow the component to not add `mouseover` event in devices without a mouse.

