### PR TITLE
Add identification for the trigger display yield

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -38,7 +38,7 @@
       select=(readonly publicAPI)
       selectedItemComponent=(readonly selectedItemComponent)
       as |opt term|}}
-      {{yield opt term}}
+      {{yield opt term true}}
     {{/component}}
   {{/dropdown.trigger}}
 
@@ -81,7 +81,7 @@
         optionsComponent=(readonly optionsComponent)
         select=(readonly publicAPI)
         as |option term|}}
-        {{yield option term}}
+        {{yield option term false}}
       {{/component}}
     {{/if}}
     {{component afterOptionsComponent select=(readonly publicAPI) extra=(readonly extra)}}

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -1139,3 +1139,23 @@ test('If the options of a single select implement `isEqual`, that option is used
   nativeMouseUp('.ember-power-select-option:eq(0)'); // select the same user again
   assert.equal(onChangeInvocationsCount, 1);
 });
+
+test('The third yielded argument in single selects is whether the display is in the trigger or dropdown', function(assert) {
+  assert.expect(2);
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select options=numbers selected=foo onchange=(action (mut foo)) as |option select triggerDisplay|}}
+      {{#if triggerDisplay}}
+        Displays in trigger: {{option}}
+      {{else}}
+        {{option}}
+      {{/if}}
+    {{/power-select}}
+  `);
+
+  clickTrigger();
+  assert.equal($('.ember-power-select-option:eq(1)').text().trim(), 'two', 'Options are not in the trigger display');
+  nativeMouseUp('.ember-power-select-option:eq(1)');
+  clickTrigger();
+  assert.equal($('.ember-power-select-trigger').text().trim(), 'Displays in trigger: two', 'The trigger display is properly informed of its state');
+});

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -1156,6 +1156,5 @@ test('The third yielded argument in single selects is whether the display is in 
   clickTrigger();
   assert.equal($('.ember-power-select-option:eq(1)').text().trim(), 'two', 'Options are not in the trigger display');
   nativeMouseUp('.ember-power-select-option:eq(1)');
-  clickTrigger();
   assert.equal($('.ember-power-select-trigger').text().trim(), 'Displays in trigger: two', 'The trigger display is properly informed of its state');
 });


### PR DESCRIPTION
This PR adds information in the yielded block whether the block is rendered in the trigger or in the dropdown, to allow for different logic in those places.

My use case: I implemented a lazy rendering component and I want to wrap the dropdown options in it, but I don't want the trigger block to have the lazy loading behavior as well. I feel like this could be used in many other situations.