### PR TITLE
Delete residual CSS from tagName removal. Allow classNames propagation.

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -1,4 +1,5 @@
 {{#basic-dropdown
+  classNames=(readonly classNames)
   horizontalPosition=(readonly horizontalPosition)
   calculatePosition=calculatePosition
   destination=(readonly destination)

--- a/app/styles/ember-power-select.less
+++ b/app/styles/ember-power-select.less
@@ -5,10 +5,7 @@
 
 @import 'ember-basic-dropdown';
 
-.ember-power-select {
-  position: relative;
-}
-.ember-power-select *, .ember-power-select-dropdown * {
+.ember-power-select-dropdown * {
   box-sizing: border-box;
 }
 

--- a/app/styles/ember-power-select.scss
+++ b/app/styles/ember-power-select.scss
@@ -5,10 +5,7 @@ $ember-basic-dropdown-content-background-color: $ember-power-select-background-c
 
 @import 'ember-basic-dropdown';
 
-.ember-power-select {
-  position: relative;
-}
-.ember-power-select *, .ember-power-select-dropdown * {
+.ember-power-select-dropdown * {
   box-sizing: border-box;
 }
 

--- a/tests/dummy/app/styles/components/docs.scss
+++ b/tests/dummy/app/styles/components/docs.scss
@@ -44,12 +44,6 @@
   }
 }
 
-.ember-power-select.has-error {
-  .ember-power-select-trigger {
-    border: 1px solid red;
-  }
-}
-
 @keyframes shake {
   0%   { transform: translateX(0px); }
   20%   { transform: translateX(-20px); }

--- a/tests/integration/components/power-select/customization-with-attrs-test.js
+++ b/tests/integration/components/power-select/customization-with-attrs-test.js
@@ -7,6 +7,21 @@ moduleForComponent('ember-power-select', 'Integration | Component | Ember Power 
   integration: true
 });
 
+test('classNames can be propagated to the child basic-dropdown component', function(assert) {
+  assert.expect(1);
+
+  this.countries = countries;
+  this.country = countries[1]; // Spain
+
+  this.render(hbs`
+    {{#power-select renderInPlace=true classNames="ember-power-select" options=countries selected=country onchange=(action (mut foo)) as |country|}}
+      {{country.name}}
+    {{/power-select}}
+  `);
+
+  assert.ok(find('.ember-basic-dropdown.ember-power-select'), 'Class was added.');
+});
+
 test('trigger on single selects can be customized using triggerClass', function(assert) {
   assert.expect(1);
 

--- a/vendor/ember-power-select-bootstrap.css
+++ b/vendor/ember-power-select-bootstrap.css
@@ -29,10 +29,7 @@
 .ember-basic-dropdown-content-wormhole-origin {
   display: inline; }
 
-.ember-power-select {
-  position: relative; }
-
-.ember-power-select *, .ember-power-select-dropdown * {
+.ember-power-select-dropdown * {
   box-sizing: border-box; }
 
 .ember-power-select-trigger {

--- a/vendor/ember-power-select-material.css
+++ b/vendor/ember-power-select-material.css
@@ -64,10 +64,7 @@
 .ember-basic-dropdown-content-wormhole-origin {
   display: inline; }
 
-.ember-power-select {
-  position: relative; }
-
-.ember-power-select *, .ember-power-select-dropdown * {
+.ember-power-select-dropdown * {
   box-sizing: border-box; }
 
 .ember-power-select-trigger {

--- a/vendor/ember-power-select.css
+++ b/vendor/ember-power-select.css
@@ -29,10 +29,7 @@
 .ember-basic-dropdown-content-wormhole-origin {
   display: inline; }
 
-.ember-power-select {
-  position: relative; }
-
-.ember-power-select *, .ember-power-select-dropdown * {
+.ember-power-select-dropdown * {
   box-sizing: border-box; }
 
 .ember-power-select-trigger {


### PR DESCRIPTION
`classNames` being passed forward allows direct configuration of `{{basic-dropdown}}` which matters for `renderInPlace=true` as you may need to distinguish in CSS between an `.ember-power-select` and your own custom `.ember-basic-dropdown` on the same page.