### PR TITLE
If a group is disabled, its options cannot be highligted or selected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Master
 
+- [ENHANCEMENT] If a group is disabled, its options (or the options of nested groups) are automatically
+  considered disabled too.
+
 # 0.10.4
 - [ENHANCEMENT] Groups can contain disabled=true property that will add aria-disabled="true" to the group.
 - [BUGFIX] Select doesn't scroll to make the selection visible on open. Regression introduced in 0.10.0.

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -334,11 +334,13 @@ export default Ember.Component.extend({
   advanceSelectableOption(activeHighlighted, step) {
     let resultsLength = this.get('resultsLength');
     let startIndex = Math.min(Math.max(this.indexOfOption(activeHighlighted) + step, 0), resultsLength - 1);
-    let nextOption = this.optionAtIndex(startIndex);
-    while (nextOption && get(nextOption, 'disabled')) {
-      nextOption = this.optionAtIndex(startIndex += step);
+    let { disabled, option } = this.optionAtIndex(startIndex);
+    while (option && disabled) {
+      let next = this.optionAtIndex(startIndex += step);
+      disabled = next.disabled;
+      option = next.option;
     }
-    return nextOption;
+    return option;
   },
 
   filter(options, term, skipDisabled = false) {
@@ -347,12 +349,8 @@ export default Ember.Component.extend({
 
   defaultHighlighted() {
     const selected = this.get('resolvedSelected');
-    if (!selected || this.indexOfOption(selected) === -1) {
-      let nextOption = this.optionAtIndex(0);
-      while (nextOption && nextOption.disabled) {
-        nextOption = this.advanceSelectableOption(nextOption, 1);
-      }
-      return nextOption;
+    if (selected === undefined || this.indexOfOption(selected) === -1) {
+      return this.advanceSelectableOption(selected, 1);
     }
     return selected;
   },

--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -13,10 +13,13 @@ export default Ember.Component.extend({
   // Lifecycle hooks
   didInsertElement() {
     this._super(...arguments);
-    if (this.get('role') === 'group') { return; }
+    if (this.get('role') === 'group') {
+      return;
+    }
     let findOptionAndPerform = (action, e) => {
       let optionItem = Ember.$(e.target).closest('[data-option-index]');
       if (!optionItem || !(0 in optionItem)) { return; }
+      if (optionItem.closest('[aria-disabled=true]').length) { return; } // Abort if the item or an ancestor is disabled
       action(this._optionFromIndex(optionItem[0].dataset.optionIndex), e);
     };
     this.element.addEventListener('mouseup', e => findOptionAndPerform(this.get('select.actions.choose'), e));

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -49,8 +49,8 @@ export function indexOfOption(collection, option) {
 
 export function optionAtIndex(originalCollection, index) {
   let counter = 0;
-  return (function walk(collection) {
-    if (!collection) { return null; }
+  return (function walk(collection, ancestorIsDisabled) {
+    if (!collection || index < 0) { return { disabled: false, option: undefined }; }
     if (!collection.objectAt) {
       collection = Ember.A(collection);
     }
@@ -59,16 +59,16 @@ export function optionAtIndex(originalCollection, index) {
     while (counter <= index && localCounter < length) {
       let entry = collection.objectAt(localCounter);
       if (isGroup(entry)) {
-        let found = walk(get(entry, 'options'));
+        let found = walk(get(entry, 'options'), ancestorIsDisabled || !!get(entry, 'disabled'));
         if (found) { return found; }
       } else if (counter === index) {
-        return entry;
+        return { disabled: ancestorIsDisabled || !!get(entry, 'disabled'), option: entry };
       } else {
         counter++;
       }
       localCounter++;
     }
-  })(originalCollection);
+  })(originalCollection, false) || { disabled: false, option: undefined };
 }
 let deprecatedMatchers = {};
 export function filterOptions(options, text, matcher, skipDisabled = false) {

--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -183,9 +183,15 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
   cursor: pointer;
   padding: 0 $ember-power-select-option-padding;
 }
+.ember-power-select-group[aria-disabled="true"] {
+  color: $ember-power-select-disabled-option-color;
+  cursor: not-allowed;
+}
+.ember-power-select-group[aria-disabled="true"] .ember-power-select-option,
 .ember-power-select-option[aria-disabled="true"] {
   color: $ember-power-select-disabled-option-color;
   pointer-events: none;
+  cursor: not-allowed;
 }
 .ember-power-select-option[aria-selected="true"] { background-color: $ember-power-select-selected-background; }
 .ember-power-select-option[aria-current="true"] {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-power-select",
   "dependencies": {
-    "ember": "~2.5.0",
+    "ember": "~2.5.1",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
@@ -10,6 +10,6 @@
     "Faker": "~3.0.0"
   },
   "resolutions": {
-    "ember": "2.5.0"
+    "ember": "2.5.1"
   }
 }

--- a/tests/dummy/app/controllers/legacy-demo.js
+++ b/tests/dummy/app/controllers/legacy-demo.js
@@ -382,9 +382,10 @@ export default Ember.Controller.extend({
   multipleSelection: ['one','two','three','four','five','six','seven','eight','nine','ten','eleven'],
   emptyMultipleSelection: [],
 
+  optionOfGroup: null,
   groupedOptions: [
-    { groupName: "Smalls", options: ["one", "two", "three"] },
-    { groupName: "Mediums", options: ["four", "five", "six"] },
+    { groupName: "Smalls", disabled: true, options: ["one", "two", "three"] },
+    { groupName: "Mediums", disabled: true, options: ["four", "five", "six"] },
     { groupName: "Bigs", options: [
         { groupName: "Fairly big", options: ["seven", "eight", "nine"] },
         { groupName: "Really big", options: [ "ten", "eleven", "twelve" ] },

--- a/tests/dummy/app/controllers/public-pages/docs/the-list.js
+++ b/tests/dummy/app/controllers/public-pages/docs/the-list.js
@@ -16,11 +16,25 @@ const countries = [
   { name: 'United Kingdom', code: 'GB', population: 64596752 },
 ];
 
+const groupedNumbers = [
+  { groupName: "Smalls", disabled: true, options: ["one", "two", "three"] },
+  { groupName: "Mediums", options: ["four", "five", "six"] },
+  { groupName: "Bigs", disabled: true, options: [
+      { groupName: "Fairly big", options: ["seven", "eight", "nine"] },
+      { groupName: "Really big", options: [ "ten", "eleven", "twelve" ] },
+      "thirteen"
+    ]
+  },
+  "one hundred",
+  "one thousand"
+];
+
 export default Ember.Controller.extend({
   names: ['Stefan', 'Miguel', 'Tomster', 'Pluto'],
   emptyList: [],
   promise: null,
   countries,
+  groupedNumbers,
 
   actions: {
     refreshCollection() {

--- a/tests/dummy/app/templates/legacy-demo.hbs
+++ b/tests/dummy/app/templates/legacy-demo.hbs
@@ -2,11 +2,11 @@
   <input type="text" value="sample input">
   <h2 id="title">Welcome to the demo of ember-power-select (provisional name)</h2>
 
+{{!--
 {{#power-select options=(readonly moarNumbers) selected=(readonly simpleSelected) onchange=(action (mut simpleSelected)) as |option|}}
   {{option}}
 {{/power-select}}
 
-{{!--
   <h4>Select of strings with value tracking</h4>
   {{#power-select options=(readonly simpleOptions) selected=(readonly simpleSelected) onchange=(action (mut simpleSelected)) as |option|}}
     {{option}}
@@ -165,11 +165,12 @@
     <a href="#">Contact us to complain about this</a>
   {{/power-select}}
 
+--}}
   <h4>Select with groups</h4>
   {{#power-select options=(readonly groupedOptions) selected=optionOfGroup onchange=(action (mut optionOfGroup)) as |option|}}
     {{option}}
   {{/power-select}}
-
+{{!--
   <h4>Options are appended to the body, unless you pass `renderInPlace=true`</h4>
   {{#power-select options=(readonly simpleOptions) renderInPlace=true selected=simpleSelected2 onchange=(action (mut simpleSelected2)) as |option|}}
     {{option}}

--- a/tests/dummy/app/templates/public-pages/docs/the-list.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/the-list.hbs
@@ -346,7 +346,7 @@
   </div>
 {{/code-sample}}
 
-<h3>Disabling specific options</h3>
+<h3>Disabling specific options or groups</h3>
 
 <p>
   In {{#link-to 'public-pages.docs.the-trigger'}}the trigger{{/link-to}} we saw how to disable the entire component,
@@ -393,6 +393,50 @@
       as |country|
     }}
       {{country.name}}
+    {{/power-select}}
+  </div>
+{{/code-sample}}
+
+<p>
+  This also works with groups. If a group has a property <code>disabled: true</code>, all options inside
+  that group, including nested groups are considered disabled, without having to mark every option as disabled.
+</p>
+
+{{#code-sample as |component|}}
+  <pre class="code-sample-snippet {{if (eq component.activeTab 'template') 'active'}}">
+    \{{#power-select
+      options=groupedNumbers
+      selected=number
+      onchange=(action (mut number))
+      as |num|
+    }}
+      \{{num}}
+    \{{/power-select}}
+  </pre>
+  <pre class="code-sample-snippet {{if (eq component.activeTab 'javascript') 'active'}}">
+    export default Ember.Controller.extend({
+      groupedNumbers: [
+        { groupName: "Smalls", disabled: true, options: ["one", "two", "three"] },
+        { groupName: "Mediums", options: ["four", "five", "six"] },
+        { groupName: "Bigs", disabled: true, options: [
+            { groupName: "Fairly big", options: ["seven", "eight", "nine"] },
+            { groupName: "Really big", options: [ "ten", "eleven", "twelve" ] },
+            "thirteen"
+          ]
+        },
+        "one hundred",
+        "one thousand"
+      ]
+    });
+  </pre>
+  <div class="code-sample-snippet result {{if (eq component.activeTab 'result') 'active'}}">
+    {{#power-select
+      options=groupedNumbers
+      selected=number
+      onchange=(action (mut number))
+      as |num|
+    }}
+      {{num}}
     {{/power-select}}
   </div>
 {{/code-sample}}

--- a/tests/integration/components/power-select/disabled-test.js
+++ b/tests/integration/components/power-select/disabled-test.js
@@ -205,7 +205,7 @@ test('If a group is disabled, any options inside cannot be interacted with mouse
 
   clickTrigger();
   assert.equal($('.ember-power-select-option[aria-current="true"]').text().trim(), 'one');
-  assert.equal($('.ember-power-select-option[aria-selected="true"]').length, 0), 'No option is selected';
+  assert.equal($('.ember-power-select-option[aria-selected="true"]').length, 0, 'No option is selected');
   Ember.run(() => {
     let event = new window.Event('mouseover', { bubbles: true, cancelable: true, view: window });
     $('.ember-power-select-option:eq(8)')[0].dispatchEvent(event);

--- a/tests/integration/components/power-select/disabled-test.js
+++ b/tests/integration/components/power-select/disabled-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { triggerKeydown, clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
+import { triggerKeydown, clickTrigger, typeInSearch, nativeMouseUp } from '../../../helpers/ember-power-select';
 import { numbers, countriesWithDisabled } from '../constants';
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Disabled)', {
@@ -178,4 +178,39 @@ test('The title of a group can be marked as disabled, and it is still disabled a
   assert.equal($('.ember-power-select-group[aria-disabled="true"]').length, 1, 'one group is disabled');
   typeInSearch('fiv');
   assert.equal($('.ember-power-select-group[aria-disabled="true"]').length, 1, 'one group is still disabled');
+});
+
+test('If a group is disabled, any options inside cannot be interacted with mouse', function(assert) {
+  assert.expect(4);
+
+  const options = [
+    { groupName: "Smalls", options: ["one", "two", "three"] },
+    { groupName: "Mediums", options: ["four", "five", "six"] },
+    { groupName: "Bigs", disabled: true, options: [
+        { groupName: "Fairly big", options: ["seven", "eight", "nine"] },
+        { groupName: "Really big", options: [ "ten", "eleven", "twelve" ] },
+        "thirteen"
+      ]
+    },
+    "one hundred",
+    "one thousand"
+  ];
+
+  this.options = options;
+  this.render(hbs`
+    {{#power-select options=options selected=foo onchange=(action (mut foo)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  assert.equal($('.ember-power-select-option[aria-current="true"]').text().trim(), 'one');
+  assert.equal($('.ember-power-select-option[aria-selected="true"]').length, 0), 'No option is selected';
+  Ember.run(() => {
+    let event = new window.Event('mouseover', { bubbles: true, cancelable: true, view: window });
+    $('.ember-power-select-option:eq(8)')[0].dispatchEvent(event);
+  });
+  assert.equal($('.ember-power-select-option[aria-current="true"]').text().trim(), 'one');
+  nativeMouseUp('.ember-power-select-option:eq(9)');
+  assert.equal($('.ember-power-select-option[aria-selected="true"]').length, 0, 'Noting was selected');
 });

--- a/tests/unit/utils/group-utils-test.js
+++ b/tests/unit/utils/group-utils-test.js
@@ -13,6 +13,18 @@ const groupedOptions = [
   "one hundred",
   "one thousand"
 ];
+const groupedOptionsWithDisabledThings = [
+  { groupName: "Smalls", options: ["zero", { disabled: true, value: "one" }, "two", "three"] },
+  { groupName: "Mediums", options: ["four", "five", "six"] },
+  { groupName: "Bigs", disabled: true, options: [
+      { groupName: "Fairly big", options: ["seven", "eight", "nine"] },
+      { groupName: "Really big", options: [ "ten", "eleven", "twelve" ] },
+      "thirteen"
+    ]
+  },
+  "one hundred",
+  "one thousand"
+];
 const basicOptions = ['zero', 'one', 'two', 'three', 'four', 'five'];
 
 module('Unit | Utility | Group utils');
@@ -42,22 +54,34 @@ test('#indexOfOption also works transversing groups', function(assert) {
   assert.equal(indexOfOption(groupedOptions, null), -1);
 });
 
-test('#optionAtIndex returns the option in that index is present, null othewise', function(assert) {
-  assert.equal(optionAtIndex(basicOptions, 0), 'zero');
-  assert.equal(optionAtIndex(basicOptions, 5), 'five');
-  assert.equal(optionAtIndex(basicOptions, 7), null);
-  assert.equal(optionAtIndex(basicOptions, -1), null); // Should this return the last??
+test('#optionAtIndex returns an object `{ disabled, option }`, disabled being true if that option or any ancestor is disabled, and the option will be undefined if the index is out of range', function(assert) {
+  assert.deepEqual(optionAtIndex(basicOptions, 0), { disabled: false, option: 'zero'});
+  assert.deepEqual(optionAtIndex(basicOptions, 5), { disabled: false, option: 'five'});
+  assert.deepEqual(optionAtIndex(basicOptions, 7), { disabled: false, option: undefined });
+  assert.deepEqual(optionAtIndex(basicOptions, -1), { disabled: false, option: undefined }); // Should this return the last??
 });
 
 test('#optionAtIndex knows how to transverse groups', function(assert) {
-  assert.equal(optionAtIndex(groupedOptions, 0), 'zero');
-  assert.equal(optionAtIndex(groupedOptions, 6), 'six');
-  assert.equal(optionAtIndex(groupedOptions, 7), 'seven');
-  assert.equal(optionAtIndex(groupedOptions, 12), 'twelve');
-  assert.equal(optionAtIndex(groupedOptions, 13), 'thirteen');
-  assert.equal(optionAtIndex(groupedOptions, 15), 'one thousand');
-  assert.equal(optionAtIndex(groupedOptions, 16), undefined);
-  assert.equal(optionAtIndex(groupedOptions, -1), undefined);
+  assert.deepEqual(optionAtIndex(groupedOptions, 0),  { disabled: false, option: 'zero' });
+  assert.deepEqual(optionAtIndex(groupedOptions, 6),  { disabled: false, option: 'six' });
+  assert.deepEqual(optionAtIndex(groupedOptions, 7),  { disabled: false, option: 'seven' });
+  assert.deepEqual(optionAtIndex(groupedOptions, 12), { disabled: false, option: 'twelve' });
+  assert.deepEqual(optionAtIndex(groupedOptions, 13), { disabled: false, option: 'thirteen' });
+  assert.deepEqual(optionAtIndex(groupedOptions, 15), { disabled: false, option: 'one thousand' });
+  assert.deepEqual(optionAtIndex(groupedOptions, 16), { disabled: false, option: undefined });
+  assert.deepEqual(optionAtIndex(groupedOptions, -1), { disabled: false, option: undefined });
+});
+
+test('#optionAtIndex knows that an option is disabled if an ancestor is disabled', function(assert) {
+  assert.deepEqual(optionAtIndex(groupedOptionsWithDisabledThings, 0),  { disabled: false, option: 'zero' });
+  assert.deepEqual(optionAtIndex(groupedOptionsWithDisabledThings, 1),  { disabled: true, option: { disabled: true, value: "one" } });
+  assert.deepEqual(optionAtIndex(groupedOptionsWithDisabledThings, 6),  { disabled: false, option: 'six' });
+  assert.deepEqual(optionAtIndex(groupedOptionsWithDisabledThings, 7),  { disabled: true, option: 'seven' });
+  assert.deepEqual(optionAtIndex(groupedOptionsWithDisabledThings, 12), { disabled: true, option: 'twelve' });
+  assert.deepEqual(optionAtIndex(groupedOptionsWithDisabledThings, 13), { disabled: true, option: 'thirteen' });
+  assert.deepEqual(optionAtIndex(groupedOptionsWithDisabledThings, 15), { disabled: false, option: 'one thousand' });
+  assert.deepEqual(optionAtIndex(groupedOptionsWithDisabledThings, 16), { disabled: false, option: undefined });
+  assert.deepEqual(optionAtIndex(groupedOptionsWithDisabledThings, -1), { disabled: false, option: undefined });
 });
 
 test('#filterOptions generates new options respecting groups when the matches returns a boolean', function(assert) {


### PR DESCRIPTION
Before this, options had to explicitly have `disabled: true` property to be
considered disabled. Since this changes, if any ancestor group is disabled,
the option is automatically considered disabled.

Also, styles have been improved a bit. Now disabled groups by default have the
disabled color, and the cursor is `not-allowed`. Options inside disabled groups
have the same styles than options with `disabled: true`