### PR TITLE
fix deprecation warning for Ember 2.5.0

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -155,7 +155,7 @@ export default Ember.Component.extend({
         isOpen: dropdown.isOpen,
         highlighted: this.get('highlighted'),
         searchText: this.get('searchText'),
-        actions: Ember.merge(ownActions, dropdown.actions)
+        actions: Ember.assign(ownActions, dropdown.actions)
       };
     }
     return {};

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -5,6 +5,7 @@ import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 
 const { computed, run, get, isBlank } = Ember;
 const EventSender = Ember.Object.extend(Ember.Evented);
+const assign = Ember.assign || Ember.merge;
 
 export default Ember.Component.extend({
   // HTML
@@ -155,7 +156,7 @@ export default Ember.Component.extend({
         isOpen: dropdown.isOpen,
         highlighted: this.get('highlighted'),
         searchText: this.get('searchText'),
-        actions: Ember.assign(ownActions, dropdown.actions)
+        actions: assign(ownActions, dropdown.actions)
       };
     }
     return {};


### PR DESCRIPTION
Fixed deprecation warning for Ember 2.5.0.

See here -> https://github.com/emberjs/ember.js/pull/12303