### PR TITLE
[BREAKING] e.preventDefault no longer prevents the default component's behaviour

### DIFF
--- a/addon/components/power-select-multiple.js
+++ b/addon/components/power-select-multiple.js
@@ -23,12 +23,7 @@ export default Ember.Component.extend({
   actions: {
     handleOpen(select, e) {
       let action = this.get('onopen');
-      if (action) {
-        let returnValue = action(select, e);
-        if (returnValue === false || (e && e.defaultPrevented)) {
-          return false;
-        }
-      }
+      if (action && action(select, e) === false) { return false; }
       this.focusInput();
     },
 
@@ -40,8 +35,10 @@ export default Ember.Component.extend({
 
     handleKeydown(select, e) {
       let action = this.get('onkeydown');
-      if (action) { action(select, e); }
-      if (e.defaultPrevented) { return; }
+      if (action && action(select, e) === false) {
+        e.stopPropagation();
+        return false;
+      }
       let selected = Ember.A((this.get('selected') || []));
       if (e.keyCode === 13 && select.isOpen) {
         e.stopPropagation();

--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -72,9 +72,7 @@ export default Ember.Component.extend({
 
     handleKeydown(e) {
       let { onkeydown, select } = this.getProperties('onkeydown', 'select');
-      if (onkeydown) { onkeydown(select, e); }
-      if (e.defaultPrevented) { return; }
-
+      if (onkeydown && onkeydown(select, e) === false) { return false; }
       let selected = Ember.A((this.get('selected') || []));
       if (e.keyCode === 8 && isBlank(e.target.value)) {
         let lastSelection = get(selected, 'lastObject');

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -208,8 +208,7 @@ export default Ember.Component.extend({
 
     handleKeydown(dropdown, e) {
       const onkeydown = this.get('onkeydown');
-      if (onkeydown) { onkeydown(this.get('publicAPI'), e); }
-      if (e.defaultPrevented) { return; }
+      if (onkeydown && onkeydown(this.get('publicAPI'), e) === false) { return; }
       if (e.keyCode === 38 || e.keyCode === 40) { // Up & Down
         return this._handleKeyUpDown(dropdown, e);
       } else if (e.keyCode === 13) {  // ENTER

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-basic-dropdown": "^0.10.0",
+    "ember-basic-dropdown": "^0.11.0",
     "ember-hash-helper-polyfill": "^0.1.0",
     "ember-truth-helpers": "^1.2.0"
   },

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -317,9 +317,7 @@ test('in multiple-mode if the users calls preventDefault on the event received i
 
   this.numbers = numbers;
   this.selectedNumbers = [];
-  this.handleKeydown = (select, e) => {
-    e.preventDefault();
-  };
+  this.handleKeydown = () => false;
 
   this.render(hbs`
     {{#power-select-multiple options=numbers selected=selectedNumbers onchange=(action (mut foo)) onkeydown=(action handleKeydown) as |option|}}

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -275,34 +275,6 @@ test('the `onopen` action is invoked just before the dropdown opens', function(a
   assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is opened');
 });
 
-test('calling `e.preventDefault()` on the event received by onopen prevents the single select from opening', function(assert) {
-  assert.expect(11);
-
-  this.numbers = numbers;
-  this.handleOpen = (select, e) => {
-    assert.equal(select.isOpen, false, 'select.isOpen is still false');
-    assert.equal(typeof select.highlighted, 'string', 'select.highlighted is a string');
-    assert.equal(typeof select.searchText, 'string', 'select.searchText is a string');
-    assert.equal(typeof select.actions.open, 'function', 'select.actions.open is a function');
-    assert.equal(typeof select.actions.close, 'function', 'select.actions.close is a function');
-    assert.equal(typeof select.actions.reposition, 'function', 'select.actions.reposition is a function');
-    assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
-    assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
-    assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
-    assert.ok(e instanceof window.Event, 'The second argument is an event');
-    e.preventDefault();
-  };
-
-  this.render(hbs`
-    {{#power-select options=numbers onchange=(action (mut foo)) onopen=handleOpen as |option|}}
-      {{option}}
-    {{/power-select}}
-  `);
-
-  clickTrigger();
-  assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown didn\'t open');
-});
-
 test('returning false from the `onopen` action prevents the single select from opening', function(assert) {
   assert.expect(11);
 
@@ -325,34 +297,6 @@ test('returning false from the `onopen` action prevents the single select from o
     {{#power-select options=numbers onchange=(action (mut foo)) onopen=handleOpen as |option|}}
       {{option}}
     {{/power-select}}
-  `);
-
-  clickTrigger();
-  assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown didn\'t open');
-});
-
-test('calling `e.preventDefault()` on the event received by onopen prevents the multiple select from opening', function(assert) {
-  assert.expect(11);
-
-  this.numbers = numbers;
-  this.handleOpen = (select, e) => {
-    assert.equal(select.isOpen, false, 'select.isOpen is still false');
-    assert.equal(typeof select.highlighted, 'string', 'select.highlighted is a string');
-    assert.equal(typeof select.searchText, 'string', 'select.searchText is a string');
-    assert.equal(typeof select.actions.open, 'function', 'select.actions.open is a function');
-    assert.equal(typeof select.actions.close, 'function', 'select.actions.close is a function');
-    assert.equal(typeof select.actions.reposition, 'function', 'select.actions.reposition is a function');
-    assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
-    assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
-    assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
-    assert.ok(e instanceof window.Event, 'The second argument is an event');
-    e.preventDefault();
-  };
-
-  this.render(hbs`
-    {{#power-select-multiple options=numbers onchange=(action (mut foo)) onopen=handleOpen as |option|}}
-      {{option}}
-    {{/power-select-multiple}}
   `);
 
   clickTrigger();
@@ -416,37 +360,6 @@ test('the `onclose` action is invoked just before the dropdown closes', function
   assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is closed');
 });
 
-
-test('calling `e.preventDefault()` on the event received by onclose prevents the single select from closing', function(assert) {
-  assert.expect(12);
-
-  this.numbers = numbers;
-  this.handleClose = (select, e) => {
-    assert.equal(select.isOpen, true, 'select.isOpen is still true');
-    assert.equal(typeof select.highlighted, 'string', 'select.highlighted is a string');
-    assert.equal(typeof select.searchText, 'string', 'select.searchText is a string');
-    assert.equal(typeof select.actions.open, 'function', 'select.actions.open is a function');
-    assert.equal(typeof select.actions.close, 'function', 'select.actions.close is a function');
-    assert.equal(typeof select.actions.reposition, 'function', 'select.actions.reposition is a function');
-    assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
-    assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
-    assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
-    assert.ok(e instanceof window.Event, 'The second argument is an event');
-    e.preventDefault();
-  };
-
-  this.render(hbs`
-    {{#power-select options=numbers onchange=(action (mut foo)) onclose=handleClose as |option|}}
-      {{option}}
-    {{/power-select}}
-  `);
-
-  clickTrigger();
-  assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is open');
-  clickTrigger();
-  assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown didn\'t close');
-});
-
 test('returning false from the `onclose` action prevents the single select from closing', function(assert) {
   assert.expect(12);
 
@@ -469,36 +382,6 @@ test('returning false from the `onclose` action prevents the single select from 
     {{#power-select options=numbers onchange=(action (mut foo)) onclose=handleClose as |option|}}
       {{option}}
     {{/power-select}}
-  `);
-
-  clickTrigger();
-  assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is open');
-  clickTrigger();
-  assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown didn\'t close');
-});
-
-test('calling `e.preventDefault()` on the event received by onclose prevents the multiple select from closing', function(assert) {
-  assert.expect(12);
-
-  this.numbers = numbers;
-  this.handleClose = (select, e) => {
-    assert.equal(select.isOpen, true, 'select.isOpen is still true');
-    assert.equal(typeof select.highlighted, 'string', 'select.highlighted is a string');
-    assert.equal(typeof select.searchText, 'string', 'select.searchText is a string');
-    assert.equal(typeof select.actions.open, 'function', 'select.actions.open is a function');
-    assert.equal(typeof select.actions.close, 'function', 'select.actions.close is a function');
-    assert.equal(typeof select.actions.reposition, 'function', 'select.actions.reposition is a function');
-    assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
-    assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
-    assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
-    assert.ok(e instanceof window.Event, 'The second argument is an event');
-    e.preventDefault();
-  };
-
-  this.render(hbs`
-    {{#power-select-multiple options=numbers onchange=(action (mut foo)) onclose=handleClose as |option|}}
-      {{option}}
-    {{/power-select-multiple}}
   `);
 
   clickTrigger();


### PR DESCRIPTION
Before users could use `return false` or `preventDefault`. Now only `return false` works.

The reason for that is that some events need to be `defaultPrevented` to avoid browsers'
behaviour (like touchEvents to avoid trigger synthetic clicks), and sometimes preventing
the default behaviour of a event has consecuences we don't want (like preventing keydowns
make the input receiving the keydown to not update it's value).

For that, the idiomatic way now of preventing the default behavior is return false
from the `on*` actions.