### PR TITLE
Check if app.options is available

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = {
     if (!app.__emberPowerSelectIncludedInvoked) {
       app.__emberPowerSelectIncludedInvoked = true;
 
-      var addonConfig = app.options['ember-power-select'] || {};
+      var options = typeof app.options === 'object' ? app.options : {};
+      var addonConfig = options['ember-power-select'] || {};
 
       // Since ember-power-select styles already `@import` styles of ember-basic-dropdown,
       // this flag tells to ember-basic-dropdown to skip importing its styles provided


### PR DESCRIPTION
In an engine, the addon errors because `app.options` is `undefined`. This PR guards against this by checking if `app.options` is an object.