### PR TITLE
lowercase string data type in api-reference.md

### DIFF
--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -248,7 +248,7 @@
     </tr>
     <tr>
       <td>tabindex</td>
-      <td><code>String</code></td>
+      <td><code>string</code></td>
       <td>The tabindex of the trigger</td>
     </tr>
   </tbody>


### PR DESCRIPTION
for consistency with how that data type is listed for all the other API options