### PR TITLE
Ignore keydown with modifier keys pressed

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -291,6 +291,9 @@ export default Component.extend({
       if (onkeydown && onkeydown(this.get('publicAPI'), e) === false) {
         return false;
       }
+      if (e.ctrlKey || e.metaKey) {
+        return false;
+      }
       if (e.keyCode >= 48 && e.keyCode <= 90) { // Keys 0-9, a-z or SPACE
         this.get('triggerTypingTask').perform(e);
       } else if (e.keyCode === 32) {  // Space

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -41,7 +41,7 @@ test('Pressing keyup highlights the previous option', function(assert) {
   assert.equal(find('.ember-power-select-option[aria-current="true"]').textContent.trim(), 'two', 'The previous options is highlighted now');
 });
 
-test('When you the last option is highlighted, pressing keydown doesn\'t change the highlighted', function(assert) {
+test('When the last option is highlighted, pressing keydown doesn\'t change the highlighted', function(assert) {
   assert.expect(2);
 
   this.numbers = numbers;
@@ -58,7 +58,7 @@ test('When you the last option is highlighted, pressing keydown doesn\'t change 
   assert.equal(find('.ember-power-select-option[aria-current="true"]').textContent.trim(), 'twenty', 'The last option is still the highlighted one');
 });
 
-test('When you the first option is highlighted, pressing keyup doesn\'t change the highlighted', function(assert) {
+test('When the first option is highlighted, pressing keyup doesn\'t change the highlighted', function(assert) {
   assert.expect(2);
 
   this.numbers = numbers;
@@ -469,6 +469,24 @@ test('Typing on a closed single select selects the value that matches the string
   keyEvent(trigger, 'keydown', 73); // i
   keyEvent(trigger, 'keydown', 78); // n
   assert.equal(trigger.textContent.trim(), 'nine', '"nine" has been selected');
+  assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
+});
+
+test('Typing with modifier keys on a closed single select does not select the value that matches the string typed so far', function(assert) {
+  assert.expect(3);
+
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select options=numbers selected=selected onchange=(action (mut selected)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  let trigger = find('.ember-power-select-trigger');
+  trigger.focus();
+  assert.notOk(find('.ember-power-select-dropdown'), 'The dropdown is closed');
+  keyEvent(trigger, 'keydown', 82, { ctrlKey: true }); // r
+  assert.notEqual(trigger.textContent.trim(), 'three', '"three" is not selected');
   assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
 });
 


### PR DESCRIPTION
If we do not ignore them, we end up, for instance, filtering by "r" when when we
press ctrl+r to reload the page, or filtering by "l" when doing ctrl+l to select
the browser's URL.

It is always a bit annoying to witness this involuntary filtering, but more so
when the widget auto-saves its content. Especially so with ctrl+r, with which
you might not even notice the change because of the page reload.