### PR TITLE
Add support for cancellables

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -117,6 +117,7 @@ export default Component.extend({
     this.activeSelectedPromise = this.activeOptionsPromise = null;
     this._removeObserversInOptions();
     this._removeObserversInSelected();
+    this._cancelActiveSearch();
     cancel(this.expirableSearchDebounceId);
   },
 
@@ -435,6 +436,7 @@ export default Component.extend({
 
   _resetSearch() {
     let results = this.get('publicAPI').options;
+    this._cancelActiveSearch();
     this.updateState({
       results,
       searchText: '',
@@ -458,6 +460,7 @@ export default Component.extend({
     if (!search) {
       publicAPI = this.updateState({ lastSearchedText: term });
     } else if (search.then) {
+      this._cancelActiveSearch();
       publicAPI = this.updateState({ loading: true, _activeSearch: search });
       search.then((results) => {
         if (this.get('isDestroyed')) {
@@ -567,6 +570,13 @@ export default Component.extend({
   _removeObserversInSelected() {
     if (this._observedSelected) {
       this._observedSelected.removeObserver('[]', this, this._updateSelectedArray);
+    }
+  },
+
+  _cancelActiveSearch() {
+    let publicAPI = this.get('publicAPI');
+    if (publicAPI._activeSearch && typeof publicAPI._activeSearch.cancel === 'function') {
+      publicAPI._activeSearch.cancel();
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-code-snippet": "1.8.0",
+    "ember-concurrency": "0.7.9",
     "ember-data": "^2.9.0-beta.1",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import $ from 'jquery';
+import { task, timeout } from 'ember-concurrency';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
@@ -576,3 +577,248 @@ test('BUGFIX: If the user provides a custom matcher, that matcher receives the e
 
   typeInSearch('po');
 });
+
+test('If the value returned from an async search is cancellable and before it completes a new search is fired, the first value gets cancelled', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  this.obj = Ember.Object.extend({
+    searchTask: task(function* (term) {
+      yield timeout(100);
+      assert.equal(term, 'nin', 'The second search gets executed');
+      return numbers.filter((str) => str.indexOf(term) > -1);
+    })
+  }).create();
+
+  this.render(hbs`
+    {{#power-select search=(perform obj.searchTask) onchange=(action (mut foo)) as |number|}}
+      {{number}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  typeInSearch('teen');
+
+  setTimeout(function() {
+    typeInSearch('nin');
+  }, 50);
+
+  setTimeout(function() {
+    done();
+  }, 200);
+});
+
+test('If the value returned from an async search is cancellable and before it completes the searchbox gets cleared, it gets cancelled', function(assert) {
+  assert.expect(0);
+  let done = assert.async();
+
+  this.obj = Ember.Object.extend({
+    searchTask: task(function* (term) {
+      yield timeout(100);
+      assert.ok(false, 'This task should not have been executed this far');
+      return numbers.filter((str) => str.indexOf(term) > -1);
+    })
+  }).create();
+
+  this.render(hbs`
+    {{#power-select search=(perform obj.searchTask) onchange=(action (mut foo)) as |number|}}
+      {{number}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  typeInSearch('teen');
+
+  setTimeout(function() {
+    typeInSearch('');
+  }, 50);
+
+  setTimeout(function() {
+    done();
+  }, 200);
+});
+
+test('If a select is destroyed while a search is still ongoing and the search is cancellable, it gets cancelled', function(assert) {
+  assert.expect(0);
+  let done = assert.async();
+
+  this.obj = Ember.Object.extend({
+    searchTask: task(function* (term) {
+      yield timeout(100);
+      assert.ok(false, 'This task should not have been executed this far');
+      return numbers.filter((str) => str.indexOf(term) > -1);
+    })
+  }).create();
+
+  this.render(hbs`
+    {{#unless hideSelect}}
+      {{#power-select search=(perform obj.searchTask) onchange=(action (mut foo)) as |number|}}
+        {{number}}
+      {{/power-select}}
+    {{/unless}}
+  `);
+
+  clickTrigger();
+  typeInSearch('teen');
+
+  setTimeout(() => {
+    this.set('hideSelect', true);
+  }, 50);
+
+  setTimeout(function() {
+    done();
+  }, 150);
+});
+
+test('If a select is closed while a search is still ongoing and the search is cancellable, it gets cancelled', function(assert) {
+  assert.expect(0);
+  let done = assert.async();
+
+  this.obj = Ember.Object.extend({
+    searchTask: task(function* (term) {
+      yield timeout(100);
+      assert.ok(false, 'This task should not have been executed this far');
+      return numbers.filter((str) => str.indexOf(term) > -1);
+    })
+  }).create();
+
+  this.render(hbs`
+    {{#power-select search=(perform obj.searchTask) onchange=(action (mut foo)) as |number|}}
+      {{number}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  typeInSearch('teen');
+
+  setTimeout(() => {
+    clickTrigger();
+  }, 50);
+
+  setTimeout(function() {
+    done();
+  }, 150);
+});
+
+test('If the value returned from an async search of a multiple-select is cancellable and before it completes a new search is fired, the first value gets cancelled', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  this.obj = Ember.Object.extend({
+    searchTask: task(function* (term) {
+      yield timeout(100);
+      assert.equal(term, 'nin', 'The second search gets executed');
+      return numbers.filter((str) => str.indexOf(term) > -1);
+    })
+  }).create();
+
+  this.render(hbs`
+    {{#power-select-multiple search=(perform obj.searchTask) onchange=(action (mut foo)) as |number|}}
+      {{number}}
+    {{/power-select-multiple}}
+  `);
+
+  clickTrigger();
+  typeInSearch('teen');
+
+  setTimeout(function() {
+    typeInSearch('nin');
+  }, 50);
+
+  setTimeout(function() {
+    done();
+  }, 200);
+});
+
+test('If the value returned from an async search of a multiple-select is cancellable and before it completes the searchbox gets cleared, it gets cancelled', function(assert) {
+  assert.expect(0);
+  let done = assert.async();
+
+  this.obj = Ember.Object.extend({
+    searchTask: task(function* (term) {
+      yield timeout(100);
+      assert.ok(false, 'This task should not have been executed this far');
+      return numbers.filter((str) => str.indexOf(term) > -1);
+    })
+  }).create();
+
+  this.render(hbs`
+    {{#power-select-multiple search=(perform obj.searchTask) onchange=(action (mut foo)) as |number|}}
+      {{number}}
+    {{/power-select-multiple}}
+  `);
+
+  clickTrigger();
+  typeInSearch('teen');
+
+  setTimeout(function() {
+    typeInSearch('');
+  }, 50);
+
+  setTimeout(function() {
+    done();
+  }, 200);
+});
+
+test('If a multiple select is destroyed while a search is still ongoing and the search is cancellable, it gets cancelled', function(assert) {
+  assert.expect(0);
+  let done = assert.async();
+
+  this.obj = Ember.Object.extend({
+    searchTask: task(function* (term) {
+      yield timeout(100);
+      assert.ok(false, 'This task should not have been executed this far');
+      return numbers.filter((str) => str.indexOf(term) > -1);
+    })
+  }).create();
+
+  this.render(hbs`
+    {{#unless hideSelect}}
+      {{#power-select-multiple search=(perform obj.searchTask) onchange=(action (mut foo)) as |number|}}
+        {{number}}
+      {{/power-select-multiple}}
+    {{/unless}}
+  `);
+
+  clickTrigger();
+  typeInSearch('teen');
+
+  setTimeout(() => {
+    this.set('hideSelect', true);
+  }, 50);
+
+  setTimeout(function() {
+    done();
+  }, 150);
+});
+
+test('If a multiple select is closed while a search is still ongoing and the search is cancellable, it gets cancelled', function(assert) {
+  assert.expect(0);
+  let done = assert.async();
+
+  this.obj = Ember.Object.extend({
+    searchTask: task(function* (term) {
+      yield timeout(100);
+      assert.ok(false, 'This task should not have been executed this far');
+      return numbers.filter((str) => str.indexOf(term) > -1);
+    })
+  }).create();
+
+  this.render(hbs`
+    {{#power-select-multiple search=(perform obj.searchTask) onchange=(action (mut foo)) as |number|}}
+      {{number}}
+    {{/power-select-multiple}}
+  `);
+
+  clickTrigger();
+  typeInSearch('teen');
+
+  setTimeout(() => {
+    clickTrigger();
+  }, 50);
+
+  setTimeout(function() {
+    done();
+  }, 150);
+});
+


### PR DESCRIPTION
With ember-concurrency gaining popularity every day and cancellable promises
around the corner (sic) it's time to start being good citizens and cancel all
work that can be cancelled when the component is no longer interested in it.

There is a couple situations where this can happen:

If the `search` action returns a `thenable` object that responds to the
`.cancel()` method, firing another search before the first one is completed will
cancel the previous. This was possible before by just adding `.restartable()`
to your e-c task, but now it will work with any cancellable object.

Another situation where this could happen is when, after firing a search that
returns can cancellable-thenable, and before that search completes, the searchbox
gets cleared. In EPS, clearing the search doesn't fire another search, so this
situation was not easy to detect and cancel properly with a `.restartable()` task.
Now, EPS detects this situation and cancels any pending search when the searchbox
is cleared.

Closes #693