### PR TITLE
Fix for didInitAttrs deprecation

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -52,7 +52,7 @@ export default Ember.Component.extend({
   previousResults: null,
 
   // Lifecycle hooks
-  didInitAttrs() {
+  init() {
     this._super(...arguments);
     Ember.assert('{{power-select}} requires an `onchange` function', this.get('onchange') && typeof this.get('onchange') === 'function');
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-cli-sass": "5.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.4.2",
+    "ember-data": "github:emberjs/data#master",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",


### PR DESCRIPTION
Calls to didInitAttrs() in components has been deprecated in favor of init(): http://emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs. Updated main power-select component to reflect the change.