### PR TITLE
Add `tagName` to arguments passed from `power-select-multiple` to `power-select`.

### DIFF
--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -45,6 +45,7 @@
     selected=selected
     selectedItemComponent=selectedItemComponent
     tabindex=computedTabIndex
+    tagName=tagName
     triggerClass=concatenatedTriggerClass
     triggerComponent=(component triggerComponent tabindex=tabindex)
     triggerId=triggerId
@@ -101,6 +102,7 @@
     selected=selected
     selectedItemComponent=selectedItemComponent
     tabindex=computedTabIndex
+    tagName=tagName
     triggerClass=concatenatedTriggerClass
     triggerComponent=(component triggerComponent tabindex=tabindex)
     triggerId=triggerId


### PR DESCRIPTION
We reopen `power-select` so we can add some attribute bindings for test hooks. This requires all instances to not be tagless, so we need the `tagName` property we pass to `power-select-multiple` to trickle down to `power-select`.