### PR TITLE
update `contentId` during async tests

### DIFF
--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -63,12 +63,16 @@ export function touchTrigger() {
 // Helpers for acceptance tests
 
 export default function() {
-  Test.registerAsyncHelper('selectChoose', function(app, cssPath, valueOrSelector) {
+  function findTrigger(cssPath) {
     let $trigger = find(`${cssPath} .ember-power-select-trigger`);
-
     if ($trigger === undefined || $trigger.length === 0) {
       $trigger = find(cssPath);
     }
+    return $trigger;
+  }
+  
+  Test.registerAsyncHelper('selectChoose', function(app, cssPath, valueOrSelector) {
+    let $trigger = findTrigger(cssPath);
 
     if ($trigger.length === 0) {
       throw new Error(`You called "selectChoose('${cssPath}', '${valueOrSelector}')" but no select was found using selector "${cssPath}"`);
@@ -84,6 +88,10 @@ export default function() {
 
     // Select the option with the given text
     andThen(function() {
+      if (contentId === undefined) { // try to find a fresh contentId
+        $trigger = findTrigger(cssPath);
+        contentId = `${$trigger.attr('aria-owns')}`;
+      }
       let potentialTargets = find(`#${contentId} .ember-power-select-option:contains("${valueOrSelector}")`).toArray();
       let target;
       if (potentialTargets.length === 0) {


### PR DESCRIPTION
I've got a test that's failing b/c the power select is only rendered when the promise is fulfilled. Due to the async op, `.ember-power-select-trigger` isn't rendered, so `$trigger` is defined in the fallback clause. The element that's defined for `$trigger` is outside the scope of the `power-select` component, and so has no `aria-owns` attribute.

This patch simply runs through the "find a trigger" logic once again in the `andThen` block if `contentId` is undefined.

also I put the "find a trigger" logic in a separate function.