### PR TITLE
Make focus handler available to custom triggers

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -75,6 +75,7 @@
     disabled=(readonly disabled)
     extra=(readonly extra)
     handleInput=(action "handleInput")
+    handleFocus=(action "handleFocus")
     lastSearchedText=(readonly lastSearchedText)
     listboxId=(readonly optionsId)
     loading=(readonly loading)


### PR DESCRIPTION
Use case is to trigger the focus handler when focusing the input in `ember-power-select-typeahead`.

PR to use it in that addon is https://github.com/cibernox/ember-power-select-typeahead/pull/10