### PR TITLE
updated troubleshooting to use dropdownClass

### DIFF
--- a/tests/dummy/app/templates/public-pages/docs/troubleshooting.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/troubleshooting.hbs
@@ -17,7 +17,7 @@
 
 <ol>
   <li>
-    Add a specific class to the select (p.e. <code>class="in-modal"</code>) will make the dropdown
+    Add a specific class to the select (p.e. <code>dropdownClass="in-modal-dropdown"</code>) will make the dropdown
     to have the class <code>"in-modal-dropdown"</code>. You can increase the z-index of this kind
     of selects.
   </li>


### PR DESCRIPTION
updated troubleshooting guide to reflect the latest dropdownClass option, as `class='in-modal'` no longer solves this problem.