### PR TITLE
Improve docs pages scroll handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-try": "^0.1.2",
     "liquid-fire": "0.23.0",
     "loader.js": "^4.0.0",
+    "memory-scroll": "0.2.0",
     "node-sass": "^3.4.2",
     "simple-git": "^1.10.0"
   },

--- a/tests/dummy/app/templates/public-pages.hbs
+++ b/tests/dummy/app/templates/public-pages.hbs
@@ -31,3 +31,5 @@
     </div>
   </div>
 </footer>
+
+{{remember-document-scroll key=applicationController.currentRouteName}}


### PR DESCRIPTION
This will cause every public page to start out scrolled to the top, and then when returning to an already visited route will return to the last remembered scroll position.

This makes moving forward and backward through the documentation pages feel nicer, because forward links scroll you to the top automatically, and backward links take you back to where you were when you clicked forward.