### PR TITLE
Make it possible to disable groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Master
 
+- [ENHANCEMENT] Groups can contain disabled=true property that will add aria-disabled="true" to the group.
 - [BUGFIX] Select doesn't scroll to make the selection visible on open. Regression introduced in 0.10.0.
 - [BUGFIX] Highlight and scrolling has been decouple, so now highlighting a partially hidden option
   with the mouse not longer triggers a scroll on the list, which was wrong behaviour.

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -5,7 +5,7 @@
 {{/if}}
 {{#each options as |opt index|}}
   {{#if opt.groupName}}
-    <li class="ember-power-select-group" role="option">
+    <li class="ember-power-select-group" aria-disabled={{opt.disabled}} role="option">
       <span class="ember-power-select-group-name">{{opt.groupName}}</span>
       {{#component optionsComponent
         highlighted=(readonly highlighted)

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -80,7 +80,11 @@ export function filterOptions(options, text, matcher, skipDisabled = false) {
     if (isGroup(entry)) {
       let suboptions = filterOptions(get(entry, 'options'), text, matcher, skipDisabled);
       if (get(suboptions, 'length') > 0) {
-        opts.push({ groupName: entry.groupName, options: suboptions });
+        let groupCopy = { groupName: entry.groupName, options: suboptions };
+        if (entry.hasOwnProperty('disabled')) {
+          groupCopy.disabled = entry.disabled;
+        }
+        opts.push(groupCopy);
       }
     } else if (!skipDisabled || !entry.disabled) {
       let matchResult = matcher(entry, text);

--- a/tests/integration/components/power-select/disabled-test.js
+++ b/tests/integration/components/power-select/disabled-test.js
@@ -150,3 +150,30 @@ test('BUGFIX: When searching by pressing keys on a focused & closed select, disa
   assert.equal($('.ember-power-select-dropdown').length, 0,  'The dropdown is still closed');
   assert.equal(trigger.textContent.trim(), 'United Kingdom', '"United Kingdom" has been selected');
 });
+
+test('The title of a group can be marked as disabled', function(assert) {
+  assert.expect(1);
+
+  const options = [
+    { groupName: "Smalls", options: ["one", "two", "three"] },
+    { groupName: "Mediums", disabled: true, options: ["four", "five", "six"] },
+    { groupName: "Bigs", options: [
+        { groupName: "Fairly big", options: ["seven", "eight", "nine"] },
+        { groupName: "Really big", options: [ "ten", "eleven", "twelve" ] },
+        "thirteen"
+      ]
+    },
+    "one hundred",
+    "one thousand"
+  ];
+
+  this.options = options;
+  this.render(hbs`
+    {{#power-select options=options onchange=(action (mut foo)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  assert.equal($('.ember-power-select-group[aria-disabled="true"]').length, 1, 'group is disabled');
+});


### PR DESCRIPTION
Although groups cannot be clicked it would be great if they could be marked as disabled using the aria-disabled tag. Then styling could be applied depending on if the aria-disabled tag is true or false.