### PR TITLE
Deprecate /test-support folder

### DIFF
--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -1,5 +1,46 @@
-import registerHelpers from 'ember-power-select/test-support/helpers';
-export default registerHelpers;
+import { deprecate } from '@ember/debug';
+import _registerHelpers from 'ember-power-select/test-support/helpers';
+import {
+  findContains as _findContains,
+  nativeMouseDown as _nativeMouseDown,
+  nativeMouseUp as _nativeMouseUp,
+  triggerKeydown as _triggerKeydown,
+  typeInSearch as _typeInSearch,
+  clickTrigger as _clickTrigger,
+  nativeTouch as _nativeTouch,
+  touchTrigger as _touchTrigger,
+  selectChoose as _selectChoose
+} from 'ember-power-select/test-support/helpers';
+
+function deprecateHelper(fn, name) {
+  return function() {
+    deprecate(
+      `DEPRECATED \`import { ${name} } from '../../tests/helpers/ember-power-select';\` is deprecated. Please, replace it with \`import { ${name} } from 'ember-power-select/test-support/helpers';\``,
+      false,
+      { until: '1.11.0', id: `ember-power-select-test-support-${name}` }
+    );
+  };
+}
+
+let findContains = deprecateHelper(_findContains, 'findContains');
+let nativeMouseDown = deprecateHelper(_nativeMouseDown, 'nativeMouseDown');
+let nativeMouseUp = deprecateHelper(_nativeMouseUp, 'nativeMouseUp');
+let triggerKeydown = deprecateHelper(_triggerKeydown, 'triggerKeydown');
+let typeInSearch = deprecateHelper(_typeInSearch, 'typeInSearch');
+let clickTrigger = deprecateHelper(_clickTrigger, 'clickTrigger');
+let nativeTouch = deprecateHelper(_nativeTouch, 'nativeTouch');
+let touchTrigger = deprecateHelper(_touchTrigger, 'touchTrigger');
+let selectChoose = deprecateHelper(_selectChoose, 'selectChoose');
+
+export default function deprecatedRegisterHelpers() {
+  deprecate(
+    "DEPRECATED `import registerPowerSelectHelpers from '../../tests/helpers/ember-power-select';` is deprecated. Please, replace it with `import registerPowerSelectHelpers from 'ember-power-select/test-support/helpers';`",
+    false,
+    { until: '1.11.0', id: 'ember-power-select-test-support-register-helpers' }
+  );
+  return _registerHelpers();
+}
+
 export {
   findContains,
   nativeMouseDown,
@@ -10,4 +51,4 @@ export {
   nativeTouch,
   touchTrigger,
   selectChoose
-} from 'ember-power-select/test-support/helpers';
+};

--- a/test-support/helpers/ember-power-select.js
+++ b/test-support/helpers/ember-power-select.js
@@ -13,12 +13,13 @@ import {
 } from 'ember-power-select/test-support/helpers';
 
 function deprecateHelper(fn, name) {
-  return function() {
+  return function(...args) {
     deprecate(
       `DEPRECATED \`import { ${name} } from '../../tests/helpers/ember-power-select';\` is deprecated. Please, replace it with \`import { ${name} } from 'ember-power-select/test-support/helpers';\``,
       false,
       { until: '1.11.0', id: `ember-power-select-test-support-${name}` }
     );
+    return fn(...args);
   };
 }
 

--- a/tests/dummy/app/templates/public-pages/docs/test-helpers.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/test-helpers.hbs
@@ -69,7 +69,7 @@ convenient:
 <p>
   Test helpers must be imported at the top of your integration test.  The basic functionality of these helpers are unlikely to change, but may experience minor revisions in the future.
 </p>
-<p><code>import { typeInSearch, clickTrigger } from '../../../helpers/ember-power-select'</code></p>
+<p><code>import { typeInSearch, clickTrigger } from 'ember-power-select/test-support/helpers'</code></p>
 <p>
   Also note that you could extract the code for these test helpers into your own helpers file was well.
 </p>

--- a/tests/dummy/app/templates/snippets/test-helpers-1-js.js
+++ b/tests/dummy/app/templates/snippets/test-helpers-1-js.js
@@ -2,7 +2,7 @@ import { run } from '@ember/runloop';
 import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
-import registerPowerSelectHelpers from '../../tests/helpers/ember-power-select';
+import registerPowerSelectHelpers from 'ember-power-select/test-support/helpers';
 
 registerPowerSelectHelpers();
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,7 +2,7 @@ import Application from '../../app';
 import config from '../../config/environment';
 import { merge } from '@ember/polyfills';
 import { run } from '@ember/runloop';
-import registerPowerSelectHelpers from '../../tests/helpers/ember-power-select';
+import registerPowerSelectHelpers from 'ember-power-select/test-support/helpers';
 
 registerPowerSelectHelpers();
 

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { numbers, groupedNumbers, countriesWithDisabled } from '../constants';
-import { clickTrigger, findContains } from '../../../helpers/ember-power-select';
+import { clickTrigger, findContains } from 'ember-power-select/test-support/helpers';
 import { find, findAll, keyEvent } from 'ember-native-dom-helpers';
 
 moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Accesibility)', {

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -4,7 +4,7 @@ import { task, timeout } from 'ember-concurrency';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
-import { typeInSearch, clickTrigger } from '../../../helpers/ember-power-select';
+import { typeInSearch, clickTrigger } from 'ember-power-select/test-support/helpers';
 import { numbers, countries } from '../constants';
 import { find, findAll, click } from 'ember-native-dom-helpers';
 import RSVP from 'rsvp';

