### PR TITLE
Check for isDestroyed when closing after choose action

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -278,7 +278,7 @@ export default Component.extend({
       }
       let publicAPI = this.get('publicAPI');
       publicAPI.actions.select(this.get('buildSelection')(selected, publicAPI), e);
-      if (this.get('closeOnSelect')) {
+      if (!this.get('isDestroyed') && this.get('closeOnSelect')) {
         publicAPI.actions.close(e);
         return false;
       }


### PR DESCRIPTION
Fixes `vendor.js:29225 Uncaught Error: Assertion Failed: calling set on destroyed object: <frontend@component:power-select-search::ember1935>.placeholder = [object String]` error when closing after choosing an option with `power-select`.

Can provide a repro repo if you'd like but basically, it started with a controller that had a property like `showSomething` along with the following template:

```
{{#if showSomething}}
  {{#power-select}}...
{{else}}
   {{#power-select}}...
{{/if}}
```

While inside the first half of the `if` statement and choosing an option, the `else` is rendered and the error above is thrown.

This PR fixes that by checking for `isDestroyed` before actually closing the component via `publicAPI.actions.close(e);`.