### PR TITLE
Preserve rawSearchResults

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -426,6 +426,7 @@ export default Component.extend({
       let resultsArray = toPlainArray(results);
       this.updateState({
         results: resultsArray,
+        _rawSearchResults: results,
         lastSearchedText: term,
         resultsCount: countOptions(results),
         loading: false


### PR DESCRIPTION
Preserves the raw results returned from the search handler by setting it on the `publicAPI`.

**Use Case:** We extend ember-power-select to render a "Load more" button in the `afterOptionsComponent`, and all of our models are special `ArrayProxy`'s that are pagination aware and have self-contained `loadMore()` functions. This is working great so far, but there's no way to access the ArrayProxy we return from a search from inside ember-power-select, since the call to `toPlainArray` effectively destroys our ArrayProxy.

We've got it working by overloading `handleAsyncSearchTask` with this exact change, but this might be a positive change for others looking to implement a similar solution.