### PR TITLE
add ability to move list of selected items to another element…

### DIFF
--- a/addon/components/power-select-multiple.js
+++ b/addon/components/power-select-multiple.js
@@ -2,12 +2,14 @@ import Component from 'ember-component';
 import computed from 'ember-computed';
 import layout from '../templates/components/power-select-multiple';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
   // Config
   triggerComponent: fallbackIfUndefined('power-select-multiple/trigger'),
   beforeOptionsComponent: fallbackIfUndefined(null),
+  selectedItemsContainerSelector: fallbackIfUndefined(null),
 
   // CPs
   concatenatedTriggerClass: computed('triggerClass', function() {
@@ -37,6 +39,12 @@ export default Component.extend({
       return this.get('tabindex');
     }
   }),
+
+  didInsertElement() {
+    if (this.get('selectedItemsContainerSelector')) {
+      $('ul.ember-power-select-multiple-options').appendTo(this.get('selectedItemsContainerSelector'));
+    }
+  },
 
   // Actions
   actions: {

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -247,6 +247,13 @@
       </td>
     </tr>
     <tr>
+      <td>selectedItemsContainerSelector</td>
+      <td><code>string</code></td>
+      <td>
+        A CSS selector used to move the list of selected items into another DOM element outside of the component. Available only for power-select-multiple.
+      </td>
+    </tr>
+    <tr>
       <td>tabindex</td>
       <td><code>String</code></td>
       <td>The tabindex of the trigger</td>

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -782,3 +782,13 @@ test('Multiple selects honor the `defaultHighlighted` option', function(assert) 
   clickTrigger();
   assert.equal($('.ember-power-select-option[aria-current=true]').text().trim(), 'four', 'the given defaultHighlighted element is highlighted instead of the first, as usual');
 });
+
+test('The selected item list can be moved to another element via CSS selector', function(assert) {
+  this.render(hbs`
+    <div id="target-div"></div>
+    {{#power-select-multiple options=numbers onchange=(action (mut foo)) selectedItemsContainerSelector="#target-div"}}
+      {{option}}
+    {{/power-select-multiple}}
+  `);
+  assert.ok($('#target-div ul.ember-power-select-multiple-options').length === 1, 'ul containing selected items is found inside element found by target selector');
+});


### PR DESCRIPTION
… via css selector

I recently did some custom styling on the power-select-multiple where I wanted to move the list of selected items to a DOM element outside of the component. I thought it might be helpful as an option for others who may also be doing custom styling.

Let me know what you think.
