### PR TITLE
[BUGFIX] Decouple scrolling from highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Master
 
+- [BUGFIX] Select doesn't scroll to make the selection visible on open. Regression introduced in 0.10.0.
+- [BUGFIX] Highlight and scrolling has been decouple, so now highlighting a partially hidden option
+  with the mouse not longer triggers a scroll on the list, which was wrong behaviour.
+  However, using the arrow keys still scrolls the list is necessary.
 - [BUGFIX] Ensure customMatchers receive always receive the entire option, even when used in conjunction
   with `searchField` option.
 - [ENHANCEMENT] The option containing the loading message has a a distinctive `.ember-power-select-option--loading-message`

--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import layout from '../../templates/components/power-select/options';
 
+const { run } = Ember;
+
 export default Ember.Component.extend({
   isTouchDevice: (!!self.window && 'ontouchstart' in self.window),
   layout: layout,
@@ -21,6 +23,10 @@ export default Ember.Component.extend({
     this.element.addEventListener('mouseover', e => findOptionAndPerform(this.get('select.actions.highlight'), e));
     if (this.get('isTouchDevice')) {
       this._addTouchEvents();
+    }
+    if (this.get('role') !== 'group') {
+      let select = this.get('select');
+      run.scheduleOnce('afterRender', null, select.actions.scrollTo, select.highlighted);
     }
   },
 

--- a/tests/dummy/app/controllers/public-pages/docs/the-search.js
+++ b/tests/dummy/app/controllers/public-pages/docs/the-search.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  names: ['Stefan', 'Miguel', 'Tomster', 'Pluto'],
+  names: ['Stefan', 'Miguel', 'Tomster', 'Pluto', 'Robert', 'Alex', 'Lauren', 'Geoffrey', 'Ricardo', 'Jamie'],
   diacritics: [
     "María",
     "Søren Larsen",

--- a/tests/dummy/app/templates/public-pages/docs/the-search.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/the-search.hbs
@@ -205,7 +205,7 @@
   </pre>
   <pre class="code-sample-snippet {{if (eq component.activeTab 'javascript') 'active'}}">
     export default Ember.Controller.extend({
-      names: ['Stefan', 'Miguel', 'Tomster', 'Pluto'],
+      names: ['Stefan', 'Miguel', 'Tomster', 'Pluto', 'Robert', 'Alex', 'Lauren', 'Geoffrey', 'Ricardo', 'Jamie'],
     });
 
     // helpers/highlight-substr.js
@@ -295,7 +295,7 @@
   </pre>
   <pre class="code-sample-snippet {{if (eq component.activeTab 'javascript') 'active'}}">
     export default Ember.Controller.extend({
-      names: ['Stefan', 'Miguel', 'Tomster', 'Pluto'],
+      names: ['Stefan', 'Miguel', 'Tomster', 'Pluto', 'Robert', 'Alex', 'Lauren', 'Geoffrey', 'Ricardo', 'Jamie'],
     });
   </pre>
   <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -3,13 +3,14 @@ import Application from '../../app';
 import config from '../../config/environment';
 import registerPowerSelectHelpers from '../../tests/helpers/ember-power-select';
 
+const merge = Ember.assign || Ember.merge;
 registerPowerSelectHelpers();
 
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -999,3 +999,18 @@ test('When the input inside the select gets focused the entire component gains t
   Ember.run(() => $('.ember-power-select-search input').focus());
   assert.ok(this.$('.ember-power-select').hasClass('ember-basic-dropdown--focus-inside'), 'The select has the class now');
 });
+
+test('[BUGFIX] When the component opens, if the selected option is not visible the list is scrolled to make it visible', function(assert) {
+  assert.expect(2);
+
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select options=numbers selected="nine" onchange=(action (mut selected)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  assert.equal($('.ember-power-select-option[aria-current="true"]').text().trim(), 'nine');
+  assert.ok($('.ember-power-select-options')[0].scrollTop > 0, 'The list has scrolled');
+});

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -74,6 +74,24 @@ test('When you the first option is highlighted, pressing keyup doesn\'t change t
   assert.equal($('.ember-power-select-option[aria-current="true"]').text().trim(), 'one', 'The first option is still the highlighted one');
 });
 
+test('The arrow keys also scroll the list if the new highlighted element if it is outside of the viewport of the list', function(assert) {
+  assert.expect(4);
+
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select options=numbers selected="seven" onchange=(action (mut selected)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  assert.equal($('.ember-power-select-option[aria-current="true"]').text().trim(), 'seven');
+  assert.equal($('.ember-power-select-options')[0].scrollTop, 0, 'The list is not scrolled');
+  triggerKeydown($('.ember-power-select-search input')[0], 40);
+  assert.equal($('.ember-power-select-option[aria-current="true"]').text().trim(), 'eight', 'The next option is highlighted now');
+  assert.ok($('.ember-power-select-options')[0].scrollTop > 0, 'The list has scrolled');
+});
+
 test('Pressing ENTER selects the highlighted element, closes the dropdown and focuses the trigger', function(assert) {
   assert.expect(5);
 
@@ -403,7 +421,7 @@ test('Typing on a closed single select selects the value that matches the string
 // });
 
 test('Typing on a opened single select highlights the value that matches the string typed so far, scrolling if needed', function(assert) {
-  assert.expect(4);
+  assert.expect(6);
 
   this.numbers = numbers;
   this.render(hbs`
@@ -415,16 +433,18 @@ test('Typing on a opened single select highlights the value that matches the str
   let trigger = this.$('.ember-power-select-trigger')[0];
   clickTrigger();
   assert.equal($('.ember-power-select-dropdown').length, 1,  'The dropdown is open');
+  assert.equal($('.ember-power-select-options')[0].scrollTop, 0, 'The list is not scrolled');
   triggerKeydown(trigger, 78); // n
   triggerKeydown(trigger, 73); // i
   triggerKeydown(trigger, 78); // n
   assert.equal(trigger.textContent.trim(), '', 'nothing has been selected');
   assert.equal($('.ember-power-select-option[aria-current=true]').text().trim(), 'nine', 'The option containing "nine" has been highlighted');
+  assert.ok($('.ember-power-select-options')[0].scrollTop > 0, 'The list has scrolled');
   assert.equal($('.ember-power-select-dropdown').length, 1,  'The dropdown is still closed');
 });
 
 test('Typing on a opened multiple select highlights the value that matches the string typed so far, scrolling if needed', function(assert) {
-  assert.expect(4);
+  assert.expect(6);
 
   this.numbers = numbers;
   this.render(hbs`
@@ -436,11 +456,13 @@ test('Typing on a opened multiple select highlights the value that matches the s
   let trigger = this.$('.ember-power-select-trigger')[0];
   clickTrigger();
   assert.equal($('.ember-power-select-dropdown').length, 1,  'The dropdown is open');
+  assert.equal($('.ember-power-select-options')[0].scrollTop, 0, 'The list is not scrolled');
   triggerKeydown(trigger, 78); // n
   triggerKeydown(trigger, 73); // i
   triggerKeydown(trigger, 78); // n
   assert.equal(trigger.textContent.trim(), '', 'nothing has been selected');
   assert.equal($('.ember-power-select-option[aria-current=true]').text().trim(), 'nine', 'The option containing "nine" has been highlighted');
+  assert.ok($('.ember-power-select-options')[0].scrollTop > 0, 'The list has scrolled');
   assert.equal($('.ember-power-select-dropdown').length, 1,  'The dropdown is still closed');
 });
 

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -10,7 +10,7 @@ moduleForComponent('ember-power-select', 'Integration | Component | Ember Power 
 });
 
 test('The search action of single selects action receives the search term and the public API', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   this.numbers = numbers;
   this.handleSearch = (term, select) => {
@@ -24,6 +24,7 @@ test('The search action of single selects action receives the search term and th
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
   };
 
   this.render(hbs`
@@ -37,7 +38,7 @@ test('The search action of single selects action receives the search term and th
 });
 
 test('The search action of multiple selects action receives the search term and the public API', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   this.numbers = numbers;
   this.handleSearch = (term, select) => {
@@ -51,6 +52,7 @@ test('The search action of multiple selects action receives the search term and 
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
   };
 
   this.render(hbs`
@@ -64,7 +66,7 @@ test('The search action of multiple selects action receives the search term and 
 });
 
 test('The onchange of single selects action receives the selection and the public API', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   this.numbers = numbers;
   this.handleChange = (selected, select) => {
@@ -78,6 +80,7 @@ test('The onchange of single selects action receives the selection and the publi
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
   };
 
   this.render(hbs`
@@ -91,7 +94,7 @@ test('The onchange of single selects action receives the selection and the publi
 });
 
 test('The onchange of multiple selects action receives the selection and the public API', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   this.numbers = numbers;
   this.handleChange = (selected, select) => {
@@ -105,6 +108,7 @@ test('The onchange of multiple selects action receives the selection and the pub
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
   };
 
   this.render(hbs`
@@ -118,7 +122,7 @@ test('The onchange of multiple selects action receives the selection and the pub
 });
 
 test('The onkeydown of single selects action receives the public API and the keydown event', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   this.numbers = numbers;
   this.onKeyDown = (select, e) => {
@@ -131,6 +135,7 @@ test('The onkeydown of single selects action receives the public API and the key
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
   };
 
@@ -170,7 +175,7 @@ test('The onkeydown can be used to easily allow to select on tab', function(asse
 });
 
 test('The onkeydown of multiple selects action receives the public API and the keydown event', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   this.numbers = numbers;
   this.onKeyDown = (select, e) => {
@@ -183,6 +188,7 @@ test('The onkeydown of multiple selects action receives the public API and the k
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
   };
 
@@ -197,7 +203,7 @@ test('The onkeydown of multiple selects action receives the public API and the k
 });
 
 test('returning false from the `onkeydown` action prevents the default behaviour in single selects', function(assert) {
-  assert.expect(22);
+  assert.expect(24);
 
   this.numbers = numbers;
   this.handleKeyDown = (select, e) => {
@@ -210,6 +216,7 @@ test('returning false from the `onkeydown` action prevents the default behaviour
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
     return false;
   };
@@ -227,7 +234,7 @@ test('returning false from the `onkeydown` action prevents the default behaviour
 });
 
 test('returning false from the `onkeydown` action prevents the default behaviour in multiple selects', function(assert) {
-  assert.expect(11);
+  assert.expect(12);
 
   this.numbers = numbers;
   this.handleKeyDown = (select, e) => {
@@ -240,6 +247,7 @@ test('returning false from the `onkeydown` action prevents the default behaviour
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
     return false;
   };
@@ -255,7 +263,7 @@ test('returning false from the `onkeydown` action prevents the default behaviour
 });
 
 test('The onfocus of single selects action receives the public API and the focus event', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   this.numbers = numbers;
   this.handleFocus = (select, e) => {
@@ -268,6 +276,7 @@ test('The onfocus of single selects action receives the public API and the focus
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
   };
 
@@ -281,7 +290,7 @@ test('The onfocus of single selects action receives the public API and the focus
 });
 
 test('The onfocus of multiple selects action receives the public API and the focus event', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   this.numbers = numbers;
   this.handleFocus = (select, e) => {
@@ -294,6 +303,7 @@ test('The onfocus of multiple selects action receives the public API and the foc
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
   };
 
@@ -307,7 +317,7 @@ test('The onfocus of multiple selects action receives the public API and the foc
 });
 
 test('the `onopen` action is invoked just before the dropdown opens', function(assert) {
-  assert.expect(11);
+  assert.expect(12);
 
   this.numbers = numbers;
   this.handleOpen = (select, e) => {
@@ -320,6 +330,7 @@ test('the `onopen` action is invoked just before the dropdown opens', function(a
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
   };
 
@@ -334,7 +345,7 @@ test('the `onopen` action is invoked just before the dropdown opens', function(a
 });
 
 test('returning false from the `onopen` action prevents the single select from opening', function(assert) {
-  assert.expect(11);
+  assert.expect(12);
 
   this.numbers = numbers;
   this.handleOpen = (select, e) => {
@@ -347,6 +358,7 @@ test('returning false from the `onopen` action prevents the single select from o
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
     return false;
   };
@@ -362,7 +374,7 @@ test('returning false from the `onopen` action prevents the single select from o
 });
 
 test('returning false from the `onopen` action prevents the multiple select from opening', function(assert) {
-  assert.expect(11);
+  assert.expect(12);
 
   this.numbers = numbers;
   this.handleOpen = (select, e) => {
@@ -375,6 +387,7 @@ test('returning false from the `onopen` action prevents the multiple select from
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
     return false;
   };
@@ -390,7 +403,7 @@ test('returning false from the `onopen` action prevents the multiple select from
 });
 
 test('the `onclose` action is invoked just before the dropdown closes', function(assert) {
-  assert.expect(12);
+  assert.expect(13);
 
   this.numbers = numbers;
   this.handleClose = (select, e) => {
@@ -404,6 +417,7 @@ test('the `onclose` action is invoked just before the dropdown closes', function
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
     assert.equal(typeof select.actions.choose, 'function', 'select.actions.choose is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
   };
 
@@ -419,7 +433,7 @@ test('the `onclose` action is invoked just before the dropdown closes', function
 });
 
 test('returning false from the `onclose` action prevents the single select from closing', function(assert) {
-  assert.expect(12);
+  assert.expect(13);
 
   this.numbers = numbers;
   this.handleClose = (select, e) => {
@@ -432,6 +446,7 @@ test('returning false from the `onclose` action prevents the single select from 
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
     return false;
   };
@@ -449,7 +464,7 @@ test('returning false from the `onclose` action prevents the single select from 
 });
 
 test('returning false from the `onclose` action prevents the multiple select from closing', function(assert) {
-  assert.expect(12);
+  assert.expect(13);
 
   this.numbers = numbers;
   this.handleClose = (select, e) => {
@@ -462,6 +477,7 @@ test('returning false from the `onclose` action prevents the multiple select fro
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The second argument is an event');
     return false;
   };
@@ -479,7 +495,7 @@ test('returning false from the `onclose` action prevents the multiple select fro
 });
 
 test('the `oninput` action is invoked when the user modifies the text of the search input on single selects, and the search happens', function(assert) {
-  assert.expect(15);
+  assert.expect(16);
 
   this.numbers = numbers;
   this.handleInput = (value, select, e) => {
@@ -493,6 +509,7 @@ test('the `oninput` action is invoked when the user modifies the text of the sea
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The third argument is an event');
   };
 
@@ -511,7 +528,7 @@ test('the `oninput` action is invoked when the user modifies the text of the sea
 });
 
 test('the `oninput` action is invoked when the user modifies the text of the search input on multiple selects, and the search happens', function(assert) {
-  assert.expect(15);
+  assert.expect(16);
 
   this.numbers = numbers;
   this.handleInput = (value, select, e) => {
@@ -525,6 +542,7 @@ test('the `oninput` action is invoked when the user modifies the text of the sea
     assert.equal(typeof select.actions.search, 'function', 'select.actions.search is a function');
     assert.equal(typeof select.actions.highlight, 'function', 'select.actions.highlight is a function');
     assert.equal(typeof select.actions.select, 'function', 'select.actions.select is a function');
+    assert.equal(typeof select.actions.scrollTo, 'function', 'select.actions.scrollTo is a function');
     assert.ok(e instanceof window.Event, 'The third argument is an event');
   };
 


### PR DESCRIPTION
That way highlight with the mouse doesn't trigger a scroll change, and
at the same time allows to scroll reliably using `didInsertElement` that
we have the guarantee that is called once the dom is ready.

This adds a nice new `scrollTo(option, dropdown, e)` action to the public API object received
by all the hooks of the component that can be used to command the select to scroll
to any option.

closes #488 