### PR TITLE
Immutable api

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -201,7 +201,7 @@ export default Component.extend({
   // Actions
   actions: {
     registerAPI(dropdown) {
-      let publicAPI = assign({}, dropdown, this.get('publicAPI'));
+      let publicAPI = assign({}, this.get('publicAPI'), dropdown);
       publicAPI.actions = assign({}, dropdown.actions, this._publicAPIActions);
       this.setProperties({
         publicAPI: publicAPI,
@@ -209,7 +209,7 @@ export default Component.extend({
       });
       let action = this.get('registerAPI');
       if (action) {
-        action(dropdown);
+        action(publicAPI);
       }
     },
 
@@ -526,7 +526,8 @@ export default Component.extend({
     let newState = set(this, 'publicAPI', assign({}, this.get('publicAPI'), changes));
     let registerAPI = this.get('registerAPI');
     if (registerAPI) {
-      scheduleOnce('actions', this, 'registerAPI', newState);
+      registerAPI(newState);
+      // scheduleOnce('actions', this, 'registerAPI', newState);
     }
     return newState;
   }

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -110,8 +110,9 @@ export default Component.extend({
   willDestroy() {
     this._super(...arguments);
     this.activeSearch = this.activeSelectedPromise = this.activeOptionsPromise = null;
-    if (this.publicAPI.options && this.publicAPI.options.removeObserver) {
-      this.publicAPI.options.removeObserver('[]', this, this._updateOptionsAndResults);
+    let publicAPI = this.get('publicAPI');
+    if (publicAPI.options && publicAPI.options.removeObserver) {
+      publicAPI.options.removeObserver('[]', this, this._updateOptionsAndResults);
     }
     cancel(this.expirableSearchDebounceId);
   },
@@ -368,7 +369,7 @@ export default Component.extend({
         selection.addObserver('[]', this, this._updateSelectedArray);
       }
       this._updateSelectedArray(selection);
-    } else if (selection !== this.publicAPI.selected) {
+    } else if (selection !== this.get('publicAPI').selected) {
       this.updateState({ selected: selection, highlighted: selection });
     }
   },
@@ -386,10 +387,11 @@ export default Component.extend({
   _updateOptionsAndResults(opts) {
     if (get(this, 'isDestroyed')) { return; }
     let options = toPlainArray(opts);
+    let publicAPI;
     if (this.get('search')) { // external search
-      this.updateState({ options, results: options, resultsCount: countOptions(options), loading: false });
+      publicAPI = this.updateState({ options, results: options, resultsCount: countOptions(options), loading: false });
     } else { // filter
-      let publicAPI = this.get('publicAPI');
+      publicAPI = this.get('publicAPI');
       let results = isBlank(publicAPI.searchText) ? options : this.filter(options, publicAPI.searchText);
       publicAPI = this.updateState({ results, options, resultsCount: countOptions(results), loading: false });
     }

--- a/addon/components/power-select/before-options.js
+++ b/addon/components/power-select/before-options.js
@@ -19,7 +19,7 @@ export default Component.extend({
   willDestroyElement() {
     this._super(...arguments);
     if (this.get('searchEnabled')) {
-      this.get('select').actions.search('');
+      scheduleOnce('actions', this, this.get('select').actions.search, '');
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-basic-dropdown": "^0.12.0",
+    "ember-basic-dropdown": "^0.13.0-beta.0",
     "ember-text-measurer": "^0.3.0",
     "ember-truth-helpers": "^1.2.0"
   },

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -102,7 +102,7 @@ test('Multiple-select: The selected options have `aria-selected=true` and the re
   assert.equal($('.ember-power-select-option[aria-selected="false"]').length, numbers.length - 2, 'All other options have aria-selected=false');
 });
 
-test('Single-select: The highlighted option has `aria-current=true` and the rest `aria-current=false`', function(assert) {
+test('Single-select: The highlighted option has `aria-current=true` and the rest not have `aria-current`', function(assert) {
   assert.expect(4);
 
   this.numbers = numbers;

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -545,7 +545,6 @@ test('The search action of multiple selects has the searchText set to the up-to-
 });
 
 test('The single component invokes the `registerAPI` action with the public API object', function(assert) {
-  assert.expect(20);
   this.numbers = numbers;
   this.storeAPI = function(select) {
     assertPublicAPIShape(assert, select);
@@ -558,7 +557,6 @@ test('The single component invokes the `registerAPI` action with the public API 
 });
 
 test('The multiple component invokes the `registerAPI` action with the public API object', function(assert) {
-  assert.expect(20);
   this.numbers = numbers;
   this.storeAPI = function(select) {
     assertPublicAPIShape(assert, select);


### PR DESCRIPTION
Following https://github.com/cibernox/ember-basic-dropdown/pull/120, this also makes the public API of this component an immutable object that gets replaced whenever the state of the component changes.

This will allow to get rid of observers in sub-components and replace them with `didReceiveAttrs`.
This can also enable fancy things like time-travel debugging, although for that to be fully reliable I'd need to move more properties that right now are internal into the public API, even if they are underscored.