### PR TITLE
Expose placeholder to beforeOptionsComponent.

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -57,6 +57,8 @@
       searchEnabled=(readonly searchEnabled)
       onFocus=(action "onFocus")
       onBlur=(action "onBlur")
+      placeholder=(readonly placeholder)
+      placeholderComponent=(readonly placeholderComponent)
       searchPlaceholder=(readonly searchPlaceholder)
       select=(readonly publicAPI)}}
     {{#if mustShowSearchMessage}}

--- a/tests/dummy/app/templates/components/custom-before-options.hbs
+++ b/tests/dummy/app/templates/components/custom-before-options.hbs
@@ -1,1 +1,2 @@
-<p id="custom-before-options-p-tag">Customized before options!</p>
+<p id="custom-before-options-p-tag">{{placeholder}}</p>
+{{component placeholderComponent placeholder=placeholder}}

--- a/tests/integration/components/power-select/customization-with-components-test.js
+++ b/tests/integration/components/power-select/customization-with-components-test.js
@@ -98,19 +98,29 @@ test('the `optionsComponent` receives the `extra` hash', function(assert) {
 });
 
 test('the content before the list can be customized passing `beforeOptionsComponent`', function(assert) {
-  assert.expect(2);
+  assert.expect(4);
 
   this.countries = countries;
   this.country = countries[1]; // Spain
 
   this.render(hbs`
-    {{#power-select options=countries selected=country beforeOptionsComponent="custom-before-options" onchange=(action (mut foo)) as |country|}}
+    {{#power-select
+      options=countries
+      selected=country
+      beforeOptionsComponent="custom-before-options"
+      placeholder="inception"
+      placeholderComponent=(component "power-select/placeholder")
+      onchange=(action (mut foo)) as |country|}}
       {{country.name}}
     {{/power-select}}
   `);
 
   clickTrigger();
-  assert.ok(find('.ember-power-select-dropdown #custom-before-options-p-tag'), 'The custom component is rendered instead of the usual search bar');
+
+  let element = find('.ember-power-select-dropdown #custom-before-options-p-tag');
+  assert.ok(element, 'The custom component is rendered instead of the usual search bar');
+  assert.equal(element.innerText, 'inception', 'The placeholder attribute is passed through.');
+  assert.ok(find('.ember-power-select-dropdown .ember-power-select-placeholder'), 'The placeholder component is passed through.');
   assert.notOk(find('.ember-power-select-search-input'), 'The search input is not visible');
 });
 


### PR DESCRIPTION
This allows behavior like having the placeholder serve as a header for the select when open.