### PR TITLE
Fix keyboard navigation in the navigable-select demo

### DIFF
--- a/tests/dummy/app/components/animated-options.js
+++ b/tests/dummy/app/components/animated-options.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import OptionsComponent from 'ember-power-select/components/power-select/options';
 
-export default Ember.Component.extend({
+export default OptionsComponent.extend({
   didReceiveAttrs({ oldAttrs, newAttrs }) {
     this._super(...arguments);
     if (!oldAttrs || !oldAttrs.options || !newAttrs.options || oldAttrs.options === newAttrs.options) {

--- a/tests/dummy/app/templates/components/animated-options.hbs
+++ b/tests/dummy/app/templates/components/animated-options.hbs
@@ -1,12 +1,12 @@
 {{#liquid-bind options use=animation enableGrowth=enableGrowth as |currentOptions|}}
-  {{#each currentOptions as |opt|}}
+  {{#each currentOptions as |opt index|}}
     <li class="ember-power-select-option"
-      aria-selected={{ember-power-select-is-selected opt selected}}
-      aria-disabled={{opt.disabled}}
-      aria-current={{eq opt highlighted}}
-      onclick={{action select.actions.select opt}}
-      onmouseover={{action select.actions.highlight opt}}>
-      {{yield opt}}
+      aria-selected="{{ember-power-select-is-selected opt select.selected}}"
+      aria-disabled={{ember-power-select-true-string-if-present opt.disabled}}
+      aria-current="{{eq opt select.highlighted}}"
+      data-option-index="{{groupIndex}}{{index}}"
+      role="option">
+      {{yield opt select}}
     </li>
   {{/each}}
 {{/liquid-bind}}


### PR DESCRIPTION
Updating the customized `optionsComponent` in the demo so that keyboard navigation works again.