### PR TITLE
[ENHANCEMENT] Selects that have elements inside with focus have a special class to allow styling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Master
 
+- [ENHANCEMENT] Add a class to the component when an element inside has the focus. This allows to
+  style the component not only when the component itself is focused but when an input inside
+  is, which was previously impossible.
 - [BUGFIX] Allow to pass `horizontalPosition` to customize to which edge of the trigger
   the dropdown is anchored to.
 

--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -33,8 +33,8 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
     display:table;
     clear:both;
   }
-  &:focus {
-    border: $ember-power-select-trigger-focus-border;
+  &:focus, .ember-basic-dropdown--focus-inside & {
+    border: $ember-power-select-active-trigger-border;
     box-shadow: $ember-power-select-focus-box-shadow;
     @if $ember-power-select-focus-outline {
       outline: $ember-power-select-focus-outline;
@@ -126,7 +126,7 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
     line-height: inherit;
     padding: 0 5px;
     &:focus {
-      border: 1px solid $ember-power-select-focus-border-color;
+      border: $ember-power-select-search-field-focus-border;
       box-shadow: $ember-power-select-focus-box-shadow;
       @if $ember-power-select-focus-outline {
         outline: $ember-power-select-focus-outline;

--- a/app/styles/ember-power-select/variables.scss
+++ b/app/styles/ember-power-select/variables.scss
@@ -21,9 +21,10 @@ $ember-power-select-default-border: 1px solid $ember-power-select-border-color !
 $ember-power-select-default-focus-border: 1px solid $ember-power-select-focus-border-color !default;
 
 $ember-power-select-trigger-border: $ember-power-select-default-border !default;
-$ember-power-select-trigger-focus-border: $ember-power-select-default-focus-border !default;
-$ember-power-select-dropdown-border: $ember-power-select-default-border !default;
+$ember-power-select-active-trigger-border: $ember-power-select-default-focus-border !default;
+$ember-power-select-dropdown-border: $ember-power-select-default-focus-border !default;
 $ember-power-select-search-field-border: $ember-power-select-default-border !default;
+$ember-power-select-search-field-focus-border: $ember-power-select-default-focus-border !default;
 
 $ember-power-select-dropdown-top-border: $ember-power-select-dropdown-border !default;
 $ember-power-select-dropdown-right-border: $ember-power-select-dropdown-border !default;

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-basic-dropdown": "^0.9.5-beta.6",
+    "ember-basic-dropdown": "^0.9.5-beta.10",
     "ember-hash-helper-polyfill": "^0.1.0",
     "ember-truth-helpers": "^1.2.0"
   },

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -193,11 +193,13 @@
     user-select: none;
     -webkit-user-select: none;
     color: inherit;
-    /* Minimum clearfix for modern browsers */ }
-    .ember-power-select-trigger:focus {
-      border: 1px solid #66afe9;
-      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
-      outline: 0; }
+  }
+  &.ember-basic-dropdown--focus-inside .ember-power-select-trigger,
+  .ember-power-select-trigger:focus {
+    border: 1px solid #66afe9;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+    outline: 0;
+  }
 
   &.ember-basic-dropdown--below .ember-power-select-trigger[aria-expanded="true"],
   &.ember-basic-dropdown--in-place .ember-power-select-trigger[aria-expanded="true"] {

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -913,3 +913,19 @@ test('When a promise resolves it doesn\'t overwrite a previous value if it isn\'
     done();
   }, 100);
 });
+
+test('When the input inside the select gets focused the entire component gains the `ember-basic-dropdown--focus-inside` class', function(assert) {
+  assert.expect(2);
+
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select options=numbers onchange=(action (mut foo)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  assert.ok(!this.$('.ember-power-select').hasClass('ember-basic-dropdown--focus-inside'), 'The select doesn\'t have the class yet');
+  clickTrigger();
+  Ember.run(() => $('.ember-power-select-search input').focus());
+  assert.ok(this.$('.ember-power-select').hasClass('ember-basic-dropdown--focus-inside'), 'The select has the class now');
+});

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -693,3 +693,18 @@ test('The component works when the array of selected elements is mutated in plac
   nativeMouseUp('.ember-power-select-option:eq(0)');
   assert.equal(this.$('.ember-power-select-multiple-option').length, 2, 'Two elements are selected');
 });
+
+test('When the input inside the multiple select gets focused the entire component gains the `ember-basic-dropdown--focus-inside` class', function(assert) {
+  assert.expect(2);
+
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select-multiple options=numbers onchange=(action (mut foo)) as |option|}}
+      {{option}}
+    {{/power-select-multiple}}
+  `);
+
+  assert.ok(!this.$('.ember-power-select').hasClass('ember-basic-dropdown--focus-inside'), 'The select doesn\'t have the class yet');
+  clickTrigger();
+  assert.ok(this.$('.ember-power-select').hasClass('ember-basic-dropdown--focus-inside'), 'The select has the class now');
+});


### PR DESCRIPTION
When any element inside the select (in the trigger or in the content) has the focus (typically an input), the input itself is not focused. So style this kind of "active" state was impossible to style.

Now, selects that have **anything** inside focused have a `ember-basic-dropdown--focus-inside` class that can be target to customize styles.

By default, the trigger on this state will have the same styles as when it's focused.

A couple sass variables have been added to style this state.

This PR was made at 13K feet over the atlantic.

Closes #397