### PR TITLE
[FEATURE] Allow to customize what element is highlighted by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+- [ENHANCEMENT] Add a `defaultHighlighted` option that can be used to customize what item is highlighted by default with the component is opened.
+  It can either be a value, or a function that gets called with the select and returns that value.
 - [ENHANCEMENT] Add `onblur` event for symmetry with `onfocus`, and also clarify that both are fired for any element of
   the select gaining the focus, so the `event.target` should be used to disambiguate the origin.
 - [BUGFIX] Fix SHIFT+TAB in multiple select: In multiple selects with search enabled that use the default component,

--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -10,6 +10,7 @@
     buildSelection=(action "buildSelection")
     class=class
     closeOnSelect=closeOnSelect
+    defaultHighlighted=defaultHighlighted
     destination=destination
     dir=dir
     disabled=disabled
@@ -21,10 +22,10 @@
     matcher=matcher
     matchTriggerWidth=matchTriggerWidth
     noMatchesMessage=noMatchesMessage
+    onblur=onblur
     onchange=onchange
     onclose=onclose
     onfocus=(action "handleFocus")
-    onblur=onblur
     oninput=oninput
     onkeydown=(action "handleKeydown")
     onopen=(action "handleOpen")
@@ -62,6 +63,7 @@
     buildSelection=(action "buildSelection")
     class=class
     closeOnSelect=closeOnSelect
+    defaultHighlighted=defaultHighlighted
     destination=destination
     dir=dir
     disabled=disabled
@@ -73,10 +75,10 @@
     matcher=matcher
     matchTriggerWidth=matchTriggerWidth
     noMatchesMessage=noMatchesMessage
+    onblur=onblur
     onchange=onchange
     onclose=onclose
     onfocus=(action "handleFocus")
-    onblur=onblur
     oninput=oninput
     onkeydown=(action "handleKeydown")
     onopen=(action "handleOpen")

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -94,6 +94,27 @@ export function filterOptions(options, text, matcher, skipDisabled = false) {
   return opts;
 }
 
