### PR TITLE
Avoid breakline in multiple selects

### DIFF
--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -48,10 +48,10 @@ export default Ember.Component.extend({
   // CPs
   triggerMultipleInputStyle: computed('searchText.length', 'selected.length', function() {
     run.scheduleOnce('afterRender', this.get('select.actions.reposition'));
-    if (this.get('selected.length') === 0) {
+    if (!this.get('selected.length')) {
       return htmlSafe('width: 100%;');
     } else {
-      return htmlSafe(`width: ${(this.get('searchText.length') || 0) * 0.5 + 0.5}em`);
+      return htmlSafe(`width: ${(this.get('searchText.length') || 0) * 0.5 + 1.5}em`);
     }
   }),
 

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -14,15 +14,15 @@
       {{/if}}
     </li>
   {{/each}}
+  {{#if searchEnabled}}
+    <input type="search" class="ember-power-select-trigger-multiple-input {{elementId}}-input"
+      tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+      aria-controls={{listboxId}}
+      style={{triggerMultipleInputStyle}}
+      placeholder={{maybePlaceholder}}
+      disabled={{disabled}}
+      oninput={{action "handleInput"}}
+      onkeydown={{action "handleKeydown"}}>
+  {{/if}}
 </ul>
-{{#if searchEnabled}}
-  <input type="search" class="ember-power-select-trigger-multiple-input {{elementId}}-input"
-    tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
-    aria-controls={{listboxId}}
-    style={{triggerMultipleInputStyle}}
-    placeholder={{maybePlaceholder}}
-    disabled={{disabled}}
-    oninput={{action "handleInput"}}
-    onkeydown={{action "handleKeydown"}}>
-{{/if}}
 <span class="ember-power-select-status-icon"></span>

--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -77,12 +77,7 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
 }
 
 // Multiple select
-.ember-power-select-multiple-trigger {
-  display: flex;
-  flex-wrap: wrap;
-}
 .ember-power-select-trigger-multiple-input {
-  flex: 1;
   font-family: inherit;
   font-size: inherit;
   border: none;


### PR DESCRIPTION
This has been done by making the input a sibling of the options, inside the `<ul>`.
I'm not sure if this is an a11y no-no.

It might be. Check.