### PR TITLE
DOCS - Add "searchMessage" parameter description to api-reference table

### DIFF
--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -113,6 +113,11 @@
       <td>Message shown when a search doesn't find any matching result.</td>
     </tr>
     <tr>
+      <td>searchMessage</td>
+      <td><code>string</code></td>
+      <td>Message shown in options list when no search has been entered and there are no options.</td>
+    </tr>
+    <tr>
       <td>triggerComponent</td>
       <td><code>string</code></td>
       <td>The component to render instead of the default one inside the trigger</td>


### PR DESCRIPTION
I had to dig into the code to find this parameter. Figured I'd add it to the reference.