### PR TITLE
[selectSearch]: use element to open if not open close #868

### DIFF
--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -120,7 +120,7 @@ export default function() {
     let $content = find(`#${contentId}`);
     let dropdownIsClosed = $content.length === 0 || $content.hasClass('ember-basic-dropdown-content-placeholder');
     if (dropdownIsClosed) {
-      nativeMouseDown(triggerPath);
+      nativeMouseDown($trigger.get(0));
       wait();
     }
     let isDefaultSingleSelect = find('.ember-power-select-search-input').length > 0;


### PR DESCRIPTION
I think this is the simplest solution.  Is it planned in the future that acceptance test helpers (find, click) will be jquery-free or can/will use both?  i.e. in the future, passing `:eq(2)` won't work?

close #868 