### PR TITLE
Check for `isDestroying` instead of `isDestroyed`

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -512,7 +512,7 @@ export default Component.extend({
   },
 
   _updateOptionsAndResults(opts) {
-    if (get(this, 'isDestroyed')) {
+    if (get(this, 'isDestroying')) {
       return;
     }
     let options = toPlainArray(opts);


### PR DESCRIPTION
I'm not able to reproduce outside of my application, but during teardown after an acceptance test `_updateOptionsAndResults` throws an error. At the time of the error, `isDestroyed` is false, but `isDestroying` is true. 

This seems like a safe change to make, but if you want I can update to: `if (get(this, 'isDestroyed') || get(this, 'isDestroying'))`.