### PR TITLE
[BUG] Multi-select disable state

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-basic-dropdown": "^0.12.0-beta.16",
+    "ember-basic-dropdown": "^0.12.0-beta.17",
     "ember-text-measurer": "^0.3.0",
     "ember-truth-helpers": "^1.2.0"
   },

--- a/tests/integration/components/power-select/disabled-test.js
+++ b/tests/integration/components/power-select/disabled-test.js
@@ -97,6 +97,26 @@ test('When passed `disabled=true`, the options cannot be removed', function(asse
   assert.equal(this.$('.ember-power-select-multiple-remove-btn').length, 0, 'There is no button to remove selected elements');
 });
 
+test('Multiple select: When passed `disabled=prop`, enabling and disabling that property changes the component', function(assert) {
+  assert.expect(2);
+
+  this.numbers = numbers;
+  this.selectedNumbers = [numbers[2], numbers[4]];
+  this.set('shouldBeDisabled', true);
+
+  this.render(hbs`
+    {{#power-select-multiple selected=selectedNumbers onchange=(action (mut foo)) options=numbers disabled=shouldBeDisabled as |option|}}
+      {{option}}
+    {{/power-select-multiple}}
+  `);
+
+  let $trigger = this.$('.ember-power-select-trigger');
+  assert.equal($trigger.attr('aria-disabled'), 'true', 'The trigger has `aria-disabled=true`');
+
+  this.set('shouldBeDisabled', false);
+  assert.ok(['false', undefined].indexOf($trigger.attr('aria-expanded')), 'The trigger is not disabled');
+});
+
 test('BUGFIX: When after a search the only result is a disabled element, it isn\'t highlighted and cannot be selected', function(assert) {
   assert.expect(3);
   this.countriesWithDisabled = countriesWithDisabled;


### PR DESCRIPTION
Hey @cibernox.
Disable state is not working properly if it depends of some property.
Here is reproducing of this bug

P.S. Sorry for messing in docs. I will remove it, just reproducing this bug.