### PR TITLE
Raise helpful assertion

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -154,7 +154,10 @@ export default Component.extend({
     if (searchField && matcher === defaultMatcher) {
       return (option, text) => matcher(get(option, searchField), text);
     } else {
-      return (option, text) => matcher(option, text);
+      return (option, text) => {
+        assert('{{power-select}} If you want the default filtering to work on options that are not plain strings, you need to provide `searchField`', matcher !== defaultMatcher || typeof option === 'string');
+        return matcher(option, text);
+      };
     }
   }),
 

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -804,3 +804,25 @@ test('BUGFIX: If pressing up/down arrow on a multiple select DOES NOT open the s
     done();
   }, 50);
 });
+
+test('Key `c` should not select the first element', function(assert) {
+  assert.expect(3);
+  assert.ok(true)
+  this.options = [
+    {label: "10", value: 10},
+    {label: "25", value: 25},
+    {label: "50", value: 50},
+    {label: "All", value: 255}
+  ];
+  this.selected = this.options[1]
+  this.render(hbs`
+    {{#power-select options=options selected=selected onchange=(action (mut selected)) searchEnabled=false as |option|}}
+      {{option.label}}
+    {{/power-select}}
+  `);
+  let trigger = find('.ember-power-select-trigger');
+  trigger.focus()
+  assert.equal(find('.ember-power-select-selected-item').textContent.trim(), '25');
+  triggerKeydown(trigger, 67); // c
+  assert.equal(find('.ember-power-select-selected-item').textContent.trim(), '25');
+});

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -805,24 +805,24 @@ test('BUGFIX: If pressing up/down arrow on a multiple select DOES NOT open the s
   }, 50);
 });
 
-test('Key `c` should not select the first element', function(assert) {
-  assert.expect(3);
-  assert.ok(true)
+test('If you try to filter options that are objects without providing a `searchField`, an assertion is thrown', function(assert) {
+  assert.expect(2);
   this.options = [
-    {label: "10", value: 10},
-    {label: "25", value: 25},
-    {label: "50", value: 50},
-    {label: "All", value: 255}
+    { label: '10', value: 10 },
+    { label: '25', value: 25 },
+    { label: '50', value: 50 },
+    { label: 'All', value: 255 }
   ];
-  this.selected = this.options[1]
+  this.selected = this.options[1];
   this.render(hbs`
     {{#power-select options=options selected=selected onchange=(action (mut selected)) searchEnabled=false as |option|}}
       {{option.label}}
     {{/power-select}}
   `);
   let trigger = find('.ember-power-select-trigger');
-  trigger.focus()
+  trigger.focus();
   assert.equal(find('.ember-power-select-selected-item').textContent.trim(), '25');
-  triggerKeydown(trigger, 67); // c
-  assert.equal(find('.ember-power-select-selected-item').textContent.trim(), '25');
+  assert.expectAssertion(() => {
+    triggerKeydown(trigger, 67); // c
+  }, '{{power-select}} If you want the default filtering to work on options that are not plain strings, you need to provide `searchField`');
 });


### PR DESCRIPTION
Replaces #965 

@BenjaminHorn It turns out there was no error. The problem is that when your options are not strings, Ember Power Select needs to know what field it should filter by, using `seachField="name"`. Since you didn't provide any, options were coherced to `[object Object]`, that is why `c` and `o` and `b` and `j` and `t` matched.

I've added a dev-time assertion that will be stripped in production builds to help users when they forget about `searchField`.