### PR TITLE
[BUGFIX] The opening event being prevented shouldn't prevent the comp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Master
 
+- [BUGFIX] Calling `preventDefault` on the events that trigger an open or a close no longer prevent
+  the component's default behaviour. Only `return false` can do that.
+
+# 0.10.5
 - [BUGFIX] Depend on EBS ^0.11.5 to fix issue with touch devices.
 - [BUGFIX] Depend on EBS ^0.11.4 to fix some issues with IE9
 - [ENHANCEMENT] If a group is disabled, its options (or the options of nested groups) are automatically

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -267,23 +267,17 @@ export default Ember.Component.extend({
     },
 
     handleOpen(dropdown, e) {
-      const action = this.get('onopen');
-      if (action) {
-        let returnValue = action(this.get('publicAPI'), e);
-        if (returnValue === false || (e && e.defaultPrevented)) {
-          return false;
-        }
+      let action = this.get('onopen');
+      if (action && action(this.get('publicAPI'), e) === false) {
+        return false;
       }
       if (e) { this.set('openingEvent', e); }
     },
 
     handleClose(dropdown, e) {
-      const action = this.get('onclose');
-      if (action) {
-        let returnValue = action(this.get('publicAPI'), e);
-        if (returnValue === false || (e && e.defaultPrevented)) {
-          return false;
-        }
+      let action = this.get('onclose');
+      if (action && action(this.get('publicAPI'), e) === false) {
+        return false;
       }
       if (e) { this.set('openingEvent', null); }
       this.send('highlight', dropdown, null, e);


### PR DESCRIPTION
…onents' behaviour.

A while ago a refactor was made to avoid this pattern, and use the `return false` pattern
instead. There was at least one place where the old thing continued to work.