### PR TITLE
Use just regular inputs

### DIFF
--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../../templates/components/power-select-multiple/trigger';
-import updateInput from '../../utils/update-input-value';
 
 const { computed, get, isBlank, run, inject: { service } } = Ember;
 const { htmlSafe } = Ember.String;
@@ -41,9 +40,6 @@ export default Ember.Component.extend({
     this._super(...arguments);
     if (oldAttrs.select.isOpen && !newAttrs.select.isOpen) {
       this.handleClose();
-    }
-    if (newAttrs.searchText !== undefined && newAttrs.searchText !== null) {
-      run.scheduleOnce('afterRender', this, this.updateInput, newAttrs.searchText);
     }
   },
 
@@ -102,10 +98,6 @@ export default Ember.Component.extend({
   // Methods
   handleClose() {
     run.scheduleOnce('actions', null, this.get('select.actions.search'), '');
-  },
-
-  updateInput(value) {
-    updateInput(this.input, value);
   },
 
   selectedObject(list, index) {

--- a/addon/components/power-select/before-options.js
+++ b/addon/components/power-select/before-options.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../../templates/components/power-select/before-options';
-import updateInput from '../../utils/update-input-value';
 
 const { run } = Ember;
 
@@ -9,13 +8,6 @@ export default Ember.Component.extend({
   layout,
 
   // Lifecycle hooks
-  didReceiveAttrs({ oldAttrs, newAttrs }) {
-    this._super(...arguments);
-    if (newAttrs.searchText !== undefined && newAttrs.searchText !== null) {
-      run.scheduleOnce('afterRender', this, this.updateInput, newAttrs.searchText);
-    }
-  },
-
   didInsertElement() {
     this._super(...arguments);
     this.focusInput();
@@ -48,10 +40,6 @@ export default Ember.Component.extend({
   },
 
   // Methods
-  updateInput(value) {
-    updateInput(this.input, value);
-  },
-
   focusInput() {
     this.input = self.document.querySelector('.ember-power-select-search-input');
     if (this.input) {

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -19,6 +19,7 @@
   {{#if searchEnabled}}
     <input type="search" class="ember-power-select-trigger-multiple-input {{elementId}}-input"
       tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+      value={{searchText}}
       aria-controls={{listboxId}}
       style={{triggerMultipleInputStyle}}
       placeholder={{maybePlaceholder}}

--- a/addon/templates/components/power-select/before-options.hbs
+++ b/addon/templates/components/power-select/before-options.hbs
@@ -4,6 +4,7 @@
       autocorrect="off" autocapitalize="off"
       spellcheck="false" role="combobox"
       class="ember-power-select-search-input"
+      value={{searchText}}
       aria-controls={{listboxId}}
       placeholder={{searchPlaceholder}}
       oninput={{handleInput}}

--- a/addon/utils/update-input-value.js
+++ b/addon/utils/update-input-value.js
@@ -1,4 +1,0 @@
-export default function updateInputValue(input, value) {
-  if (!input || input.value === value) { return; }
-  input.value = value;
-}


### PR DESCRIPTION
Now that the component is 2.3.1+, it can just use a regular `<input value={{}}`
and it will just work.