### PR TITLE
selectChoose, selectSearch scrollIntoView

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -82,6 +82,10 @@ export async function selectChoose(cssPathOrTrigger, valueOrSelector, optionInde
     }
   }
 
+  if (trigger.scrollIntoView) {
+    trigger.scrollIntoView();
+  }
+
   let contentId = `${trigger.attributes['aria-owns'].value}`;
   let content = find(`#${contentId}`);
   // If the dropdown is closed, open it
@@ -149,6 +153,10 @@ export default function() {
       if (!trigger) {
         throw new Error(`You called "selectSearch('${cssPathOrTrigger}', '${value}')" but no select was found using selector "${cssPathOrTrigger}"`);
       }
+    }
+
+    if (trigger.scrollIntoView) {
+      trigger.scrollIntoView();
     }
 
     let contentId = `${trigger.attributes['aria-owns'].value}`;


### PR DESCRIPTION
If the trigger is scrolled off screen, the options menu may not appear properly, causing the action not to fire. This commit changes the test helpers to scroll the trigger into view (assuming the browser supports the function) before trying to open the menu and select an item.