### PR TITLE
Bail out of _updateOptionsAndResults if `isDestroying`

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -525,7 +525,7 @@ export default Component.extend({
   },
 
   _updateOptionsAndResults(opts) {
-    if (get(this, 'isDestroyed')) {
+    if (get(this, 'isDestroying')) {
       return;
     }
     let options = toPlainArray(opts);


### PR DESCRIPTION
I opened a similar PR while back, but declined when I couldn't consistently reproduce the issue. Now I can, although the setup is hard to explain. The specific error I get is `TypeError: Cannot read property 'isOpen' of undefined`, which happens on line 540 (`publicAPI.isOpen`).

I have a page with two ember-power-selects. When the first is selected, it populates the choices of the second (from a `hasMany` association from the selected model). When ember tears down all the models at the end of an acceptance test, it triggers the change event on the `hasMany` relationship, causing ember-power-select to want to update, but since everything is mid-teardown I get the error I mentioned. There's a lot of other stuff going on in my test, but I think it boils down to a race condition that this PR fixes.