### PR TITLE
Remove `opened` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Master
 
+# 0.10.0-beta.4
+- [REMOVE FEATURE] The `opened` property (the only using double bindings instead of DDAU) has been
+  removed. It was the cause of some errors due to race conditions in the bindings propagation.
+  It is still possible to pass `initiallyOpened=true` to render a select already opened, but it is
+  a one time property. It won't onpen/close the select when mutated nor will be mutated when the
+  select is opened or closed.
 - [BUGFIX] Fix option highlighting when the use mouseovers in an element inside the `<li>`s
 
 # 0.10.0-beta.3

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
   dropdownClass: fallbackIfUndefined(null),
   triggerClass: fallbackIfUndefined(null),
   dir: fallbackIfUndefined(null),
-  opened: fallbackIfUndefined(false),
+  initiallyOpened: fallbackIfUndefined(false),
   searchEnabled: fallbackIfUndefined(true),
   searchMessage: fallbackIfUndefined("Type to search"),
   searchPlaceholder: fallbackIfUndefined(null),

--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -29,7 +29,7 @@
       allowClear=allowClear
       verticalPosition=verticalPosition
       closeOnSelect=closeOnSelect
-      opened=opened
+      initiallyOpened=initiallyOpened
       tabindex=tabindex
       destination=destination
       dir=dir
@@ -73,7 +73,7 @@
       allowClear=allowClear
       verticalPosition=verticalPosition
       closeOnSelect=closeOnSelect
-      opened=opened
+      initiallyOpened=initiallyOpened
       tabindex=tabindex
       destination=destination
       dir=dir

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -9,7 +9,7 @@
   triggerClass=(readonly concatenatedTriggerClasses)
   dropdownClass=(readonly concatenatedDropdownClasses)
   destination=(readonly destination)
-  opened=opened
+  initiallyOpened=initiallyOpened
   triggerId=triggerId
   onOpen=(action "handleOpen")
   onClose=(action "handleClose")

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-basic-dropdown": "^0.9.5-beta.4",
+    "ember-basic-dropdown": "^0.9.5-beta.6",
     "ember-hash-helper-polyfill": "^0.1.0",
     "ember-truth-helpers": "^1.2.0"
   },

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -149,11 +149,11 @@
       <td>Object to store any arbitrary configuration meant to be used by custom components</td>
     </tr>
     <tr>
-      <td>opened</td>
+      <td>initiallyOpened</td>
       <td><code>boolean</code></td>
       <td>
-        Boolean property that controls if the component is opened or closed. Unlinke all other properties
-        passed to this component, this is the only one desiged to be mutable.
+        Boolean property that controls if the component is rendered initially in the open state. It
+        won't mutate if the component is opened/closed. It won't close/open the component when mutated either.
       </td>
     </tr>
     <tr>

--- a/tests/integration/components/power-select/opened-property-test.js
+++ b/tests/integration/components/power-select/opened-property-test.js
@@ -1,56 +1,20 @@
-import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { clickTrigger } from '../../../helpers/ember-power-select';
 import { numbers } from '../constants';
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (The opened property)', {
   integration: true
 });
 
-test('the select can be rendered already opened by passing `opened=true`', function(assert) {
+test('the select can be rendered already opened by passing `initiallyOpened=true`', function(assert) {
   assert.expect(1);
 
   this.numbers = numbers;
   this.render(hbs`
-    {{#power-select options=numbers onchange=(action (mut foo)) opened=true as |option|}}
+    {{#power-select options=numbers onchange=(action (mut foo)) initiallyOpened=true as |option|}}
       {{option}}
     {{/power-select}}
   `);
 
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is opened');
-});
-
-test('It can be opened and closed by toggling the `opened` property', function(assert) {
-  assert.expect(3);
-
-  this.numbers = numbers;
-  this.opened = false;
-  this.render(hbs`
-    {{#power-select options=numbers onchange=(action (mut foo)) opened=opened as |option|}}
-      {{option}}
-    {{/power-select}}
-  `);
-
-  assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is closed');
-  Ember.run(() => this.set('opened', true));
-  assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is opened');
-  Ember.run(() => this.set('opened', false));
-  assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is closed again');
-});
-
-test('when it is opened/closed and the `opened` property is multable, it gets updated', function(assert) {
-  assert.expect(2);
-
-  this.numbers = numbers;
-  this.opened = false;
-  this.render(hbs`
-    {{#power-select options=numbers onchange=(action (mut foo)) opened=opened as |option|}}
-      {{option}}
-    {{/power-select}}
-  `);
-
-  assert.ok(!this.get('opened'), 'The opened property is false');
-  clickTrigger();
-  assert.ok(this.get('opened'), 'The opened property is true now');
 });


### PR DESCRIPTION
[REMOVE FEATURE] The opened property (the only using double bindings instead of DDAU) has been removed. It was the cause of some errors due to race conditions in the bindings propagation. It is still possible to pass `initiallyOpened=true` to render a select already opened, but it is a one time property. It won't onpen/close the select when mutated nor will be mutated when the select is opened or closed.