### PR TITLE
Disable trigger when option is disabled

### DIFF
--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -1,7 +1,7 @@
 <ul id="ember-power-select-multiple-options-{{select.uniqueId}}" class="ember-power-select-multiple-options">
   {{#each select.selected as |opt idx|}}
-    <li class="ember-power-select-multiple-option">
-      {{#unless (or select.disabled opt.disabled)}}
+    <li class="ember-power-select-multiple-option {{if opt.disabled 'ember-power-select-multiple-option--disabled' }}">
+      {{#unless select.disabled }}
         <span role="button"
           aria-label="remove element"
           class="ember-power-select-multiple-remove-btn"

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -1,7 +1,7 @@
 <ul id="ember-power-select-multiple-options-{{select.uniqueId}}" class="ember-power-select-multiple-options">
   {{#each select.selected as |opt idx|}}
     <li class="ember-power-select-multiple-option">
-      {{#unless select.disabled}}
+      {{#unless (or select.disabled opt.disabled)}}
         <span role="button"
           aria-label="remove element"
           class="ember-power-select-multiple-remove-btn"

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { typeInSearch, triggerKeydown, clickTrigger, nativeMouseDown, nativeMouseUp } from '../../../helpers/ember-power-select';
-import { numbers, names, countries } from '../constants';
+import { numbers, names, countries, countriesWithDisabled } from '../constants';
 
 const { RSVP, Object: eObject, get } = Ember;
 
@@ -809,4 +809,26 @@ test('If the options of a multiple select implement `isEqual`, that option is us
   assert.equal($('.ember-power-select-option:eq(0)').attr('aria-selected'), 'true', 'The item in the list is marked as selected');
   nativeMouseUp('.ember-power-select-option:eq(0)'); // select the same user again should remove it
   assert.equal(this.$('.ember-power-select-multiple-option').length, 0);
+});
+
+test('When there is an option which is disabled the css class "ember-power-select-multiple-option--disabled" should be added', function(assert) {
+  assert.expect(2);
+
+  this.countriesWithDisabled = countriesWithDisabled;
+  let countriesWithDisabledLength = this.countriesWithDisabled.length;
+  let disabledNumCountries = 0;
+  for (let i = 0; i < countriesWithDisabledLength; i++) {
+    if (this.countriesWithDisabled[i].disabled) {
+      disabledNumCountries++;
+    }
+  }
+
+  assert.notEqual(disabledNumCountries, 0, 'There is at least one disabled option');
+  this.foo = countriesWithDisabled;
+  this.render(hbs`
+    {{#power-select-multiple options=countriesWithDisabled selected=foo onchange=(action (mut foo)) as |option|}}
+      {{option}}
+    {{/power-select-multiple}}
+  `);
+  assert.equal(this.$('.ember-power-select-multiple-options .ember-power-select-multiple-option--disabled').length, disabledNumCountries, 'The class "ember-power-select-multiple-option--disabled" is added to disabled options');
 });


### PR DESCRIPTION
I added behavior to `templates/components/power-select-multiple/trigger.hbs` so that the remove-button is hidden if an option is disabled. In our app this happens within the following use case: 

There are options which are only addable by an admin. The regular user should see the options but should not be able to remove them. 

In our UI this looks something like this:
![image](https://cloud.githubusercontent.com/assets/1695329/23362388/ce5308b4-fcf5-11e6-86e4-7f5355826e21.png)

The green category are the "admin categories". They should not be deletable by the regular user. Therefore the disabled flag is set on them.

@cibernox let me know what you think. Would be great to have a way to "disable" single options. Maybe my solution is sufficient 😉  