### PR TITLE
Allow customizing the search message component

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -58,6 +58,7 @@ export default Component.extend({
   optionsComponent: fallbackIfUndefined('power-select/options'),
   selectedItemComponent: fallbackIfUndefined(null),
   triggerComponent: fallbackIfUndefined('power-select/trigger'),
+  searchMessageComponent: fallbackIfUndefined('power-select/search-message'),
 
   // Private state
   expirableSearchText: '',

--- a/addon/components/power-select/search-message.js
+++ b/addon/components/power-select/search-message.js
@@ -1,0 +1,7 @@
+import Component from 'ember-component';
+import layout from '../../templates/components/power-select/search-message';
+
+export default Component.extend({
+  layout: layout,
+  tagName: ''
+});

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -56,11 +56,10 @@
       searchPlaceholder=(readonly searchPlaceholder)
       select=(readonly publicAPI)}}
     {{#if mustShowSearchMessage}}
-      <ul class="ember-power-select-options" role="listbox">
-        <li class="ember-power-select-option ember-power-select-option--search-message" role="option">
-          {{searchMessage}}
-        </li>
-      </ul>
+      {{component searchMessageComponent
+        searchMessage=(readonly searchMessage)
+        select=(readonly publicAPI)
+      }}
     {{else if mustShowNoMessages}}
       {{#if (hasBlock "inverse")}}
         {{yield to="inverse"}}

--- a/addon/templates/components/power-select/search-message.hbs
+++ b/addon/templates/components/power-select/search-message.hbs
@@ -1,0 +1,5 @@
+<ul class="ember-power-select-options" role="listbox">
+  <li class="ember-power-select-option ember-power-select-option--search-message" role="option">
+    {{searchMessage}}
+  </li>
+</ul>

--- a/app/components/power-select/search-message.js
+++ b/app/components/power-select/search-message.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-power-select/components/power-select/search-message';

--- a/tests/dummy/app/templates/components/custom-search-message.hbs
+++ b/tests/dummy/app/templates/components/custom-search-message.hbs
@@ -1,0 +1,1 @@
+<p id="custom-search-message-p-tag">Customized seach message!</p>

--- a/tests/dummy/app/templates/public-pages/docs/architecture.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/architecture.hbs
@@ -53,13 +53,14 @@
 </p>
 
 <p>
-  At the moment there is a total of 5 "holes" you can fill.
+  At the moment there is a total of 7 "holes" you can fill.
   <ul>
     <li><code>triggerComponent</code>: Replaces the entire trigger markup and logic.</li>
     <li><code>selectedItemComponent</code>: Replaces only the selected option(s) inside the trigger. By default it just yields the block given to the component.</li>
     <li><code>beforeOptionsComponent</code>: Contains any markup and logic displayed before the list of options (by default, a search box)</li>
     <li><code>optionsComponent</code>: Contains the list of options. The content of each option is the block given to the component.</li>
     <li><code>afterOptionsComponent</code>: Contains any markup and logic displayed after the list of options. Unused by default.</li>
+    <li><code>searchMessageComponent</code>: Displays the "Type to search" message. By default it just displays the <code>searchMessage</code>.</li>
   </ul>
 </p>
 

--- a/tests/integration/components/power-select/customization-with-compoments-test.js
+++ b/tests/integration/components/power-select/customization-with-compoments-test.js
@@ -149,3 +149,18 @@ test('the `triggerComponent` receives the `onFocus` action that triggers the `on
 
   this.$('#focusable-input')[0].focus();
 });
+
+test('the search message can be customized passing `searchMessageComponent`', function(assert) {
+  assert.expect(1);
+
+  this.searchFn = function() {};
+
+  this.render(hbs`
+    {{#power-select search=searchFn searchMessageComponent="custom-search-message" onchange=(action (mut foo)) as |country|}}
+      {{country.name}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  assert.equal($('.ember-power-select-dropdown #custom-search-message-p-tag').length, 1, 'The custom component is rendered instead of the usual message');
+});


### PR DESCRIPTION
Adds `noMatchesMessageComponent` and `searchMessageComponent` options to customize the no-matches and search message components respectively.