### PR TITLE
Allow `triggerRole` to be set

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -15,6 +15,7 @@
   as |dropdown|}}
 
   {{#dropdown.trigger
+    role=(readonly triggerRole)
     tagName=(readonly _triggerTagName)
     ariaDescribedBy=(readonly ariaDescribedBy)
     ariaInvalid=(readonly ariaInvalid)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "bower": "^1.8.2",
-    "ember-basic-dropdown": "^0.33.8",
+    "ember-basic-dropdown": "^0.33.9",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-concurrency": "^0.8.1",

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -281,6 +281,11 @@
       <td>The id to be applied to the trigger. Useful link the select to a <code>&lt;label&gt;</code> tag</td>
     </tr>
     <tr>
+      <td>triggerRole</td>
+      <td><code>string</code></td>
+      <td>The aria-role to use on the trigger element. Defaults to <code>'button'</code></td>
+    </tr>
+    <tr>
       <td>verticalPosition</td>
       <td><code>string</code></td>
       <td>

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -428,3 +428,22 @@ test('Multiple-select: The trigger element correctly passes through WAI-ARIA rel
   assert.equal(trigger.attributes['aria-describedby'].value, 'ariaDescribedByString', 'aria-describedby set correctly');
   assert.equal(trigger.attributes['aria-labelledby'].value, 'ariaLabelledByString', 'aria-required set correctly');
 });
+
+test('Trigger can have a custom aria-role passing triggerRole', function(assert) {
+  assert.expect(2);
+  let role = 'my-role';
+  this.role = role;
+
+  this.numbers = numbers;
+
+  this.render(hbs`
+    {{#power-select options=countries selected=country onchange=(action (mut foo)) triggerRole=role as |country|}}
+      {{country.name}}
+    {{/power-select}}
+  `);
+
+  assert.equal(find('.ember-power-select-trigger').getAttribute('role'), role, 'The `role` was added.');
+
+  this.set('role', undefined);
+  assert.equal(find('.ember-power-select-trigger').getAttribute('role'), 'button', 'The `role` was defaults to `button`.');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,11 +2579,11 @@ electron-to-chromium@^1.3.27:
   version "1.3.27"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
 
-ember-basic-dropdown@^0.33.8:
-  version "0.33.8"
-  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-0.33.8.tgz#a82f7eabdf43f626e5cb8534539b7914c05e61fe"
+ember-basic-dropdown@^0.33.9:
+  version "0.33.9"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-0.33.9.tgz#09db10b1588845f0603fce0879edf5c0db9c6136"
   dependencies:
-    ember-cli-babel "^6.8.1"
+    ember-cli-babel "^6.8.2"
     ember-cli-htmlbars "^2.0.3"
     ember-native-dom-helpers "^0.5.4"
     ember-wormhole "^0.5.2"


### PR DESCRIPTION
Part of fix for https://github.com/cibernox/ember-power-select-typeahead/issues/67
in `ember-power-select-typeahead`