### PR TITLE
Pass disabled state to the trigger component

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -35,6 +35,7 @@
       searchField=(readonly searchField)
       select=(readonly publicAPI)
       selectedItemComponent=(readonly selectedItemComponent)
+      disabled=(readonly disabled)
       as |opt term|}}
       {{yield opt term}}
     {{/component}}


### PR DESCRIPTION
ember-power-select-typeahead needs to know the disabled state in order to disable its `<input>` element