### PR TITLE
Feature - Add support for Numpad typing

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -294,7 +294,8 @@ export default Component.extend({
       if (e.ctrlKey || e.metaKey) {
         return false;
       }
-      if (e.keyCode >= 48 && e.keyCode <= 90) { // Keys 0-9, a-z or SPACE
+      if ((e.keyCode >= 48 && e.keyCode <= 90) // Keys 0-9, a-z
+        || this._isNumpadKeyEvent(e)) {
         this.get('triggerTypingTask').perform(e);
       } else if (e.keyCode === 32) {  // Space
         return this._handleKeySpace(e);
@@ -386,7 +387,11 @@ export default Component.extend({
   // Tasks
   triggerTypingTask: task(function* (e) {
     let publicAPI = this.get('publicAPI');
-    let term = publicAPI._expirableSearchText + String.fromCharCode(e.keyCode);
+    let charCode = e.keyCode;
+    if (this._isNumpadKeyEvent(e)) {
+      charCode -= 48; // Adjust char code offset for Numpad key codes. Check here for numapd key code behavior: https://goo.gl/Qwc9u4
+    }
+    let term = publicAPI._expirableSearchText + String.fromCharCode(charCode);
     this.updateState({ _expirableSearchText: term });
     let matches = this.filter(publicAPI.options, term, true);
     if (get(matches, 'length') > 0) {
@@ -622,6 +627,10 @@ export default Component.extend({
     if (this._observedSelected) {
       this._observedSelected.removeObserver('[]', this, this._updateSelectedArray);
     }
+  },
+
+  _isNumpadKeyEvent(e) {
+    return e.keyCode >= 96 && e.keyCode <= 105;
   },
 
   updateState(changes) {

--- a/tests/integration/components/constants.js
+++ b/tests/integration/components/constants.js
@@ -21,6 +21,19 @@ export const numbers = [
   'twenty'
 ];
 
+export const numerals = [
+  '2',
+  '3',
+  '5',
+  '7',
+  '11',
+  '13',
+  '17',
+  '19',
+  '23',
+  '853'
+];
+
 export const names = [
   'María',
   'Søren Larsen',

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { triggerKeydown, clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
-import { numbers, countries, countriesWithDisabled, groupedNumbers, groupedNumbersWithDisabled } from '../constants';
+import { numbers, numerals, countries, countriesWithDisabled, groupedNumbers, groupedNumbersWithDisabled } from '../constants';
 import { find, keyEvent } from 'ember-native-dom-helpers';
 import { run } from '@ember/runloop';
 
@@ -516,6 +516,27 @@ test('Typing on a opened single select highlights the first value that matches t
   triggerKeydown(trigger, 78); // n
   assert.equal(trigger.textContent.trim(), '', 'nothing has been selected');
   assert.equal(find('.ember-power-select-option[aria-current=true]').textContent.trim(), 'nine', 'The option containing "nine" has been highlighted');
+  assert.ok(find('.ember-power-select-options').scrollTop > 0, 'The list has scrolled');
+  assert.ok(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
+});
+
+test('Typing from the Numpad on an opened single select highlights the first value that matches the string typed so far, scrolling if needed', function(assert) {
+  assert.expect(6);
+
+  this.numerals = numerals;
+  this.render(hbs`
+    {{#power-select options=numerals selected=selected onchange=(action (mut selected)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  let trigger = find('.ember-power-select-trigger');
+  clickTrigger();
+  assert.ok(find('.ember-power-select-dropdown'),  'The dropdown is open');
+  assert.equal(find('.ember-power-select-options').scrollTop, 0, 'The list is not scrolled');
+  triggerKeydown(trigger, 104); // Numpad 8
+  assert.equal(trigger.textContent.trim(), '', 'nothing has been selected');
+  assert.equal(find('.ember-power-select-option[aria-current=true]').textContent.trim(), '853', 'The option containing "853" has been highlighted');
   assert.ok(find('.ember-power-select-options').scrollTop > 0, 'The list has scrolled');
   assert.ok(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
 });

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -497,7 +497,7 @@ test('Typing with modifier keys on a closed single select does not select the va
 // test('Typing on a closed multiple select with no searchbox does nothing', function(assert) {
 // });
 
-test('Typing on a opened single select highlights the first value that matches the string typed so far, scrolling if needed', function(assert) {
+test('Typing on an opened single select highlights the first value that matches the string typed so far, scrolling if needed', function(assert) {
   assert.expect(6);
 
   this.numbers = numbers;
@@ -541,7 +541,7 @@ test('Typing from the Numpad on an opened single select highlights the first val
   assert.ok(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
 });
 
-test('Typing on a opened multiple select highlights the value that matches the string typed so far, scrolling if needed', function(assert) {
+test('Typing on an opened multiple select highlights the value that matches the string typed so far, scrolling if needed', function(assert) {
   assert.expect(6);
 
   this.numbers = numbers;
@@ -612,7 +612,7 @@ test('Type something that doesn\'t give you any result leaves the current select
   assert.equal(trigger.textContent.trim(), 'nine', 'nine is still selected because "ninew" gave no results');
 });
 
-test('Typing on a opened single select highlights the value that matches the string, also when the options are complex, using the `searchField` for that', function(assert) {
+test('Typing on an opened single select highlights the value that matches the string, also when the options are complex, using the `searchField` for that', function(assert) {
   assert.expect(4);
 
   this.countries = countries;
@@ -632,7 +632,7 @@ test('Typing on a opened single select highlights the value that matches the str
   assert.ok(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
 });
 
-test('Typing on a opened single select containing groups highlights the value that matches the string', function(assert) {
+test('Typing on an opened single select containing groups highlights the value that matches the string', function(assert) {
   assert.expect(4);
 
   this.groupedNumbers = groupedNumbers;
@@ -652,7 +652,7 @@ test('Typing on a opened single select containing groups highlights the value th
   assert.ok(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
 });
 
-test('Typing on a opened single select highlights skips disabled options', function(assert) {
+test('Typing on an opened single select highlights skips disabled options', function(assert) {
   assert.expect(4);
 
   this.countries = countriesWithDisabled;
@@ -671,7 +671,7 @@ test('Typing on a opened single select highlights skips disabled options', funct
   assert.ok(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
 });
 
-test('Typing on a opened single select highlights skips disabled groups', function(assert) {
+test('Typing on an opened single select highlights skips disabled groups', function(assert) {
   assert.expect(4);
 
   this.numbers = groupedNumbersWithDisabled;


### PR DESCRIPTION
This PR adds the ability for users to select an option by typing from their Numpad keys.

In order to achieve this I expanded the whitelist of allowed keycodes that trigger the `triggerTypingTask` task so as to include the appropriate keycodes. I also had to update the code which converted the keycode into an actual character so as to take this into account since the keycode for Numpad keys does not directly translate to the unicode representation of the equivalent number character. 

Docs:
- info on Numpad keys in Javascript [here](https://www.cambiaresearch.com/articles/15/javascript-char-codes-key-codes)
- info on String.fromCharCode [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode)