### PR TITLE
Fix debounced search with ember-concurrency documentation

### DIFF
--- a/tests/dummy/app/controllers/public-pages/cookbook/debounce-searches.js
+++ b/tests/dummy/app/controllers/public-pages/cookbook/debounce-searches.js
@@ -17,7 +17,7 @@ export default Ember.Controller.extend({
     yield timeout(600);
     let url = `https://api.github.com/search/repositories?q=${term}`;
     return this.get('ajax').request(url).then((json) => json.items);
-  }),
+  }).restartable(),
 
   _performSearch(term, resolve, reject) {
     if (isBlank(term)) {

--- a/tests/dummy/app/templates/snippets/debounce-searches-2-js.js
+++ b/tests/dummy/app/templates/snippets/debounce-searches-2-js.js
@@ -8,5 +8,5 @@ export default Ember.Controller.extend({
     yield timeout(600);
     let url = `https://api.github.com/search/repositories?q=${term}`;
     return this.get('ajax').request(url).then(json => json.items);
-  })
+  }).restartable()
 });


### PR DESCRIPTION
As seen [here](http://ember-concurrency.com/#/docs/task-concurrency) the default option for ember-concurrency tasks is to run concurrently, which doesn't make much sense for a debounced task 😉 

I've updated both the code snippet and the actual controller to have the `restartable` modifier, which should enable true debouncing.