### PR TITLE
Allow `selectChoose` to receive a CSS selector as second argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Master
 
+- [ENHANCEMENT] The `selectChose` helper now also allows to receive a CSS selector as second argument (instead of
+  the text value of the option). This makes easier for selects with complex HTML inside their options
+  to be interacted with.
 - [DOCS] Add not explaining that automatic animation detection doesn't work with CSS transitions,
   only with CSS animations.
 

--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -87,7 +87,7 @@ export function touchTrigger() {
 // Helpers for acceptance tests
 
 export default function() {
-  Test.registerAsyncHelper('selectChoose', function(app, cssPath, value) {
+  Test.registerAsyncHelper('selectChoose', function(app, cssPath, valueOrSelector) {
     let $trigger = find(`${cssPath} .ember-power-select-trigger`);
 
     if ($trigger === undefined || $trigger.length === 0) {
@@ -104,10 +104,14 @@ export default function() {
 
     // Select the option with the given text
     andThen(function() {
-      let potentialTargets = $(`#${contentId} .ember-power-select-option:contains("${value}")`).toArray();
+      let potentialTargets = $(`#${contentId} .ember-power-select-option:contains("${valueOrSelector}")`).toArray();
       let target;
+      if (potentialTargets.length === 0) {
+        // If treating the value as text doesn't gave use any result, let's try if it's a css selector
+        potentialTargets = $(`#${contentId} ${valueOrSelector}`).toArray();
+      }
       if (potentialTargets.length > 1) {
-        target = potentialTargets.filter((t) => t.textContent.trim() === value)[0] || potentialTargets[0];
+        target = potentialTargets.filter((t) => t.textContent.trim() === valueOrSelector)[0] || potentialTargets[0];
       } else {
         target = potentialTargets[0];
       }

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -76,6 +76,21 @@ test('the selectChoose helper works when it receives the class of the trigger', 
   });
 });
 
+test('the selectChoose helper works when it receives the css selector of the chosen option as second arguments', function(assert) {
+  visit('/helpers-testing');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/helpers-testing');
+    selectChoose('.select-with-class-in-trigger', '.ember-power-select-option:eq(2)');
+  });
+
+  andThen(function() {
+    assert.equal(find('.select-choose').text().trim(), 'three', 'The proper value has been selected');
+    assert.equal($('.ember-power-select-options').length, 0, 'The selectis closed');
+    assert.equal(find('.select-choose-target').text().trim(), 'You\'ve selected: three');
+  });
+});
+
 test('the selectChoose helper works when it receives a wildcard css class', function(assert) {
   visit('/helpers-testing-single-power-select');
   andThen(function() {

--- a/tests/dummy/app/templates/public-pages/docs/test-helpers.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/test-helpers.hbs
@@ -31,7 +31,7 @@
 
 </pre>
 
-<h3><code>selectChoose(cssPath, optionText)</code></h3>
+<h3><code>selectChoose(cssPath, optionTextOrOptionSelector)</code></h3>
 
 <p>
   This async helper allows you to select an option of a select by it's text, without worrying about
@@ -43,9 +43,17 @@
   selectChoose('.city-selector', 'Rome');
   // ...
   click('.submit-btn');
-
 </pre>
 
+It also allows to pass a complec CSS selector where using the text of the option is not
+convenient:
+
+<pre>
+  fillIn('.username', 'Tomster');
+  selectChoose('.select-with-only-images', '.ember-power-select-option:eq(3)'); // Select the 4th image
+  // ...
+  click('.submit-btn');
+</pre>
 
 <h3><code>selectSearch(cssPath, searchText)</code></h3>
 
@@ -67,7 +75,7 @@
 <h3><code>removeMultipleOption(cssPath, optionText)</code></h3>
 
 <p>
-  Use this helper to remove an option from a multiple select. 
+  Use this helper to remove an option from a multiple select.
 </p>
 
 <pre>
@@ -80,7 +88,7 @@
 <h3><code>clearSelected(cssPath, optionText)</code></h3>
 
 <p>
-  Use this helper to remove an option from a single select when allowClear is set to true. 
+  Use this helper to remove an option from a single select when allowClear is set to true.
 </p>
 
 <pre>
@@ -99,7 +107,7 @@
 <h2>Integration Tests</h2>
 
 <p>
-  Test helpers must be imported at the top of your integration test.  The basic functionality of these helpers are unlikely to change, but may experience minor revisions in the future.  
+  Test helpers must be imported at the top of your integration test.  The basic functionality of these helpers are unlikely to change, but may experience minor revisions in the future.
 </p>
 <p><code>import { typeInSearch, clickTrigger } from '../../../helpers/ember-power-select'</code></p>
 <p>


### PR DESCRIPTION
This allows to select options in a group that have the same text than
some other option in another group. Before, passing just the content,
only the first matching option could be reached. Now using CSS selectors,
any option can be selected.

Closes #691