### PR TITLE
Add isOpen to the API reference docs

### DIFF
--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -303,6 +303,7 @@
   disabled: &lt;boolean&gt;,            // Truthy if the component received `disabled=true`
   highlighted: &lt;T&gt;,               // Contains the currently highlighted option (if any)
   isActive: &lt;boolean&gt;,            // Truthy if the trigger is focused. Other subcomponents can mark it as active depending on other logic.
+  isOpen: &lt;boolean&gt;,              // Truthy if the dropdown is open.
   lastSearchedText: &lt;string&gt;,     // Contains the text of the last finished search. In sync searches will match `searchText`. In async searches, it will match it if the current search is fulfilled
   loading: &lt;boolean&gt;,             // Truthy if there is a pending promise that will update the results
   options: &lt;array[T]&gt;,            // Contains the regular array with the resolved collection of options.


### PR DESCRIPTION
To http://www.ember-power-select.com/docs/api-reference.

Not a lot of thought went into this, so feel free to close if this is the wrong thing to do or I'm wrong about something! Just noticed `isOpen` in my console, didn't see it in the docs, and figured it'd be fastest to open a PR.

Thanks so much for the addon :) its beauty brings me much joy.