### PR TITLE
Add keyup

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -308,6 +308,14 @@ export default Component.extend({
       return this._routeKeydown(e);
     },
 
+    // keyups handled by inputs inside the component
+    onKeyup(e) {
+      let onkeyup = this.get('onkeyup');
+      if (onkeyup) {
+        onkeyup(this.get('publicAPI'), e);
+      }
+    },
+
     scrollTo(option /*, e */) {
       if (!self.document || !option) { return; }
       let optionsList = self.document.querySelector('.ember-power-select-options');

--- a/addon/components/power-select/before-options.js
+++ b/addon/components/power-select/before-options.js
@@ -34,6 +34,10 @@ export default Component.extend({
         let select = this.get('select');
         select.actions.close(e);
       }
+    },
+    onKeyup(e) {
+      let onKeyup = this.get('onKeyup');
+      onKeyup(e);
     }
   },
 

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -50,6 +50,7 @@
       listboxId=(readonly optionsId)
       onInput=(action "onInput")
       onKeydown=(action "onKeydown")
+      onKeyup=(action "onKeyup")
       searchEnabled=(readonly searchEnabled)
       onFocus=(action "onFocus")
       onBlur=(action "deactivate")

--- a/addon/templates/components/power-select/before-options.hbs
+++ b/addon/templates/components/power-select/before-options.hbs
@@ -10,6 +10,7 @@
       oninput={{onInput}}
       onfocus={{onFocus}}
       onblur={{onBlur}}
-      onkeydown={{action "onKeydown"}}>
+      onkeydown={{action "onKeydown"}}
+      onkeyup={{action "onKeyup"}}>
   </div>
 {{/if}}

--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -32,9 +32,9 @@ export function nativeMouseUp(selectorOrDomElement, options) {
   fireNativeMouseEvent('mouseup', selectorOrDomElement, options);
 }
 
-export function triggerKeydown(domElement, k) {
+function triggerKeyEvent(type, domElement, k) {
   let oEvent = document.createEvent('Events');
-  oEvent.initEvent('keydown', true, true);
+  oEvent.initEvent(type, true, true);
   $.extend(oEvent, {
     view: window,
     ctrlKey: false,
@@ -49,21 +49,12 @@ export function triggerKeydown(domElement, k) {
   });
 }
 
+export function triggerKeydown(domElement, k) {
+  triggerKeyEvent('keydown', domElement, k);
+}
+
 export function triggerKeyup(domElement, k) {
-  let oEvent = document.createEvent('Events');
-  oEvent.initEvent('keyup', true, true);
-  $.extend(oEvent, {
-    view: window,
-    ctrlKey: false,
-    altKey: false,
-    shiftKey: false,
-    metaKey: false,
-    keyCode: k,
-    charCode: k
-  });
-  run(() => {
-    domElement.dispatchEvent(oEvent);
-  });
+  triggerKeyEvent('keyup', domElement, k);
 }
 
 export function typeInSearch(text) {

--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -49,6 +49,23 @@ export function triggerKeydown(domElement, k) {
   });
 }
 
+export function triggerKeyup(domElement, k) {
+  let oEvent = document.createEvent('Events');
+  oEvent.initEvent('keyup', true, true);
+  $.extend(oEvent, {
+    view: window,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+    keyCode: k,
+    charCode: k
+  });
+  run(() => {
+    domElement.dispatchEvent(oEvent);
+  });
+}
+
 export function typeInSearch(text) {
   run(() => {
     typeText('.ember-power-select-search-input, .ember-power-select-search input, .ember-power-select-trigger-multiple-input, input[type="search"]', text);

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -52,6 +52,11 @@
       <td>The function to be invoked when the user presses a key down inside the component or the inputs inside it when focused</td>
     </tr>
     <tr>
+      <td>onkeyup</td>
+      <td><code>function</code></td>
+      <td>The function to be invoked when the user releases a key within the search input</td>
+    </tr>
+    <tr>
       <td>onfocus</td>
       <td><code>function</code></td>
       <td>The function to be invoked when component gains the focus</td>

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -49,7 +49,7 @@
     <tr>
       <td>onkeydown</td>
       <td><code>function</code></td>
-      <td>The function to be invoked when the user presses a key being the component or the inputs inside it focused</td>
+      <td>The function to be invoked when the user presses a key down inside the component or the inputs inside it when focused</td>
     </tr>
     <tr>
       <td>onfocus</td>

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { triggerKeydown, clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
+import { triggerKeydown, triggerKeyup, clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
 import { numbers, countries, countriesWithDisabled, groupedNumbers, groupedNumbersWithDisabled } from '../constants';
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Keyboard control)', {
@@ -299,6 +299,31 @@ test('Pressing ESC while the component is opened closes it and focuses the trigg
   triggerKeydown($('.ember-power-select-trigger')[0], 27);
   assert.equal($('.ember-power-select-dropdown').length, 0, 'The select is closed');
   assert.ok($('.ember-power-select-trigger').get(0) === document.activeElement, 'The select is focused');
+});
+
+test('In single-mode, when the user presses a key being the search input focused the passes `onkeyup` action is invoked with the public API and the event', function(assert) {
+  assert.expect(7);
+
+  this.numbers = numbers;
+  this.selected = null;
+  this.handleKeyup = (select, e) => {
+    assert.ok(select.hasOwnProperty('isOpen'), 'The yieded object has the `isOpen` key');
+    assert.ok(select.actions.open, 'The yieded object has an `actions.open` key');
+    assert.ok(select.actions.close, 'The yieded object has an `actions.close` key');
+    assert.ok(select.actions.select, 'The yieded object has an `actions.select` key');
+    assert.ok(select.actions.highlight, 'The yieded object has an `actions.highlight` key');
+    assert.ok(select.actions.search, 'The yieded object has an `actions.search` key');
+    assert.equal(e.keyCode, 13, 'The event is received as second argument');
+  };
+
+  this.render(hbs`
+    {{#power-select options=numbers selected=selected onchange=(action (mut foo)) onkeyup=(action handleKeyup) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  triggerKeyup($('.ember-power-select-search-input')[0], 13);
 });
 
 test('In single-mode, when the user presses a key being the search input focused the passes `onkeydown` action is invoked with the public API and the event', function(assert) {


### PR DESCRIPTION
Adds support for keyup handler for the search input if you're interested.

We came across a need for it (or we could be overlooking something). Currently, we've setup a higher level event listener, but it would be great if a public API existed, so this PR makes that API.

Thank you for ember-power-select; it has really helped us a lot!