### PR TITLE
Placeholder component for power select multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Master
+- [ENHANCEMENT] Providing a custom `placeholderComponent` is available for
+  `power-select-multiple` too now.
 
 # 1.5.0-beta.0
 - [ENHANCEMENT/BREAKING-ISH] `ember-basic-dropdown` has improved the experience with A11y 
@@ -6,8 +8,6 @@
   there before. EPS doens't rely on those attributes and it's unlikely that this will 
   break for anyone, but just in case I'll bump a minor version number and keep it in 
   beta for some days.
-- [ENHANCEMENT] Providing a custom `placeholderComponent` is available for
-  `power-select-multiple` too now.
 
 # 1.4.3
 - [ENHANCEMENT] `typeInSearch` integration test helper now accepts an options scope to 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   there before. EPS doens't rely on those attributes and it's unlikely that this will 
   break for anyone, but just in case I'll bump a minor version number and keep it in 
   beta for some days.
+- [ENHANCEMENT] Providing a custom `placeholderComponent` is available for
+  `power-select-multiple` too now.
 
 # 1.4.3
 - [ENHANCEMENT] `typeInSearch` integration test helper now accepts an options scope to 

--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -70,10 +70,7 @@ export default Component.extend({
   }),
 
   maybePlaceholder: computed('placeholder', 'select.selected.length', function() {
-    let component = this.get('placeholderComponent');
-    let hasCustomPlaceholder = component !== 'power-select/placeholder';
-
-    if (isIE || hasCustomPlaceholder) {
+    if (isIE) {
       return null;
     }
     let select = this.get('select');

--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -70,8 +70,8 @@ export default Component.extend({
   }),
 
   maybePlaceholder: computed('placeholder', 'select.selected.length', function() {
-    const component = this.get('placeholderComponent');
-    const hasCustomPlaceholder = component !== 'power-select/placeholder';
+    let component = this.get('placeholderComponent');
+    let hasCustomPlaceholder = component !== 'power-select/placeholder';
 
     if (isIE || hasCustomPlaceholder) {
       return null;

--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -70,7 +70,10 @@ export default Component.extend({
   }),
 
   maybePlaceholder: computed('placeholder', 'select.selected.length', function() {
-    if (isIE) {
+    const component = this.get('placeholderComponent');
+    const hasCustomPlaceholder = component !== 'power-select/placeholder';
+
+    if (isIE || hasCustomPlaceholder) {
       return null;
     }
     let select = this.get('select');

--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -32,6 +32,7 @@
     options=options
     optionsComponent=optionsComponent
     placeholder=placeholder
+    placeholderComponent=placeholderComponent
     registerAPI=(readonly registerAPI)
     renderInPlace=renderInPlace
     required=required
@@ -86,6 +87,7 @@
     options=options
     optionsComponent=optionsComponent
     placeholder=placeholder
+    placeholderComponent=placeholderComponent
     registerAPI=(readonly registerAPI)
     renderInPlace=renderInPlace
     required=required

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -16,7 +16,7 @@
       {{/if}}
     </li>
   {{else}}
-    {{#if placeholder}}
+    {{#if (not-eq placeholder maybePlaceholder)}}
       {{component placeholderComponent placeholder=placeholder}}
     {{/if}}
   {{/each}}

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -16,8 +16,8 @@
       {{/if}}
     </li>
   {{else}}
-    {{#if (and placeholder (not searchEnabled))}}
-      <span class="ember-power-select-placeholder">{{placeholder}}</span>
+    {{#if placeholder}}
+      {{component placeholderComponent placeholder=placeholder}}
     {{/if}}
   {{/each}}
   {{#if searchEnabled}}

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -16,7 +16,7 @@
       {{/if}}
     </li>
   {{else}}
-    {{#if (not-eq placeholder maybePlaceholder)}}
+    {{#if (and placeholder (not searchEnabled))}}
       {{component placeholderComponent placeholder=placeholder}}
     {{/if}}
   {{/each}}

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -16,7 +16,7 @@
       {{/if}}
     </li>
   {{else}}
-    {{#if (and placeholder (not searchEnabled))}}
+    {{#if (not searchEnabled)}}
       {{component placeholderComponent placeholder=placeholder}}
     {{/if}}
   {{/each}}

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -810,3 +810,26 @@ test('If the options of a multiple select implement `isEqual`, that option is us
   nativeMouseUp('.ember-power-select-option:eq(0)'); // select the same user again should remove it
   assert.equal(this.$('.ember-power-select-multiple-option').length, 0);
 });
+
+test('placeholder can be customized using placeholderComponent', function(assert) {
+  assert.expect(2);
+
+  this.countries = countries;
+
+  this.render(hbs`
+    {{#power-select-multiple
+      options=countries
+      placeholder="test"
+      placeholderComponent="custom-placeholder"
+      onchange=(action (mut foo)) as |country|}}
+      {{country.name}}
+    {{/power-select-multiple}}
+  `);
+
+  assert.equal($('.ember-power-select-placeholder').length, 1, 'The placeholder appears.');
+  assert.equal(
+    $('.ember-power-select-placeholder').text().trim(),
+    'This is a very bold placeholder',
+    'The placeholder content is equal.'
+   );
+});

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -820,6 +820,7 @@ test('placeholder can be customized using placeholderComponent', function(assert
     {{#power-select-multiple
       options=countries
       placeholder="test"
+      searchEnabled=false
       placeholderComponent="custom-placeholder"
       onchange=(action (mut foo)) as |country|}}
       {{country.name}}


### PR DESCRIPTION
This PR adds support for `placeholderComponent: 'custom-placeholder` to `power-select-multiple`.

I also added a regression test.