### PR TITLE
Add special class to loading message option

### DIFF
--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -1,6 +1,6 @@
 {{#if loading}}
   {{#if loadingMessage}}
-    <li class="ember-power-select-option" role="option">{{loadingMessage}}</li>
+    <li class="ember-power-select-option ember-power-select-option--loading-message" role="option">{{loadingMessage}}</li>
   {{/if}}
 {{/if}}
 {{#each options as |opt index|}}

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -109,7 +109,7 @@ test('Each option of the select is the result of yielding an item', function(ass
 
 test('If the passed options is a promise and it\'s not resolved the component shows a Loading message', function(assert) {
   let done = assert.async();
-  assert.expect(3);
+  assert.expect(4);
 
   this.numbersPromise = new RSVP.Promise(function(resolve) {
     Ember.run.later(function() { console.debug('resolved!'); resolve(numbers); }, 100);
@@ -123,6 +123,7 @@ test('If the passed options is a promise and it\'s not resolved the component sh
 
   clickTrigger();
   assert.equal($('.ember-power-select-option').text().trim(), 'Loading options...', 'The loading message appears while the promise is pending');
+  assert.ok($('.ember-power-select-option').hasClass('ember-power-select-option--loading-message'), 'The row has a special class to differentiate it from regular options');
   setTimeout(function() {
     assert.ok(!/Loading options/.test($('.ember-power-select-option').text()), 'The loading message is gone');
     assert.equal($('.ember-power-select-option').length, 20, 'The results appear when the promise is resolved');


### PR DESCRIPTION
closes #479
- makes the loading message option consistent with other special option elements by adding the custom class `.ember-power-select-option--loading-message`