### PR TITLE
Convert to array when it's possible

### DIFF
--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -21,8 +21,12 @@ export default Ember.Component.extend({
       if (e.target.dataset.selectedIndex) {
         e.stopPropagation();
         e.preventDefault();
+
+        let index = e.target.dataset.selectedIndex;
         let selected = this.get('selected');
-        this.get('select.actions.choose')(get(selected, e.target.dataset.selectedIndex));
+        let object = this.selectedObject(selected, index);
+
+        this.get('select.actions.choose')(object);
       }
     };
     if (isTouchDevice) {
@@ -98,5 +102,13 @@ export default Ember.Component.extend({
 
   updateInput(value) {
     updateInput(this.input, value);
+  },
+
+  selectedObject(list, index) {
+    if (list.objectAt) {
+      return list.objectAt(index);
+    } else {
+      return get(list, index);
+    }
   }
 });

--- a/tests/integration/components/power-select/ember-data-test.js
+++ b/tests/integration/components/power-select/ember-data-test.js
@@ -5,6 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { typeInSearch, clickTrigger } from '../../../helpers/ember-power-select';
 import { startMirage } from '../../../../initializers/ember-cli-mirage';
 import emberDataInitializer from '../../../../initializers/ember-data';
+import { nativeMouseDown } from '../../../helpers/ember-power-select';
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Ember-data integration)', {
   integration: true,
@@ -56,5 +57,20 @@ test('Passing as options the result of `store.query` works', function(assert) {
     assert.equal($('.ember-power-select-option').length, 10, 'Once the collection resolves the options render normally');
     typeInSearch('2');
     assert.equal($('.ember-power-select-option').length, 1, 'Filtering works');
+  });
+});
+
+test('Delete an item in a multiple selection', function(assert) {
+  server.createList('user', 10);
+  this.users = this.store.findAll('user');
+  this.render(hbs`
+    {{#power-select-multiple options=users searchField="name" selected=users onchange=(action (mut users)) as |option|}}
+      {{option.name}}
+    {{/power-select-multiple}}
+  `);
+
+  return wait().then(function() {
+    nativeMouseDown('.ember-power-select-multiple-remove-btn:first');
+    assert.equal($('.ember-power-select-multiple-remove-btn').length, 9, 'Once the collection resolves the options render normally');
   });
 });


### PR DESCRIPTION
This fix issue #380 

With ember data, it's not possible to do `items.get('0')` to have the first value and it have to be converted to array. 

I can't do an integration test because [this line](https://github.com/cibernox/ember-power-select/blob/master/tests/integration/components/power-select/ember-data-test.js#L20) gives an error because `server` is undefined.