### PR TITLE
Support passing in custom `groupNameComponent`

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -59,6 +59,7 @@
       searchText=(readonly searchText)
       select=(readonly publicAPI)
       selected=(readonly resolvedSelected)
+      groupNameComponent=(readonly groupNameComponent)
       as |option term|}}
       {{yield option term}}
     {{/component}}

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -7,7 +7,10 @@
   {{#if opt.groupName}}
     <li class="ember-power-select-group" aria-disabled={{opt.disabled}} role="option">
       {{#if groupNameComponent}}
-        {{component groupNameComponent name=opt.groupName option=opt index=index}}
+        {{component groupNameComponent
+          name=opt.groupName
+          option=opt
+          index=index}}
       {{else}}
         <span class="ember-power-select-group-name">
           {{opt.groupName}}

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -6,7 +6,13 @@
 {{#each options as |opt index|}}
   {{#if opt.groupName}}
     <li class="ember-power-select-group" aria-disabled={{opt.disabled}} role="option">
-      <span class="ember-power-select-group-name">{{opt.groupName}}</span>
+      {{#if groupNameComponent}}
+        {{component groupNameComponent name=opt.groupName option=opt index=index}}
+      {{else}}
+        <span class="ember-power-select-group-name">
+          {{opt.groupName}}
+        </span>
+      {{/if}}
       {{#component optionsComponent
         highlighted=(readonly highlighted)
         selected=(readonly selected)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@
 module.exports = {
   name: 'ember-power-select',
 
+  isDevelopingAddon: function() {
+    return true;
+  },
+
   included: function(appOrAddon) {
     var app = appOrAddon.app || appOrAddon;
     if (!app.__emberPowerSelectIncludedInvoked) {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-basic-dropdown": "^0.11.5",
+    "ember-basic-dropdown": "^0.11.7",
     "ember-hash-helper-polyfill": "^0.1.0",
     "ember-text-measurer": "^0.3.0",
     "ember-truth-helpers": "^1.2.0"


### PR DESCRIPTION
This is a pretty simple spike that allows you to pass in a  `groupNameComponent` option to a top-level `{{power-select}}` component.

 This component will be used instead of just rendering the plain text `groupName` in a `<span>`.

This would, for example, allow you to create icons for each of your groups or anything else that is a little more involved than the plain text.

If you give the go ahead, @cibernox, I will test and document this and finish out the pull-request.

Thoughts?