### PR TITLE
[FEATURE] Implement native-like behaviour when power-select is closed.

### DIFF
--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { triggerKeydown, clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
-import { numbers, numerals, countries, countriesWithDisabled, groupedNumbers, groupedNumbersWithDisabled } from '../constants';
+import { names, numbers, numerals, countries, countriesWithDisabled, groupedNumbers, groupedNumbersWithDisabled } from '../constants';
 import { find, keyEvent } from 'ember-native-dom-helpers';
 import { run } from '@ember/runloop';
 
@@ -470,6 +470,44 @@ test('Typing on a closed single select selects the value that matches the string
   keyEvent(trigger, 'keydown', 73); // i
   keyEvent(trigger, 'keydown', 78); // n
   assert.equal(trigger.textContent.trim(), 'nine', '"nine" has been selected');
+  assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
+});
+
+test('Typing on a closed single select the first character for n times, selects the nth result for the search of the first character', function(assert) {
+  this.names = names;
+  this.render(hbs`
+    {{#power-select options=names selected=selected onchange=(action (mut selected)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  let trigger = find('.ember-power-select-trigger');
+  trigger.focus();
+  assert.notOk(find('.ember-power-select-dropdown'), 'The dropdown is closed');
+  keyEvent(trigger, 'keydown', 77); // m
+  keyEvent(trigger, 'keydown', 77); // m
+  keyEvent(trigger, 'keydown', 77); // m
+  assert.equal(trigger.textContent.trim(), 'Marta', '"Marta" has been selected');
+  assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
+});
+
+test('Typing on a closed single select the first character for more times than results are available, selects the result for the search of the first character cycling through them', function(assert) {
+  this.names = names;
+  this.render(hbs`
+    {{#power-select options=names selected=selected onchange=(action (mut selected)) as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+  let trigger = find('.ember-power-select-trigger');
+  trigger.focus();
+  assert.notOk(find('.ember-power-select-dropdown'), 'The dropdown is closed');
+  keyEvent(trigger, 'keydown', 77); // m
+  keyEvent(trigger, 'keydown', 77); // m
+  keyEvent(trigger, 'keydown', 77); // m
+  keyEvent(trigger, 'keydown', 77); // m
+  keyEvent(trigger, 'keydown', 77); // m
+  assert.equal(trigger.textContent.trim(), 'Miguel', '"Miguel" has been selected');
   assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
 });
 


### PR DESCRIPTION
When a select element is closed and focus, repeating the first character over and over again, cicles through the results.

For example, given the list of options 1, 2, 20, 21, 22; pressing _2_ twice (in the conditions specified above) will select _20_ and not _22_.

While native behaviour is a bit more complex than currently implemented (for both closed and open states), this take us closer to the real behaviour while we look for an actual spec of it. The cycling of the matches array relates to this more complex behaviour, though for now we could just select the right option.

The function `onlyOneLetterRepeatedAtLeastOnce` function checks that the string is just that. Could not find a better name but I am very much open to suggestions. Using the regular expression is 20 - 30% slower by some quick perf tests but is left in the docs in case it helps to understand its behaviour (never thought I would say that).