### PR TITLE
break word on options

### DIFF
--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -182,6 +182,7 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
 .ember-power-select-option {
   cursor: pointer;
   padding: 0 $ember-power-select-option-padding;
+  word-wrap: break-word;
 }
 .ember-power-select-option[aria-disabled="true"] {
   color: $ember-power-select-disabled-option-color;


### PR DESCRIPTION
@cibernox - what your thoughts are on this? This becomes an issue when you use power-select in a place that has a small container.

Before:
<img width="826" alt="screen shot 2016-05-02 at 11 47 27 am" src="https://cloud.githubusercontent.com/assets/58678/14962546/9a7b158a-105c-11e6-844e-167202f517a2.png">

After:
<img width="746" alt="screen shot 2016-05-02 at 11 47 35 am" src="https://cloud.githubusercontent.com/assets/58678/14962552/a0cd77d4-105c-11e6-9f23-845c3f2a5029.png">

