### PR TITLE
Find parent app by using findHost method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,24 @@
 /* eslint-env node */
 'use strict';
 
+// For ember-cli < 2.7 findHost doesnt exist so we backport from that version
+// for earlier version of ember-cli.
+//https://github.com/ember-cli/ember-cli/blame/16e4492c9ebf3348eb0f31df17215810674dbdf6/lib/models/addon.js#L533
+  function findHostShim() {
+    let current = this;
+    let app;
+    do {
+      app = current.app || app;
+    } while (current.parent.parent && (current = current.parent));
+    return app;
+  }
+
 module.exports = {
   name: 'ember-power-select',
 
   included(appOrAddon) {
-    let app = this._lookupApp(appOrAddon);
+    let findHost = this._findHost || findHostShim;
+    let app = findHost.call(this);
     if (!app.__emberPowerSelectIncludedInvoked) {
       app.__emberPowerSelectIncludedInvoked = true;
 
@@ -38,13 +51,5 @@ module.exports = {
   contentFor(type, config) {
     let emberBasicDropdown = this.addons.find((a) => a.name === 'ember-basic-dropdown');
     return emberBasicDropdown.contentFor(type, config);
-  },
-
-  _lookupApp: function(appOrAddon) {
-    let app = appOrAddon || appOrAddon.app;
-    while (appOrAddon.parent) {
-      app = appOrAddon.parent.app;
-    }
-    return app;
   }
 };


### PR DESCRIPTION
## Problem
Although using `_lookupApp()` worked, it wasn't a fool-proof way of finding the correct parent App and I feared breaking other peoples' builds in future EmberCLI versions:
<img width="605" alt="screen shot 2017-01-31 at 3 26 03 pm" src="https://cloud.githubusercontent.com/assets/9805776/22485054/b78f5970-e7c9-11e6-8b70-b92d214a1a53.png">

## Approach
We are backporting `findHost()` method if you're running EmberCLI < 2.7 and using it if you're on a version > 2.7.