--- a/tests/integration/components/power-select/customization-with-components-test.js
+++ b/tests/integration/components/power-select/customization-with-components-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { countries } from '../constants';
 import { groupedNumbers } from '../constants';
-import { clickTrigger } from '../../../helpers/ember-power-select';
+import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import { find, findAll, click } from 'ember-native-dom-helpers';
 import { get } from '@ember/object';
 import Component from '@ember/component';

--- a/tests/integration/components/power-select/disabled-test.js
+++ b/tests/integration/components/power-select/disabled-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
-import { clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
+import { clickTrigger, typeInSearch } from 'ember-power-select/test-support/helpers';
 import { numbers, countriesWithDisabled } from '../constants';
 import { find, findAll, triggerEvent, keyEvent, click } from 'ember-native-dom-helpers';
 

--- a/tests/integration/components/power-select/ember-data-test.js
+++ b/tests/integration/components/power-select/ember-data-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import wait from 'ember-test-helpers/wait';
 import hbs from 'htmlbars-inline-precompile';
-import { typeInSearch, clickTrigger } from '../../../helpers/ember-power-select';
+import { typeInSearch, clickTrigger } from 'ember-power-select/test-support/helpers';
 import { startMirage } from '../../../../initializers/ember-cli-mirage';
 import emberDataInitializer from '../../../../initializers/ember-data';
 import { find, findAll, click } from 'ember-native-dom-helpers';

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { typeInSearch, clickTrigger, findContains } from '../../../helpers/ember-power-select';
+import { typeInSearch, clickTrigger, findContains } from 'ember-power-select/test-support/helpers';
 import RSVP from 'rsvp';
 import EmberObject, { get } from '@ember/object';
 import { A } from '@ember/array';

--- a/tests/integration/components/power-select/groups-test.js
+++ b/tests/integration/components/power-select/groups-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { typeInSearch, clickTrigger } from '../../../helpers/ember-power-select';
+import { typeInSearch, clickTrigger } from 'ember-power-select/test-support/helpers';
 import { groupedNumbers } from '../constants';
 import { find, findAll, click } from 'ember-native-dom-helpers';
 

--- a/tests/integration/components/power-select/helpers-test.js
+++ b/tests/integration/components/power-select/helpers-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { selectChoose } from '../../../helpers/ember-power-select';
+import { selectChoose } from 'ember-power-select/test-support/helpers';
 import { numbers } from '../constants';
 import { find, findAll } from 'ember-native-dom-helpers';
 

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { triggerKeydown, clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
+import { triggerKeydown, clickTrigger, typeInSearch } from 'ember-power-select/test-support/helpers';
 import { numbers, numerals, countries, countriesWithDisabled, groupedNumbers, groupedNumbersWithDisabled } from '../constants';
 import { find, keyEvent } from 'ember-native-dom-helpers';
 import { run } from '@ember/runloop';

--- a/tests/integration/components/power-select/mouse-control-test.js
+++ b/tests/integration/components/power-select/mouse-control-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { clickTrigger } from '../../../helpers/ember-power-select';
+import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import { numbers } from '../constants';
 import { find, findAll, click, triggerEvent } from 'ember-native-dom-helpers';
 

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { typeInSearch, clickTrigger } from '../../../helpers/ember-power-select';
+import { typeInSearch, clickTrigger } from 'ember-power-select/test-support/helpers';
 import { numbers, names, countries, countriesWithDisabled } from '../constants';
 import { find, findAll, click, tap, keyEvent } from 'ember-native-dom-helpers';
 import RSVP from 'rsvp';

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { clickTrigger, typeInSearch } from '../../../helpers/ember-power-select';
+import { clickTrigger, typeInSearch } from 'ember-power-select/test-support/helpers';
 import { numbers } from '../constants';
 import { find, findAll, click, keyEvent, focus } from 'ember-native-dom-helpers';
 import { run } from '@ember/runloop';

--- a/tests/integration/components/power-select/touch-control-test.js
+++ b/tests/integration/components/power-select/touch-control-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { touchTrigger } from '../../../helpers/ember-power-select';
+import { touchTrigger } from 'ember-power-select/test-support/helpers';
 import { numbers } from '../constants';
 import { find, findAll, tap } from 'ember-native-dom-helpers';
 

--- a/tests/integration/helpers-test.js
+++ b/tests/integration/helpers-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { numbers } from './components/constants';
-import { clickTrigger, typeInSearch, findContains } from '../helpers/ember-power-select';
+import { clickTrigger, typeInSearch, findContains } from 'ember-power-select/test-support/helpers';
 
 moduleForComponent('ember-power-select', 'Integration | Helpers', {
   integration: true


### PR DESCRIPTION
The helpers exported from there will continue to work for a while, but the amount of deprecation will be so annoying that people will upgrade quicky.