### PR TITLE
[BUGFIX] Custom matchers receive the entire option even when used along with searchField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+- [BUGFIX] Ensure customMatchers receive always receive the entire option, even when used in conjunction
+  with `searchField` option.
 - [ENHANCEMENT] The option containing the loading message has a a distinctive `.ember-power-select-option--loading-message`
   class.
 

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -139,7 +139,7 @@ export default Ember.Component.extend({
 
   optionMatcher: computed('searchField', 'matcher', function() {
     let { matcher, searchField } = this.getProperties('matcher', 'searchField');
-    if (searchField) {
+    if (searchField && matcher === defaultMatcher) {
       return (option, text) => matcher(get(option, searchField), text);
     } else {
       return (option, text) => matcher(option, text);

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import { typeInSearch, clickTrigger } from '../../../helpers/ember-power-select';
-import { numbers } from '../constants';
+import { numbers, countries } from '../constants';
 
 const { RSVP } = Ember;
 
@@ -550,4 +550,19 @@ test('BUGFIX: When the given options are a promise and a search function is prov
   assert.equal($('.ember-power-select-option').length, 7, 'There is 7 options');
   typeInSearch("");
   assert.equal($('.ember-power-select-option').length, 20, 'There is 20 options again§');
+});
+
+test('BUGFIX: If the user provides a custom matcher, the that matcher receives the entire option even if the user also provided a searchField', function(assert) {
+  assert.expect(14);
+  this.countries = countries;
+  this.matcherFn = function(option) {
+    assert.equal(typeof option, 'object', 'The first argument received by the custom matches is the option itself');
+  };
+  this.render(hbs`
+    {{#power-select-multiple options=countries matcher=matcherFn searchField="name" onchange=(action (mut foo)) as |number searchTerm|}}
+      {{country.name}}
+    {{/power-select-multiple}}
+  `);
+
+  typeInSearch('po');
 });

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -552,7 +552,7 @@ test('BUGFIX: When the given options are a promise and a search function is prov
   assert.equal($('.ember-power-select-option').length, 20, 'There is 20 options again§');
 });
 
-test('BUGFIX: If the user provides a custom matcher, the that matcher receives the entire option even if the user also provided a searchField', function(assert) {
+test('BUGFIX: If the user provides a custom matcher, that matcher receives the entire option even if the user also provided a searchField', function(assert) {
   assert.expect(14);
   this.countries = countries;
   this.matcherFn = function(option) {


### PR DESCRIPTION
Closes #473