### PR TITLE
[BUGFIX] Ensure scrollTo targets the proper list of options if another select is being animated out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Master
 
+- [BUGFIX] Ensure scrolling to the selected option works if another select is still on the page being animated out.
 - [BUGFIX] A disabled select won't have tabindex at all (it used to have -1)
 - [BUGFIX] If `tabindex=false`, the component won't have tabindex (it used to have -1)
 

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -310,9 +310,10 @@ export default Component.extend({
 
     scrollTo(option /*, e */) {
       if (!self.document || !option) { return; }
-      let optionsList = self.document.querySelector('.ember-power-select-options');
+      let publicAPI = this.get('publicAPI');
+      let optionsList = self.document.getElementById('ember-power-select-options-' + publicAPI.uniqueId);
       if (!optionsList) { return; }
-      let index = indexOfOption(this.get('publicAPI').results, option);
+      let index = indexOfOption(publicAPI.results, option);
       if (index === -1) { return; }
       let optionElement = optionsList.querySelectorAll('[data-option-index]').item(index);
       let optionTopScroll = optionElement.offsetTop - optionsList.offsetTop;


### PR DESCRIPTION
Closes #642