### PR TITLE
Improved animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-pagefront": "0.10.10",
     "ember-resolver": "^2.0.3",
-    "liquid-fire": "git://github.com/ember-animation/liquid-fire.git#218a791ea7f311e38bdd6a8211d488d40baf82ca",
+    "liquid-fire": "0.26.1",
     "loader.js": "^4.0.1",
     "memory-scroll": "0.2.0",
     "node-sass": "^3.8.0",

--- a/tests/dummy/app/components/animated-options.js
+++ b/tests/dummy/app/components/animated-options.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import OptionsComponent from 'ember-power-select/components/power-select/options';
 
-export default Ember.Component.extend({
+export default OptionsComponent.extend({
   didReceiveAttrs({ oldAttrs, newAttrs }) {
     this._super(...arguments);
     if (!oldAttrs || !oldAttrs.options || !newAttrs.options || oldAttrs.options === newAttrs.options) {

--- a/tests/dummy/app/components/animated-options.js
+++ b/tests/dummy/app/components/animated-options.js
@@ -1,23 +1,28 @@
+import Ember from 'ember';
 import OptionsComponent from 'ember-power-select/components/power-select/options';
 
 export default OptionsComponent.extend({
-  didReceiveAttrs({ oldAttrs, newAttrs }) {
+  animationRules: Ember.computed(function() {
+    return function() {
+      this.transition(
+        this.toValue(function(newOptions, oldOptions) {
+          return oldOptions === safeGet(newOptions, 0, 'parentLevel', 'options');
+        }),
+        this.use('toLeft'),
+        this.reverse('toRight')
+      );
+    };
+  }),
+
+  didReceiveAttrs() {
     this._super(...arguments);
-    if (!oldAttrs || !oldAttrs.options || !newAttrs.options || oldAttrs.options === newAttrs.options) {
-      return;
-    }
-    if (newAttrs.options.fromSearch) {
-      this.set('animation', false);
-      this.set('enableGrowth', false);
-    } else {
-      this.set('enableGrowth', true);
-      const parentLevel = oldAttrs.options[0] && oldAttrs.options[0].parentLevel;
-      const goingBack = !!parentLevel && parentLevel.options === newAttrs.options;
-      if (goingBack) {
-        this.set('animation', 'toRight');
-      } else {
-        this.set('animation', 'toLeft');
-      }
-    }
+    this.set('enableGrowth', !this.get('options.fromSearch'));
   }
 });
+
+function safeGet(base, ...keys) {
+  while (base && keys.length > 0) {
+    base = base[keys.shift()];
+  }
+  return base;
+}

--- a/tests/dummy/app/components/navigable-select.js
+++ b/tests/dummy/app/components/navigable-select.js
@@ -7,6 +7,12 @@ export default Ember.Component.extend({
   transformedOptions: computed('options', function() {
     return (function walker(options, parentLevel = null) {
       let results = Ember.A();
+
+      // this is necessary because power-select calls `toArray`, which
+      // makes a copy and breaks our ability to compare parentLevel
+      // via `===`.
+      results.toArray = () => results;
+
       let len = get(options, 'length');
       parentLevel = parentLevel || { root: true };
       for (let i = 0; i < len; i++) {

--- a/tests/dummy/app/templates/components/animated-options.hbs
+++ b/tests/dummy/app/templates/components/animated-options.hbs
@@ -1,4 +1,4 @@
-{{#liquid-bind options use=animation enableGrowth=enableGrowth as |currentOptions|}}
+{{#liquid-bind options rules=animationRules enableGrowth=enableGrowth as |currentOptions|}}
   {{#each currentOptions as |opt index|}}
     <li class="ember-power-select-option"
       aria-selected="{{ember-power-select-is-selected opt select.selected}}"

--- a/tests/dummy/app/templates/components/animated-options.hbs
+++ b/tests/dummy/app/templates/components/animated-options.hbs
@@ -1,12 +1,12 @@
 {{#liquid-bind options use=animation enableGrowth=enableGrowth as |currentOptions|}}
-  {{#each currentOptions as |opt|}}
+  {{#each currentOptions as |opt index|}}
     <li class="ember-power-select-option"
-      aria-selected={{ember-power-select-is-selected opt selected}}
-      aria-disabled={{opt.disabled}}
-      aria-current={{eq opt highlighted}}
-      onclick={{action select.actions.select opt}}
-      onmouseover={{action select.actions.highlight opt}}>
-      {{yield opt}}
+      aria-selected="{{ember-power-select-is-selected opt select.selected}}"
+      aria-disabled={{ember-power-select-true-string-if-present opt.disabled}}
+      aria-current="{{eq opt select.highlighted}}"
+      data-option-index="{{groupIndex}}{{index}}"
+      role="option">
+      {{yield opt select}}
     </li>
   {{/each}}
 {{/liquid-bind}}


### PR DESCRIPTION
This switches from liquid-bind's `use=` to `rules=` so we can do declarative matching.

Also, both the existing code and my new version rely on equality checking that was not working with the latest code in power-select due to `toArray` on `options`. I patched the demo so that toArray is a no-op on our demo data, but it would be nice to skip the unnecessary copy in cases where options is already a true Array.

This PR builds off #678.