+export function defaultHighlighted(select) {
+  let { results, highlighted, selected } = select;
+  let option = highlighted || selected;
+  if (option === undefined || indexOfOption(results, option) === -1) {
+    return advanceSelectableOption(results, option, 1);
+  }
+  return option;
+}
+
+export function advanceSelectableOption(options, currentOption, step) {
+  let resultsLength = countOptions(options);
+  let startIndex = Math.min(Math.max(indexOfOption(options, currentOption) + step, 0), resultsLength - 1);
+  let { disabled, option } = optionAtIndex(options, startIndex);
+  while (option && disabled) {
+    let next = optionAtIndex(options, startIndex += step);
+    disabled = next.disabled;
+    option = next.option;
+  }
+  return option;
+}
+
 const DIACRITICS = {
   'Ⓐ': 'A',
   'Ａ': 'A',

--- a/tests/dummy/app/controllers/legacy-demo.js
+++ b/tests/dummy/app/controllers/legacy-demo.js
@@ -370,6 +370,7 @@ const searchTypes = [
 export default Ember.Controller.extend({
   names,
   simpleOptions: numbers,
+  defaultHighlightedExample: numbers[3],
   moarNumbers,
   simpleSelected: 'six',
 

--- a/tests/dummy/app/templates/legacy-demo.hbs
+++ b/tests/dummy/app/templates/legacy-demo.hbs
@@ -215,6 +215,11 @@
     {{/power-select}}
   </div>
 
+  <h4>Customized defaultHighlighted</h4>
+  {{#power-select options=(readonly simpleOptions) selected=(readonly simpleSelected) onchange=(action (mut simpleSelected)) defaultHighlighted=defaultHighlightedExample as |option|}}
+    {{option}}
+  {{/power-select}}
+
   <br>
   <br>
   <br>

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -42,6 +42,11 @@
       <td>The selected option (or collection of options in multiple mode)</td>
     </tr>
     <tr>
+      <td>defaultHighlighted</td>
+      <td><code>any or function</code></td>
+      <td>By default when the select opens, the highlighted element is the selected one, or the first if none. If you want to change this behaviour, pass an option or a function that receives the publicAPI and resolves to the highlighted option.</td>
+    </tr>
+    <tr>
       <td>onchange</td>
       <td><code>function</code></td>
       <td>The function to be invoked when the user selects or unselects an option</td>

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -1071,3 +1071,47 @@ test('[BUGFIX] When the component is open and it has a `search` action, if optio
   run(() => this.set('numbers', ['one', 'three', 'five', 'seven', 'nine']));
   assert.equal($('.ember-power-select-option[aria-current="true"]').text().trim(), 'one');
 });
+
+test('the item that is highlighted by default can be customized passing a value to `defaultHighlighted`', function(assert) {
+  assert.expect(2);
+
+  this.numbers = numbers;
+  this.defaultHighlighted = numbers[4];
+  this.render(hbs`
+    {{#power-select options=numbers onchange=(action (mut foo)) defaultHighlighted=defaultHighlighted as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
+  assert.equal($('.ember-power-select-option[aria-current=true]').text().trim(), 'five', 'the given element is highlighted instead of the first, as usual');
+});
+
+test('the item that is highlighted by default can be customized passing a function to `defaultHighlighted`', function(assert) {
+  assert.expect(12);
+
+  this.numbers = numbers;
+  this.defaultHighlighted = function(select) {
+    assert.equal(typeof select.uniqueId, 'string', 'select.uniqueId is a string');
+    assert.equal(typeof select.isOpen, 'boolean', 'select.isOpen is a boolean');
+    assert.equal(typeof select.disabled, 'boolean', 'select.disabled is a boolean');
+    assert.equal(typeof select.isActive, 'boolean', 'select.isActive is a boolean');
+    assert.equal(typeof select.loading, 'boolean', 'select.loading is a boolean');
+    assert.ok(select.options instanceof Array, 'select.options is an array');
+    assert.ok(select.results instanceof Array, 'select.results is an array');
+    assert.equal(typeof select.resultsCount, 'number', 'select.resultsCount is a number');
+    assert.ok(select.hasOwnProperty('selected'));
+    assert.ok(select.hasOwnProperty('highlighted'));
+    return 'five';
+  };
+  this.render(hbs`
+    {{#power-select options=numbers onchange=(action (mut foo)) defaultHighlighted=defaultHighlighted as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  assert.equal($('.ember-power-select-dropdown').length, 1, 'Dropdown is rendered');
+  assert.equal($('.ember-power-select-option[aria-current=true]').text().trim(), 'five', 'the given element is highlighted instead of the first, as usual');
+});

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -767,3 +767,18 @@ test('When the power select multiple uses the default component and the search i
   assert.equal(this.$('.ember-power-select-trigger').attr('tabindex'), '-1', 'The trigger has tabindex=1');
   assert.equal(this.$('.ember-power-select-trigger-multiple-input').attr('tabindex'), '3', 'The searchbox has tabindex=3');
 });
+
+test('Multiple selects honor the `defaultHighlighted` option', function(assert) {
+  assert.expect(1);
+
+  this.numbers = numbers;
+  this.defaultHighlighted = numbers[3];
+  this.render(hbs`
+    {{#power-select-multiple options=numbers selected=foo onchange=(action (mut foo)) defaultHighlighted=defaultHighlighted as |option|}}
+      {{option}}
+    {{/power-select-multiple}}
+  `);
+
+  clickTrigger();
+  assert.equal($('.ember-power-select-option[aria-current=true]').text().trim(), 'four', 'the given defaultHighlighted element is highlighted instead of the first, as usual');
+});


### PR DESCRIPTION
By default when a select component opens, the highlighted element is the selected one,
or the first option in the list if nothing is selected. This is the right behaviour for
99% percent of the cases.

However, there might be some situations where the user wants to customize this, and now
it's possible passing `defaultHighlighted=something`.

That `something` can be either one of the options, or a function that takes the publicAPI
of the component and returns one of the options.