### PR TITLE
Open dropdown onInput after render to avoid deprecation warning

### DIFF
--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -80,7 +80,9 @@ export default Component.extend({
     onInput(e) {
       let action = this.get('onInput');
       if (action &&  action(e) === false) { return; }
-      this.get('select').actions.open(e);
+
+      const select = this.get('select');
+      scheduleOnce('afterRender', null, select.actions.open, e);
     },
 
     onKeydown(e) {


### PR DESCRIPTION
- When triggering the power-select-multiple open when input is entered,
  only do so in the "afterRender" queue to avoid the
  "render-double-modify" deprecation warning