### PR TITLE
hotfix for error calling set on destroyed object during tests

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -650,11 +650,15 @@ export default Component.extend({
   },
 
   updateState(changes) {
-    let newState = set(this, 'publicAPI', assign({}, this.get('publicAPI'), changes));
-    let registerAPI = this.get('registerAPI');
-    if (registerAPI) {
-      registerAPI(newState);
+    if(this.isDestroyed) {
+      console.log('tried to set a destroyed ember power select object')
+    } else {
+      let newState = set(this, 'publicAPI', assign({}, this.get('publicAPI'), changes));
+      let registerAPI = this.get('registerAPI');
+      if (registerAPI) {
+        registerAPI(newState);
+      }
+      return newState;
     }
-    return newState;
   }
 });

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -650,8 +650,8 @@ export default Component.extend({
   },
 
   updateState(changes) {
-    if(this.isDestroyed) {
-      console.log('tried to set a destroyed ember power select object')
+    if (get(this, 'isDestroyed')) {
+      return;
     } else {
       let newState = set(this, 'publicAPI', assign({}, this.get('publicAPI'), changes));
       let registerAPI = this.get('registerAPI');


### PR DESCRIPTION
during our test runs, we would randomly get the "error calling set on destroyed object" message and there was no real way to track it down since the error was coming from the updateState function on the power select component itself. 

This fix just checks that the component is not destroyed before trying to call set