### PR TITLE
`selectChoose` and `selectSearch` throw explicative errors when something goes wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Master
 
-- [ENHANCEMENT] The `selectChose` helper now also allows to receive a CSS selector as second argument (instead of
+- [ENHANCEMENT] The `selectChoose` and `selectSearch` helpers now throw explicative errors when something goes wrong.
+- [ENHANCEMENT] The `selectChoose` helper now also allows to receive a CSS selector as second argument (instead of
   the text value of the option). This makes easier for selects with complex HTML inside their options
   to be interacted with.
 - [DOCS] Add not explaining that automatic animation detection doesn't work with CSS transitions,

--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -94,6 +94,10 @@ export default function() {
       $trigger = find(cssPath);
     }
 
+    if ($trigger.length === 0) {
+      throw new Error(`You called "selectChoose('${cssPath}', '${valueOrSelector}')" but no select was found using selector "${cssPath}"`);
+    }
+
     let contentId = `${$trigger.attr('aria-controls')}`;
     let $content = find(`#${contentId}`)
     // If the dropdown is closed, open it
@@ -115,6 +119,9 @@ export default function() {
       } else {
         target = potentialTargets[0];
       }
+      if (!target) {
+        throw new Error(`You called "selectChoose('${cssPath}', '${valueOrSelector}')" but "${valueOrSelector}" didn't match any option`);
+      }
       nativeMouseUp(target);
     });
   });
@@ -125,6 +132,10 @@ export default function() {
     if ($trigger === undefined || $trigger.length === 0) {
       triggerPath = cssPath;
       $trigger = find(triggerPath);
+    }
+
+    if ($trigger.length === 0) {
+      throw new Error(`You called "selectSearch('${cssPath}', '${value}')" but no select was found using selector "${cssPath}"`);
     }
 
     let contentId = `${$trigger.attr('aria-controls')}`;

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -104,6 +104,30 @@ test('the selectChoose helper works when it receives a wildcard css class', func
   });
 });
 
+test('selectChoose helper throws an explicative error when no select is found in the given scope', function(assert) {
+  assert.expect(2);
+  visit('/helpers-testing');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/helpers-testing');
+    selectChoose('.there-is-no-select', 'three').catch(function(error) {
+      assert.equal(error.message, `You called "selectChoose('.there-is-no-select', 'three')" but no select was found using selector ".there-is-no-select"`);
+    });
+  });
+});
+
+test('selectChoose helper throws an explicative error when no option matches the given value', function(assert) {
+  assert.expect(2);
+  visit('/helpers-testing');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/helpers-testing');
+    selectChoose('.select-choose', 'non-existent-option').catch(function(error) {
+      assert.equal(error.message, `You called "selectChoose('.select-choose', 'non-existent-option')" but "non-existent-option" didn't match any option`);
+    });
+  });
+});
+
 moduleForAcceptance('Acceptance | helpers | selectSearch');
 
 test('selectSearch helper searches in the given single select if it is already opened', function(assert) {
@@ -212,6 +236,18 @@ test('the selectSearch helper works when it receives the class of the trigger', 
 
   andThen(function() {
     assert.equal(find('.ember-power-select-options').text().trim(), 'three');
+  });
+});
+
+test('the selectSearch helper throws an explicative error when no select is found in the given scope', function(assert) {
+  assert.expect(2);
+  visit('/helpers-testing');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/helpers-testing');
+    selectSearch('.there-is-no-select', 'three').catch(function(error) {
+      assert.equal(error.message, `You called "selectSearch('.there-is-no-select', 'three')" but no select was found using selector ".there-is-no-select"`);
+    });
   });
 });
 


### PR DESCRIPTION
Example errors:
```
- You called `selectChoose('.cities', 'Rome')` but no power-select was found using selector `.cities`
- You called `selectChoose('.cities', 'Rome')` but "Rome" did not match any option
```
Closes #698