### PR TITLE
[ENHANCEMENT] Expose a `selectChoose` integration helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+- [ENHANCEMENT] Allow to use `selectChoose` in integration.
+
 # 1.8.3
 - [BUGFIX] Improve smoothness of the scroll of the list of options in iOS devices.
 - [ENHANCEMENT] Add an assertion in dev/test to warn the user that having promises inside

--- a/tests/integration/components/power-select/helpers-test.js
+++ b/tests/integration/components/power-select/helpers-test.js
@@ -1,0 +1,41 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { selectChoose } from '../../../helpers/ember-power-select';
+import { numbers } from '../constants';
+import { find, findAll } from 'ember-native-dom-helpers';
+
+moduleForComponent('ember-power-select', 'Integration | Helpers | selectChoose', {
+  integration: true
+});
+
+test('selectChoose selects the given value on single selects', async function(assert) {
+  assert.expect(2);
+
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select options=numbers selected=foo onchange=(action (mut foo)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  assert.equal(find('.ember-power-select-trigger').textContent.trim(), '', 'The select is empty');
+  await selectChoose('.ember-power-select-trigger', 'three');
+  assert.equal(find('.ember-power-select-trigger').textContent.trim(), 'three', 'The values has been selected');
+});
+
+test('selectChoose selects the given value on multiple selects', async function(assert) {
+  assert.expect(3);
+
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select-multiple options=numbers selected=foo onchange=(action (mut foo)) as |option|}}
+      {{option}}
+    {{/power-select-multiple}}
+  `);
+
+  assert.equal(findAll('.ember-power-select-multiple-option ').length, 0, 'There is no selected options');
+  await selectChoose('.ember-power-select-trigger', 'three');
+  assert.equal(findAll('.ember-power-select-multiple-option ').length, 1, 'There is one selected option');
+  await selectChoose('.ember-power-select-trigger', 'five');
+  assert.equal(findAll('.ember-power-select-multiple-option ').length, 2, 'There is one selected option');
+});


### PR DESCRIPTION
Identical to the acceptance one. Eventually will replace it.
TODO: Other acceptance helpers should be exposed too.

If there is a single select in the integration test, you can pass
an empty string as selector: `selectChoose('', 'three')`. Perhaps
I should check the arity and allow a shorter `selectChoose('three')`

/cc @martndemus It turned to be as easy as I thought it was.