### PR TITLE
Improve selectSearch helper to be less dependent on css classes

### DIFF
--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -96,16 +96,29 @@ export default function() {
       nativeMouseDown(`${cssPath} .ember-power-select-trigger`);
       wait();
     }
+    const isDefaultSingleSelect = Ember.$(`.ember-power-select-search input`).length > 0;
 
     if (isMultipleSelect) {
       fillIn(`${cssPath} .ember-power-select-trigger-multiple-input`, value);
       if (isEmberOne) {
         triggerEvent(`${cssPath} .ember-power-select-trigger-multiple-input`, 'input');
       }
-    } else {
+    } else if (isDefaultSingleSelect) {
       fillIn('.ember-power-select-search input', value);
       if (isEmberOne) {
         triggerEvent(`.ember-power-select-dropdown-ember${id} .ember-power-select-search input`, 'input');
+      }
+    } else { // It's probably a customized version
+      let inputIsInTrigger = !!find(`${cssPath} .ember-power-select-trigger input[type=search]`)[0];
+      if (inputIsInTrigger) {
+        fillIn(`${cssPath} .ember-power-select-trigger input[type=search]`, value);
+        if (isEmberOne) {
+          triggerEvent(`${cssPath} .ember-power-select-trigger input[type=search]`, 'input');
+        }
+      } else {
+        if (isEmberOne) {
+          triggerEvent(`.ember-power-select-dropdown-ember${id} .ember-power-select-search input[type=search]`, 'input');
+        }
       }
     }
 

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -119,6 +119,20 @@ test('selectSearch helper searches in the given multiple select closed', functio
   });
 });
 
+test('selectSearch helper works even with custom components as long as the input has [type=searcg]', function(assert) {
+  visit('/helpers-testing');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/helpers-testing');
+    click('.select-custom-search .ember-power-select-trigger');
+    selectSearch('.select-custom-search', 'three');
+  });
+
+  andThen(function() {
+    assert.equal(find('.ember-power-select-options').text().trim(), 'three');
+  });
+});
+
 test('removeMultipleOption removes selected option', function(assert) {
   visit('/helpers-testing');
 

--- a/tests/dummy/app/templates/components/custom-trigger-with-search.hbs
+++ b/tests/dummy/app/templates/components/custom-trigger-with-search.hbs
@@ -1,0 +1,8 @@
+{{#if selected}}
+  <span class="ember-power-select-selected-item">{{yield selected lastSearchedText}}</span>
+{{else}}
+  <input type="search"
+    tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+    aria-controls={{listboxId}}
+    oninput={{action select.actions.search value="target.value"}}>
+{{/if}}

--- a/tests/dummy/app/templates/helpers-testing.hbs
+++ b/tests/dummy/app/templates/helpers-testing.hbs
@@ -22,3 +22,14 @@
 {{#power-select-multiple class="select-multiple" options=numbers selected=selectedList onchange=(action (mut selectedList)) as |num|}}
   {{num}}
 {{/power-select-multiple}}
+
+<h3>Customized component</h3>
+
+{{#power-select class="select-custom-search"
+  selected=selected3
+  onchange=(action (mut selected3))
+  search=(action "searchAsync")
+  beforeOptionsComponent=null
+  triggerComponent="custom-trigger-with-search" as |num|}}
+  {{num}}
+{{/power-select}}


### PR DESCRIPTION
It will fallback to use any input[type=search] that it can find if the default
css classes are not there.