### PR TITLE
Search Input Focus Bug

### DIFF
--- a/addon/components/power-select/before-options.js
+++ b/addon/components/power-select/before-options.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import Component from 'ember-component';
 import { scheduleOnce } from 'ember-runloop';
 import layout from '../../templates/components/power-select/before-options';
@@ -39,7 +40,11 @@ export default Component.extend({
 
   // Methods
   focusInput() {
-    this.input = self.document.querySelector('.ember-power-select-search-input');
+    const parentElement = Ember.get(this, 'parentView.element');
+
+    if (parentElement) {
+      this.input = parentElement.querySelector('.ember-power-select-search-input');
+    }
     if (this.input) {
       scheduleOnce('afterRender', this.input, 'focus');
     }


### PR DESCRIPTION
If I'm using ember-power-select-typeahead with ember-power-select, it focuses to the first element found for `.ember-power-select-search-input` not the direct children search bar input. 

This will bind the querySelector to the power-select component, not the whole dom.