### PR TITLE
Remove project jscs warnings

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+  "preset": "ember-suave"
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-pagefront": "0.10.10",
     "ember-resolver": "^2.0.3",
+    "ember-suave": "2.0.1",
     "ember-try": "^0.2.2",
     "liquid-fire": "0.23.0",
     "loader.js": "^4.0.1",

--- a/tests/acceptance/all-public-pages-test.js
+++ b/tests/acceptance/all-public-pages-test.js
@@ -5,15 +5,15 @@ import Ember from 'ember';
 moduleForAcceptance('Acceptance | All Public Pages');
 
 test('visit every Docs page in order', function(assert) {
-  const expectedPages = 15;
-  return keepClickingNext('/docs', '.doc-page-nav-link-next').then(urls => {
+  let expectedPages = 15;
+  return keepClickingNext('/docs', '.doc-page-nav-link-next').then((urls) => {
     assert.equal(urls.length, expectedPages);
   });
 });
 
 test('visit every Cookbook page in order', function(assert) {
-  const expectedPages = 6;
-  return keepClickingNext('/cookbook', '.doc-page-nav-link-next').then(urls => {
+  let expectedPages = 6;
+  return keepClickingNext('/cookbook', '.doc-page-nav-link-next').then((urls) => {
     assert.equal(urls.length, expectedPages);
   });
 });
@@ -27,7 +27,7 @@ test('visit /addons', function(assert) {
 
 function keepClickingNext(initialUrl, nextLinkSelector) {
   let seenURLs = Object.create(null);
-  return new Ember.RSVP.Promise(resolve => {
+  return new Ember.RSVP.Promise((resolve) => {
     visit(initialUrl);
     andThen(() => {
       visitNextPage();
@@ -35,7 +35,7 @@ function keepClickingNext(initialUrl, nextLinkSelector) {
     function visitNextPage() {
       andThen(() => {
         if (seenURLs[currentURL()]) {
-          throw new Error("page visitor detected a loop");
+          throw new Error('page visitor detected a loop');
         }
         seenURLs[currentURL()] = true;
         let nextLink = find(nextLinkSelector);

--- a/tests/blanket-options.js
+++ b/tests/blanket-options.js
@@ -1,6 +1,6 @@
 /* globals blanket, module */
 
-var options = {
+let options = {
   modulePrefix: 'ember-power-select',
   filter: '//.*ember-power-select/.*/',
   antifilter: '//.*(tests|template).*/',

--- a/tests/dummy/app/components/animated-options.js
+++ b/tests/dummy/app/components/animated-options.js
@@ -11,8 +11,8 @@ export default Ember.Component.extend({
       this.set('enableGrowth', false);
     } else {
       this.set('enableGrowth', true);
-      const parentLevel = oldAttrs.options[0] && oldAttrs.options[0].parentLevel;
-      const goingBack = !!parentLevel && parentLevel.options === newAttrs.options;
+      let parentLevel = oldAttrs.options[0] && oldAttrs.options[0].parentLevel;
+      let goingBack = !!parentLevel && parentLevel.options === newAttrs.options;
       if (goingBack) {
         this.set('animation', 'toRight');
       } else {

--- a/tests/dummy/app/components/navigable-select.js
+++ b/tests/dummy/app/components/navigable-select.js
@@ -43,8 +43,8 @@ export default Ember.Component.extend({
     },
 
     search(term) {
-      const normalizedTerm = term.toLowerCase();
-      const results = this.get('currentOptions').filter(o => {
+      let normalizedTerm = term.toLowerCase();
+      let results = this.get('currentOptions').filter((o) => {
         if (o.parentLevel) {
           return normalizedTerm === '';
         } else if (get(o, 'levelName')) {

--- a/tests/dummy/app/controllers/helpers-testing.js
+++ b/tests/dummy/app/controllers/helpers-testing.js
@@ -32,11 +32,11 @@ export default Ember.Controller.extend({
     searchAsync(term) {
       return new Ember.RSVP.Promise(function(resolve) {
         Ember.run.later(function() {
-          resolve(numbers.filter(n => n.indexOf(term) > -1));
+          resolve(numbers.filter((n) => n.indexOf(term) > -1));
         }, 100);
       });
     },
-    onOpenHandle(){
+    onOpenHandle() {
       Ember.run.later(() => {
         this.set('optionz', numbers);
       }, 100);

--- a/tests/dummy/app/controllers/legacy-demo.js
+++ b/tests/dummy/app/controllers/legacy-demo.js
@@ -322,7 +322,7 @@ const moarNumbers = [
   'two hundred and ninety six',
   'two hundred and ninety seven',
   'two hundred and ninety eight',
-  'two hundred and ninety nine',
+  'two hundred and ninety nine'
 ];
 
 const countries = [
@@ -332,7 +332,7 @@ const countries = [
   { name: 'Russia',         code: 'RU', population: 146588880 },
   { name: 'Latvia',         code: 'LV', population: 1978300 },
   { name: 'Brazil',         code: 'BR', population: 204921000 },
-  { name: 'United Kingdom', code: 'GB', population: 64596752 },
+  { name: 'United Kingdom', code: 'GB', population: 64596752 }
 ];
 
 const contriesWithDisabled = [
@@ -342,16 +342,16 @@ const contriesWithDisabled = [
   { name: 'Russia',         code: 'RU', population: 146588880, disabled: true },
   { name: 'Latvia',         code: 'LV', population: 1978300 },
   { name: 'Brazil',         code: 'BR', population: 204921000, disabled: true },
-  { name: 'United Kingdom', code: 'GB', population: 64596752 },
+  { name: 'United Kingdom', code: 'GB', population: 64596752 }
 ];
 
 const names = [
-  "María",
-  "Søren Larsen",
-  "João",
-  "Miguel",
-  "Marta",
-  "Lisa"
+  'María',
+  'Søren Larsen',
+  'João',
+  'Miguel',
+  'Marta',
+  'Lisa'
 ];
 
 const searchTypes = [
@@ -363,11 +363,11 @@ const searchTypes = [
   { label: 'FooBar' },
   { label: 'Tomster' },
   { label: 'Aretha' },
-  { label: 'Franklin' },
+  { label: 'Franklin' }
 ];
 
 export default Ember.Controller.extend({
-  names: names,
+  names,
   simpleOptions: numbers,
   moarNumbers,
   simpleSelected: 'six',
@@ -384,16 +384,16 @@ export default Ember.Controller.extend({
 
   optionOfGroup: null,
   groupedOptions: [
-    { groupName: "Smalls", disabled: true, options: ["one", "two", "three"] },
-    { groupName: "Mediums", disabled: true, options: ["four", "five", "six"] },
-    { groupName: "Bigs", options: [
-        { groupName: "Fairly big", options: ["seven", "eight", "nine"] },
-        { groupName: "Really big", options: [ "ten", "eleven", "twelve" ] },
-        "thirteen"
+    { groupName: 'Smalls', disabled: true, options: ['one', 'two', 'three'] },
+    { groupName: 'Mediums', disabled: true, options: ['four', 'five', 'six'] },
+    { groupName: 'Bigs', options: [
+        { groupName: 'Fairly big', options: ['seven', 'eight', 'nine'] },
+        { groupName: 'Really big', options: [ 'ten', 'eleven', 'twelve' ] },
+        'thirteen'
       ]
     },
-    "one hundred",
-    "one thousand"
+    'one hundred',
+    'one thousand'
   ],
 
   actions: {
@@ -406,18 +406,18 @@ export default Ember.Controller.extend({
     },
 
     debugSelection(option) {
-      console.debug("I've selected", option);
+      console.debug('I\'ve selected', option);
     },
 
     search(term) {
-      var length = term.length;
-      return numbers.filter(str => str.length === length); // returns the numbers with the same length than the current
+      let { length } = term;
+      return numbers.filter((str) => str.length === length); // returns the numbers with the same length than the current
     },
 
     asyncSearch(term) {
       return new Ember.RSVP.Promise(function(resolve) {
         Ember.run.later(function() {
-          resolve(numbers.filter(str => str.indexOf(term) > -1));
+          resolve(numbers.filter((str) => str.indexOf(term) > -1));
         }, 1500);
       });
     },
@@ -441,6 +441,6 @@ export default Ember.Controller.extend({
   },
 
   // Flexbox issue
-  searchTypes: searchTypes,
+  searchTypes,
   searchKey: searchTypes[0]
 });

--- a/tests/dummy/app/controllers/public-pages.js
+++ b/tests/dummy/app/controllers/public-pages.js
@@ -19,7 +19,7 @@ export default Ember.Controller.extend({
 
   actions: {
     changeOptions() {
-      const index = options.indexOf(this.get('mainSelectOptions')) + 1;
+      let index = options.indexOf(this.get('mainSelectOptions')) + 1;
       if (index === options.length) {
         this.set('disabled', true);
       } else {

--- a/tests/dummy/app/controllers/public-pages/cookbook.js
+++ b/tests/dummy/app/controllers/public-pages/cookbook.js
@@ -17,14 +17,14 @@ const groupedSections = [
   {
     groupName: 'Advanced recipes',
     options: [
-      { route: 'public-pages.cookbook.navigable-select', text: 'Navigable select' },
+      { route: 'public-pages.cookbook.navigable-select', text: 'Navigable select' }
     ]
   }
 ];
 
 export default Ember.Controller.extend({
   routing: service('-routing'),
-  groupedSections: groupedSections,
+  groupedSections,
 
   currentSection: computed('routing.currentRouteName', function() {
     let currentRouteName = this.get('routing.currentRouteName');

--- a/tests/dummy/app/controllers/public-pages/docs.js
+++ b/tests/dummy/app/controllers/public-pages/docs.js
@@ -21,13 +21,13 @@ const groupedSections = [
       { route: 'public-pages.docs.the-list',         text: 'The list' },
       { route: 'public-pages.docs.the-trigger',      text: 'The trigger' },
       { route: 'public-pages.docs.the-search',       text: 'The Search' },
-      { route: 'public-pages.docs.styles',           text: 'Styles' },
+      { route: 'public-pages.docs.styles',           text: 'Styles' }
     ]
   },
   {
     groupName: 'Advanced customization',
     options: [
-      { route: 'public-pages.docs.custom-search-action', text: 'Custom search action' },
+      { route: 'public-pages.docs.custom-search-action', text: 'Custom search action' }
     ]
   },
   {
@@ -43,7 +43,7 @@ const groupedSections = [
 
 export default Ember.Controller.extend({
   routing: service('-routing'),
-  groupedSections: groupedSections,
+  groupedSections,
 
   currentSection: computed('routing.currentRouteName', function() {
     let currentRouteName = this.get('routing.currentRouteName');

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -11,12 +11,12 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        return options.beforeEach.apply(this, arguments);
+        return options.beforeEach.call(this, ...arguments);
       }
     },
 
     afterEach() {
-      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      let afterEach = options.afterEach && options.afterEach.call(this, ...arguments);
       return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });

--- a/tests/integration/components/constants.js
+++ b/tests/integration/components/constants.js
@@ -22,12 +22,12 @@ export const numbers = [
 ];
 
 export const names = [
-  "María",
-  "Søren Larsen",
-  "João",
-  "Miguel",
-  "Marta",
-  "Lisa"
+  'María',
+  'Søren Larsen',
+  'João',
+  'Miguel',
+  'Marta',
+  'Lisa'
 ];
 
 export const countries = [
@@ -37,7 +37,7 @@ export const countries = [
   { name: 'Russia',         code: 'RU', population: 146588880 },
   { name: 'Latvia',         code: 'LV', population: 1978300 },
   { name: 'Brazil',         code: 'BR', population: 204921000 },
-  { name: 'United Kingdom', code: 'GB', population: 64596752 },
+  { name: 'United Kingdom', code: 'GB', population: 64596752 }
 ];
 
 export const countriesWithDisabled = [
@@ -47,18 +47,18 @@ export const countriesWithDisabled = [
   { name: 'Russia',         code: 'RU', population: 146588880, disabled: true },
   { name: 'Latvia',         code: 'LV', population: 1978300 },
   { name: 'Brazil',         code: 'BR', population: 204921000, disabled: true },
-  { name: 'United Kingdom', code: 'GB', population: 64596752 },
+  { name: 'United Kingdom', code: 'GB', population: 64596752 }
 ];
 
 export const groupedNumbers = [
-  { groupName: "Smalls", options: ["one", "two", "three"] },
-  { groupName: "Mediums", options: ["four", "five", "six"] },
-  { groupName: "Bigs", options: [
-      { groupName: "Fairly big", options: ["seven", "eight", "nine"] },
-      { groupName: "Really big", options: [ "ten", "eleven", "twelve" ] },
-      "thirteen"
+  { groupName: 'Smalls', options: ['one', 'two', 'three'] },
+  { groupName: 'Mediums', options: ['four', 'five', 'six'] },
+  { groupName: 'Bigs', options: [
+      { groupName: 'Fairly big', options: ['seven', 'eight', 'nine'] },
+      { groupName: 'Really big', options: [ 'ten', 'eleven', 'twelve' ] },
+      'thirteen'
     ]
   },
-  "one hundred",
-  "one thousand"
+  'one hundred',
+  'one thousand'
 ];

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -21,7 +21,7 @@ test('Single-select: The top-level options list have `role=listbox` and nested l
   let $rootLevelOptionsList = $('.ember-power-select-dropdown > .ember-power-select-options');
   assert.equal($rootLevelOptionsList.attr('role'), 'listbox', 'The top-level list has `role=listbox`');
   let $nestedOptionList = $('.ember-power-select-options .ember-power-select-options');
-  assert.ok($nestedOptionList.toArray().every(l => l.attributes.role.value === 'group'), 'All the nested lists have `role=group`');
+  assert.ok($nestedOptionList.toArray().every((l) => l.attributes.role.value === 'group'), 'All the nested lists have `role=group`');
 });
 
 test('Multiple-select: The top-level options list have `role=listbox` and nested lists have `role=group`', function(assert) {
@@ -38,7 +38,7 @@ test('Multiple-select: The top-level options list have `role=listbox` and nested
   let $rootLevelOptionsList = $('.ember-power-select-dropdown > .ember-power-select-options');
   assert.equal($rootLevelOptionsList.attr('role'), 'listbox', 'The top-level list has `role=listbox`');
   let $nestedOptionList = $('.ember-power-select-options .ember-power-select-options');
-  assert.ok($nestedOptionList.toArray().every(l => l.attributes.role.value === 'group'), 'All the nested lists have `role=group`');
+  assert.ok($nestedOptionList.toArray().every((l) => l.attributes.role.value === 'group'), 'All the nested lists have `role=group`');
 });
 
 test('Single-select: All options have `role=option`', function(assert) {
@@ -52,7 +52,7 @@ test('Single-select: All options have `role=option`', function(assert) {
   `);
 
   clickTrigger();
-  assert.ok($('.ember-power-select-option').toArray().every(l => l.attributes.role.value === 'option'), 'All the options have `role=option`');
+  assert.ok($('.ember-power-select-option').toArray().every((l) => l.attributes.role.value === 'option'), 'All the options have `role=option`');
 });
 
 test('Multiple-select: All options have `role=option`', function(assert) {
@@ -66,14 +66,14 @@ test('Multiple-select: All options have `role=option`', function(assert) {
   `);
 
   clickTrigger();
-  assert.ok($('.ember-power-select-option').toArray().every(l => l.attributes.role.value === 'option'), 'All the options have `role=option`');
+  assert.ok($('.ember-power-select-option').toArray().every((l) => l.attributes.role.value === 'option'), 'All the options have `role=option`');
 });
 
 test('Single-select: The selected option has `aria-selected=true` and the rest `aria-selected=false`', function(assert) {
   assert.expect(2);
 
   this.numbers = numbers;
-  this.selected = "two";
+  this.selected = 'two';
   this.render(hbs`
     {{#power-select options=numbers selected=selected onchange=(action (mut selected)) as |option|}}
       {{option}}
@@ -355,7 +355,7 @@ test('Single-select: The trigger element correctly passes through WAI-ARIA widge
       {{option}}
     {{/power-select}}
   `);
-  const $trigger = this.$('.ember-power-select-trigger');
+  let $trigger = this.$('.ember-power-select-trigger');
 
   assert.equal($trigger.attr('aria-label'), 'ariaLabelString', 'aria-label set correctly');
   assert.equal($trigger.attr('aria-invalid'), 'true', 'aria-invalid set correctly');
@@ -379,7 +379,7 @@ test('Multiple-select: The trigger element correctly passes through WAI-ARIA wid
       {{option}}
     {{/power-select-multiple}}
   `);
-  const $trigger = this.$('.ember-power-select-trigger');
+  let $trigger = this.$('.ember-power-select-trigger');
 
   assert.equal($trigger.attr('aria-label'), 'ariaLabelString', 'aria-label set correctly');
   assert.equal($trigger.attr('aria-invalid'), 'true', 'aria-invalid set correctly');
@@ -402,7 +402,7 @@ test('Single-select: The trigger element correctly passes through WAI-ARIA relat
       {{option}}
     {{/power-select}}
   `);
-  const $trigger = this.$('.ember-power-select-trigger');
+  let $trigger = this.$('.ember-power-select-trigger');
 
   assert.equal($trigger.attr('aria-describedby'), 'ariaDescribedByString', 'aria-describedby set correctly');
   assert.equal($trigger.attr('aria-labelledby'), 'ariaLabelledByString', 'aria-required set correctly');
@@ -424,7 +424,7 @@ test('Multiple-select: The trigger element correctly passes through WAI-ARIA rel
       {{option}}
     {{/power-select-multiple}}
   `);
-  const $trigger = this.$('.ember-power-select-trigger');
+  let $trigger = this.$('.ember-power-select-trigger');
 
   assert.equal($trigger.attr('aria-describedby'), 'ariaDescribedByString', 'aria-describedby set correctly');
   assert.equal($trigger.attr('aria-labelledby'), 'ariaLabelledByString', 'aria-required set correctly');

--- a/tests/integration/components/power-select/check-horizontal-position-test.js
+++ b/tests/integration/components/power-select/check-horizontal-position-test.js
@@ -35,7 +35,6 @@ test('check horizontal position without specify property (using power-select com
   assert.equal($('.ember-basic-dropdown--left').length, 2);
 });
 
-
 test('check horizontal position without specify property (using power-select-multiple component)', function(assert) {
   assert.expect(2);
 

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -59,7 +59,7 @@ test('The search function can return an array and those options get rendered', f
   assert.expect(1);
 
   this.searchFn = function(term) {
-    return numbers.filter(str => str.indexOf(term) > -1);
+    return numbers.filter((str) => str.indexOf(term) > -1);
   };
 
   this.render(hbs`
@@ -69,7 +69,7 @@ test('The search function can return an array and those options get rendered', f
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
   assert.equal($('.ember-power-select-option').length, 7);
 });
 
@@ -79,7 +79,7 @@ test('The search function can return a promise that resolves to an array and tho
   this.searchFn = function(term) {
     return new RSVP.Promise(function(resolve) {
       Ember.run.later(function() {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 100);
     });
   };
@@ -91,7 +91,7 @@ test('The search function can return a promise that resolves to an array and tho
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
 
   return wait().then(function() {
     assert.equal($('.ember-power-select-option').length, 7);
@@ -104,7 +104,7 @@ test('While the async search is being performed the "Type to search" dissapears 
   this.searchFn = function(term) {
     return new RSVP.Promise(function(resolve) {
       Ember.run.later(function() {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 100);
     });
   };
@@ -117,7 +117,7 @@ test('While the async search is being performed the "Type to search" dissapears 
 
   clickTrigger();
   assert.ok(/Type to search/.test($('.ember-power-select-dropdown').text()), 'The type to search message is displayed');
-  typeInSearch("teen");
+  typeInSearch('teen');
   assert.ok(!/Type to search/.test($('.ember-power-select-dropdown').text()), 'The type to search message dissapeared');
   assert.ok(/Loading options\.\.\./.test($('.ember-power-select-dropdown').text()), '"Loading options..." message appears');
   return wait();
@@ -128,7 +128,9 @@ test('When the search resolves to an empty array then the "No results found" mes
 
   this.searchFn = function() {
     return new RSVP.Promise(function(resolve) {
-      Ember.run.later(function() { resolve([]); }, 10);
+      Ember.run.later(function() {
+        resolve([]);
+      }, 10);
     });
   };
 
@@ -139,7 +141,7 @@ test('When the search resolves to an empty array then the "No results found" mes
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
   return wait().then(function() {
     assert.ok(/No results found/.test($('.ember-power-select-option').text()), 'The default "No results" message renders');
   });
@@ -150,7 +152,9 @@ test('When the search resolves to an empty array then the custom "No results" me
 
   this.searchFn = function() {
     return new RSVP.Promise(function(resolve) {
-      Ember.run.later(function() { resolve([]); }, 10);
+      Ember.run.later(function() {
+        resolve([]);
+      }, 10);
     });
   };
 
@@ -161,7 +165,7 @@ test('When the search resolves to an empty array then the custom "No results" me
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
   return wait().then(function() {
     assert.ok(/Meec\. Try again/.test($('.ember-power-select-option').text()), 'The customized "No results" message renders');
   });
@@ -172,7 +176,9 @@ test('When the search resolves to an empty array then the custom alternate block
 
   this.searchFn = function() {
     return new RSVP.Promise(function(resolve) {
-      Ember.run.later(function() { resolve([]); }, 10);
+      Ember.run.later(function() {
+        resolve([]);
+      }, 10);
     });
   };
 
@@ -185,19 +191,21 @@ test('When the search resolves to an empty array then the custom alternate block
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
   return wait().then(function() {
     assert.equal($('.ember-power-select-dropdown .foo-bar').length, 1, 'The alternate block message gets rendered');
   });
 });
 
 test('When one search is fired before the previous one resolved, the "Loading" continues until the 2nd is resolved', function(assert) {
-  var done = assert.async();
+  let done = assert.async();
   assert.expect(2);
 
   this.searchFn = function() {
     return new RSVP.Promise(function(resolve) {
-      Ember.run.later(function() { resolve(numbers); }, 100);
+      Ember.run.later(function() {
+        resolve([]);
+      }, 100);
     });
   };
 
@@ -207,10 +215,10 @@ test('When one search is fired before the previous one resolved, the "Loading" c
     {{/power-select}}
   `);
   clickTrigger();
-  typeInSearch("tee");
+  typeInSearch('tee');
 
   setTimeout(function() {
-    typeInSearch("teen");
+    typeInSearch('teen');
   }, 50);
 
   setTimeout(function() {
@@ -227,7 +235,7 @@ test('On an empty select, when the search resolves, the first element is highlig
   this.searchFn = function(term) {
     return new RSVP.Promise(function(resolve) {
       Ember.run.later(function() {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 100);
     });
   };
@@ -239,7 +247,7 @@ test('On an empty select, when the search resolves, the first element is highlig
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
 
   return wait().then(function() {
     assert.equal($('.ember-power-select-option:eq(0)').attr('aria-current'), 'true', 'The first result is highlighted');
@@ -254,7 +262,7 @@ test('On an select with a selected value, if after a search this value is not am
   this.searchFn = function(term) {
     return new RSVP.Promise(function(resolve) {
       Ember.run.later(function() {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 100);
     });
   };
@@ -267,7 +275,7 @@ test('On an select with a selected value, if after a search this value is not am
 
   clickTrigger();
   assert.equal($('.ember-power-select-option:eq(2)').attr('aria-current'), 'true', 'The 3rd result is highlighted');
-  typeInSearch("teen");
+  typeInSearch('teen');
 
   return wait().then(function() {
     assert.equal($('.ember-power-select-option:eq(0)').attr('aria-current'), 'true', 'The first result is highlighted');
@@ -277,7 +285,7 @@ test('On an select with a selected value, if after a search this value is not am
 test('Closing a component with a custom search cleans the search box and the results list', function(assert) {
   assert.expect(5);
   this.searchFn = function(term) {
-    return RSVP.resolve(numbers.filter(str => str.indexOf(term) > -1));
+    return RSVP.resolve(numbers.filter((str) => str.indexOf(term) > -1));
   };
 
   this.render(hbs`
@@ -288,7 +296,7 @@ test('Closing a component with a custom search cleans the search box and the res
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
   assert.equal($('.ember-power-select-option').length, 7, 'Results are filtered');
   assert.equal($('.ember-power-select-search input').val(), 'teen');
   Ember.run(() => {
@@ -308,7 +316,7 @@ test('When received both options and search, those options are shown when the dr
   this.searchFn = (term) => {
     return new RSVP.Promise(function(resolve) {
       Ember.run.later(function() {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 50);
     });
   };
@@ -322,7 +330,7 @@ test('When received both options and search, those options are shown when the dr
 
   clickTrigger();
   assert.equal($('.ember-power-select-option').length, 20, 'All the options are shown');
-  typeInSearch("teen");
+  typeInSearch('teen');
   assert.equal($('.ember-power-select-option').length, 21, 'All the options are shown and also the loading message');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Loading options...');
   return wait().then(function() {
@@ -336,7 +344,7 @@ test('Don\'t return from the search action and update the options instead also w
   this.selectedOptions = numbers;
   this.searchFn = (term) => {
     Ember.run.later(() => {
-      this.set('selectedOptions', numbers.filter(str => str.indexOf(term) > -1));
+      this.set('selectedOptions', numbers.filter((str) => str.indexOf(term) > -1));
     }, 20);
   };
 
@@ -349,7 +357,7 @@ test('Don\'t return from the search action and update the options instead also w
 
   clickTrigger();
   assert.equal($('.ember-power-select-option').length, 20, 'All the options are shown');
-  typeInSearch("teen");
+  typeInSearch('teen');
 
   return wait().then(function() {
     assert.equal($('.ember-power-select-option').length, 7);
@@ -366,7 +374,7 @@ test('Setting the options to a promise from the custom search function works (an
     searchCalls++;
     let promise = new RSVP.Promise(function(resolve) {
       Ember.run.later(() => {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 30);
     });
     this.set('selectedOptions', promise);
@@ -381,14 +389,14 @@ test('Setting the options to a promise from the custom search function works (an
 
   clickTrigger();
   assert.equal($('.ember-power-select-option').length, 20, 'All the options are shown');
-  typeInSearch("teen");
+  typeInSearch('teen');
   assert.equal($('.ember-power-select-option').length, 21, 'All the options are shown plus the loading message');
   assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Loading options...', 'The loading message is shown');
 
   setTimeout(function() {
     assert.equal(searchCalls, 1, 'The search was called only once');
     assert.equal($('.ember-power-select-option').length, 7);
-    typeInSearch("seven");
+    typeInSearch('seven');
     assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Loading options...', 'The loading message is shown');
     assert.equal($('.ember-power-select-option').length, 8);
   }, 40);
@@ -397,7 +405,7 @@ test('Setting the options to a promise from the custom search function works (an
     assert.equal(searchCalls, 2, 'The search was called only twice');
     assert.equal($('.ember-power-select-option').length, 8);
     assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Loading options...', 'It is still searching the previous result');
-    typeInSearch("four");
+    typeInSearch('four');
     assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Loading options...', 'The loading message is shown');
     assert.equal($('.ember-power-select-option').length, 8);
   }, 60);
@@ -416,7 +424,7 @@ test('If you delete the last char of the input before the previous promise resol
   this.searchFn = function(term) {
     return new RSVP.Promise(function(resolve) {
       setTimeout(function() {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 100);
     });
   };
@@ -428,12 +436,12 @@ test('If you delete the last char of the input before the previous promise resol
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
   setTimeout(function() {
-    typeInSearch("t");
+    typeInSearch('t');
   }, 150);
   setTimeout(function() {
-    typeInSearch("");
+    typeInSearch('');
   }, 200);
   setTimeout(function() {
     assert.equal($('.ember-power-select-option').length, numbers.length, 'All the options are displayed after clearing the search');
@@ -449,7 +457,7 @@ test('The yielded search term in single selects is updated only when the async s
   this.searchFn = function(term) {
     return new RSVP.Promise(function(resolve) {
       setTimeout(function() {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 100);
     });
   };
@@ -461,10 +469,10 @@ test('The yielded search term in single selects is updated only when the async s
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
   setTimeout(function() {
     assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'thirteen:teen', 'The results and the searchTerm have updated');
-    typeInSearch("four");
+    typeInSearch('four');
     assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Loading options...', 'There is a search going on');
     assert.equal($('.ember-power-select-option:eq(1)').text().trim(), 'thirteen:teen', 'The results and the searchTerm are still the same because the search has not finished yet');
     done();
@@ -478,7 +486,7 @@ test('The yielded search term in multiple selects is updated only when the async
   this.searchFn = function(term) {
     return new RSVP.Promise(function(resolve) {
       setTimeout(function() {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 100);
     });
   };
@@ -490,10 +498,10 @@ test('The yielded search term in multiple selects is updated only when the async
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
   setTimeout(function() {
     assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'thirteen:teen', 'The results and the searchTerm have updated');
-    typeInSearch("four");
+    typeInSearch('four');
     assert.equal($('.ember-power-select-option:eq(0)').text().trim(), 'Loading options...', 'There is a search going on');
     assert.equal($('.ember-power-select-option:eq(1)').text().trim(), 'thirteen:teen', 'The results and the searchTerm are still the same because the search has not finished yet');
     done();
@@ -509,7 +517,7 @@ test('BUGFIX: Destroy a component why an async search is pending does not cause 
   this.searchFn = function(term) {
     return new RSVP.Promise(function(resolve) {
       setTimeout(function() {
-        resolve(numbers.filter(str => str.indexOf(term) > -1));
+        resolve(numbers.filter((str) => str.indexOf(term) > -1));
       }, 200);
     });
   };
@@ -523,7 +531,7 @@ test('BUGFIX: Destroy a component why an async search is pending does not cause 
   `);
 
   clickTrigger();
-  typeInSearch("teen");
+  typeInSearch('teen');
   this.set('visible', false);
   setTimeout(() => {
     done();
@@ -535,7 +543,7 @@ test('BUGFIX: When the given options are a promise and a search function is prov
   this.numbersPromise = RSVP.Promise.resolve(numbers);
 
   this.searchFn = function(term) {
-    return numbers.filter(str => str.indexOf(term) > -1);
+    return numbers.filter((str) => str.indexOf(term) > -1);
   };
 
   this.render(hbs`
@@ -546,9 +554,9 @@ test('BUGFIX: When the given options are a promise and a search function is prov
 
   clickTrigger();
   assert.equal($('.ember-power-select-option').length, 20, 'There is 20 options');
-  typeInSearch("teen");
+  typeInSearch('teen');
   assert.equal($('.ember-power-select-option').length, 7, 'There is 7 options');
-  typeInSearch("");
+  typeInSearch('');
   assert.equal($('.ember-power-select-option').length, 20, 'There is 20 options again§');
 });
 


### PR DESCRIPTION
This adds [ember-suave](https://github.com/DockYard/ember-suave) which is based on [jscs](http://jscs.info)

Most of the changes are trivial such as using single quotes vs. double quotes.  However, others enforce ES2015 code style, which helps make it second nature.

When a 'rule' is broken, it will show up as a test failure with a message and line number.

I also found that creating exceptions for rules was a straightforward process.

FYI - These are the rules I made changes for in ember-power-select:

`disallowConstOutsideModuleScope: `const` should only be used in module scope (not inside functions/blocks)`

`requireParenthesesAroundArrowParam: Wrap arrow function expressions in parentheses`

`requireSpaceBeforeBlockStatements: One (or more) spaces required before opening brace for block expressions`

`disallowTrailingComma: Extra comma following the final element of an array or object literal`

`validateQuoteMarks: Invalid quote mark found`

`requireObjectDestructuring: Property assignments should use destructuring`

`requireEnhancedObjectLiterals: Property assignment should use enhanced object literal function`

`requireSpread: Illegal use of apply method. Use the spread operator instead` 

`equireBlocksOnNewline: Missing newline after opening curly brace`