### PR TITLE
Better check for groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Master
 
+- [BUGFIX] Ensure that options are not considered a group when they have `groupName` but lack of an `options` property.
 - [BUGFIX] The clear button is now activate in touchstart, fixing a bug where in iOS the button was effectively unoperative.
 
 # 1.0.0-beta.30

--- a/addon/helpers/ember-power-select-is-group.js
+++ b/addon/helpers/ember-power-select-is-group.js
@@ -1,0 +1,8 @@
+import { helper } from 'ember-helper';
+import { isGroup } from '../utils/group-utils';
+
+export function emberPowerSelectIsGroup([maybeGroup]) {
+  return isGroup(maybeGroup);
+}
+
+export default helper(emberPowerSelectIsGroup);

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -4,7 +4,7 @@
   {{/if}}
 {{/if}}
 {{#each options as |opt index|}}
-  {{#if opt.groupName}}
+  {{#if (ember-power-select-is-group opt)}}
     <li class="ember-power-select-group" aria-disabled={{ember-power-select-true-string-if-present opt.disabled}} role="option">
       <span class="ember-power-select-group-name">{{opt.groupName}}</span>
       {{#component optionsComponent

--- a/app/helpers/ember-power-select-is-group.js
+++ b/app/helpers/ember-power-select-is-group.js
@@ -1,0 +1,1 @@
+export { default, emberPowerSelectIsGroup } from 'ember-power-select/helpers/ember-power-select-is-group';

--- a/tests/integration/components/power-select/groups-test.js
+++ b/tests/integration/components/power-select/groups-test.js
@@ -38,6 +38,27 @@ test('Options that have a `groupName` and `options` are considered groups and ar
   assert.equal($bigs.find('> .ember-power-select-option').length, 1, 'There is 1 option in the "bigs" group');
 });
 
+test('Options that have a `groupName` but NOT `options` are NOT considered groups and are rendered normally', function(assert) {
+  assert.expect(3);
+
+  this.notQuiteGroups = [
+    { groupName: 'Lions', initial: 'L' },
+    { groupName: 'Tigers', initial: 'T' },
+    { groupName: 'Dogs', initial: 'D' },
+    { groupName: 'Eagles', initial: 'E' }
+  ];
+  this.render(hbs`
+    {{#power-select options=notQuiteGroups onchange=(action (mut foo)) as |option|}}
+      {{option.groupName}}
+    {{/power-select}}
+  `);
+
+  assert.equal($('.ember-power-select-dropdown').length, 0, 'Dropdown is not rendered');
+  clickTrigger();
+  assert.equal($('.ember-power-select-option').length, 4);
+  assert.equal($('.ember-power-select-option:eq(1)').text().trim(), 'Tigers');
+});
+
 test('When filtering, a group title is visible as long as one of it\'s elements is', function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
That an option has `groupName` is not enough to make it a group, it
also has to have an options property. Created a template helper that
runs the same logic present in the `isGroup` utility function in /utils