### PR TITLE
Enable native-like search logic

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -11,6 +11,7 @@ import { isArray as isEmberArray } from '@ember/array';
 import ArrayProxy from '@ember/array/proxy';
 import layout from '../templates/components/power-select';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
+import optionsMatcher from '../utils/computed-options-matcher';
 import {
   defaultMatcher,
   indexOfOption,
@@ -164,17 +165,9 @@ export default Component.extend({
     }
   }),
 
-  optionMatcher: computed('searchField', 'matcher', function() {
-    let { matcher, searchField } = this.getProperties('matcher', 'searchField');
-    if (searchField && matcher === defaultMatcher) {
-      return (option, text) => matcher(get(option, searchField), text);
-    } else {
-      return (option, text) => {
-        assert('{{power-select}} If you want the default filtering to work on options that are not plain strings, you need to provide `searchField`', matcher !== defaultMatcher || typeof option === 'string');
-        return matcher(option, text);
-      };
-    }
-  }),
+  optionMatcher: optionsMatcher('matcher', defaultMatcher),
+
+  typeAheadOptionMatcher: optionsMatcher('typeAheadMatcher', defaultTypeAheadMatcher),
 
   concatenatedTriggerClasses: computed('triggerClass', 'publicAPI.isActive', function() {
     let classes = ['ember-power-select-trigger'];
@@ -511,7 +504,7 @@ export default Component.extend({
   },
 
   filterWithOffset(options, term, offset, skipDisabled = false) {
-    return filterOptionsWithOffset(options || [], term, this.get('typeAheadMatcher'), offset, skipDisabled);
+    return filterOptionsWithOffset(options || [], term, this.get('typeAheadOptionMatcher'), offset, skipDisabled);
   },
 
   updateOptions(options) {

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -409,6 +409,7 @@ export default Component.extend({
     // In general, a user doing this interaction means to have a different result.
     let searchStartOffset = 1;
     let publicAPI = this.get('publicAPI');
+    let repeatingChar = publicAPI._repeatingChar;
     let charCode = e.keyCode;
     if (this._isNumpadKeyEvent(e)) {
       charCode -= 48; // Adjust char code offset for Numpad key codes. Check here for numapd key code behavior: https://goo.gl/Qwc9u4
@@ -427,9 +428,9 @@ export default Component.extend({
       // If the term is longer than one char, the user is in the middle of a non-cycling interaction
       // so the offset is just zero (the current selection is a valid match).
       searchStartOffset = 0;
-      this.updateState({ _repeatingChar: '' });
+      repeatingChar = '';
     } else {
-      this.updateState({ _repeatingChar: c });
+      repeatingChar = c;
     }
 
     // When the select is open, the "selection" is just highlighted.
@@ -443,7 +444,7 @@ export default Component.extend({
 
     // The char is always appended. That way, searching for words like "Aaron" will work even
     // if "Aa" would cycle through the results.
-    this.updateState({ _expirableSearchText: publicAPI._expirableSearchText + c });
+    this.updateState({ _expirableSearchText: publicAPI._expirableSearchText + c, _repeatingChar: repeatingChar });
     let matches = this.filterWithOffset(publicAPI.options, term, searchStartOffset, true);
     if (get(matches, 'length') > 0) {
       let firstMatch = optionAtIndex(matches, 0);

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -435,6 +435,8 @@ export default Component.extend({
       searchStartOffset += indexOfOption(publicAPI.options, publicAPI.highlighted);
     } else if (!publicAPI.isOpen && publicAPI.selected) {
       searchStartOffset += indexOfOption(publicAPI.options, publicAPI.selected);
+    } else {
+      searchStartOffset = 0;
     }
 
     // The char is always appended. That way, searching for words like "Aaron" will work even

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -19,7 +19,8 @@ import {
   filterOptionsWithOffset,
   countOptions,
   defaultHighlighted,
-  advanceSelectableOption
+  advanceSelectableOption,
+  defaultTypeAheadMatcher
 } from '../utils/group-utils';
 import { task, timeout } from 'ember-concurrency';
 
@@ -83,6 +84,7 @@ export default Component.extend({
   searchMessage: fallbackIfUndefined('Type to search'),
   closeOnSelect: fallbackIfUndefined(true),
   defaultHighlighted: fallbackIfUndefined(defaultHighlighted),
+  typeAheadMatcher: fallbackIfUndefined(defaultTypeAheadMatcher),
 
   afterOptionsComponent: fallbackIfUndefined(null),
   beforeOptionsComponent: fallbackIfUndefined('power-select/before-options'),
@@ -508,7 +510,7 @@ export default Component.extend({
   },
 
   filterWithOffset(options, term, offset, skipDisabled = false) {
-    return filterOptionsWithOffset(options || [], term, this.get('optionMatcher'), offset, skipDisabled);
+    return filterOptionsWithOffset(options || [], term, this.get('typeAheadMatcher'), offset, skipDisabled);
   },
 
   updateOptions(options) {

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -15,9 +15,8 @@ import optionsMatcher from '../utils/computed-options-matcher';
 import {
   defaultMatcher,
   indexOfOption,
-  optionAtIndex,
   filterOptions,
-  filterOptionsWithOffset,
+  findOptionWithOffset,
   countOptions,
   defaultHighlighted,
   advanceSelectableOption,
@@ -438,16 +437,13 @@ export default Component.extend({
     // The char is always appended. That way, searching for words like "Aaron" will work even
     // if "Aa" would cycle through the results.
     this.updateState({ _expirableSearchText: publicAPI._expirableSearchText + c, _repeatingChar: repeatingChar });
-    let matches = this.filterWithOffset(publicAPI.options, term, searchStartOffset, true);
-    if (get(matches, 'length') > 0) {
-      let firstMatch = optionAtIndex(matches, 0);
-      if (firstMatch !== undefined) {
-        if (publicAPI.isOpen) {
-          publicAPI.actions.highlight(firstMatch.option, e);
-          publicAPI.actions.scrollTo(firstMatch.option, e);
-        } else {
-          publicAPI.actions.select(firstMatch.option, e);
-        }
+    let match = this.findWithOffset(publicAPI.options, term, searchStartOffset, true);
+    if (match !== undefined) {
+      if (publicAPI.isOpen) {
+        publicAPI.actions.highlight(match, e);
+        publicAPI.actions.scrollTo(match, e);
+      } else {
+        publicAPI.actions.select(match, e);
       }
     }
     yield timeout(1000);
@@ -503,8 +499,8 @@ export default Component.extend({
     return filterOptions(options || [], term, this.get('optionMatcher'), skipDisabled);
   },
 
-  filterWithOffset(options, term, offset, skipDisabled = false) {
-    return filterOptionsWithOffset(options || [], term, this.get('typeAheadOptionMatcher'), offset, skipDisabled);
+  findWithOffset(options, term, offset, skipDisabled = false) {
+    return findOptionWithOffset(options || [], term, this.get('typeAheadOptionMatcher'), offset, skipDisabled);
   },
 
   updateOptions(options) {

--- a/addon/utils/computed-options-matcher.js
+++ b/addon/utils/computed-options-matcher.js
@@ -1,0 +1,16 @@
+import { computed, get } from '@ember/object';
+import { assert } from '@ember/debug';
+
+export default function computedOptionsMatcher(matcherField, defaultMatcher) {
+  return computed('searchField', matcherField, function() {
+    let { [matcherField]: matcher, searchField } = this.getProperties(matcherField, 'searchField');
+    if (searchField && matcher === defaultMatcher) {
+      return (option, text) => matcher(get(option, searchField), text);
+    } else {
+      return (option, text) => {
+        assert('{{power-select}} If you want the default filtering to work on options that are not plain strings, you need to provide `searchField`', matcher !== defaultMatcher || typeof option === 'string');
+        return matcher(option, text);
+      };
+    }
+  });
+}

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -1010,3 +1010,7 @@ export function stripDiacritics(text) {
 export function defaultMatcher(value, text) {
   return stripDiacritics(value).toUpperCase().indexOf(stripDiacritics(text).toUpperCase());
 }
+
+export function defaultTypeAheadMatcher(value, text) {
+  return stripDiacritics(value).toUpperCase().startsWith(stripDiacritics(text).toUpperCase()) ? 1 : -1;
+}

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -286,6 +286,14 @@
       <td>The aria-role to use on the trigger element. Defaults to <code>'button'</code></td>
     </tr>
     <tr>
+      <td>typeAheadMatcher</td>
+      <td><code>function</code></td>
+      <td>
+        The <code>function(option, searchTerm)</code> used to match the searchTerm with an option when the
+        selector is closed or search is disabled. The default one will compare ignoring diacritics.
+      </td>
+    </tr>
+    <tr>
       <td>verticalPosition</td>
       <td><code>string</code></td>
       <td>

--- a/tests/integration/components/constants.js
+++ b/tests/integration/components/constants.js
@@ -92,3 +92,52 @@ export const groupedNumbersWithDisabled = [
   'one hundred',
   'one thousand'
 ];
+
+export const namesStartingWithA = [
+  'Abigail',
+  'Abril',
+  'Adriana',
+  'Adrián',
+  'Agustina',
+  'Agustín',
+  'Aitana',
+  'Alan',
+  'Alejandra',
+  'Alejandro',
+  'Alessandra',
+  'Alex',
+  'Alexa',
+  'Alexander',
+  'Allison',
+  'Alma',
+  'Alonso',
+  'Álvaro',
+  'Amanda',
+  'Amelia',
+  'Ana',
+  'Andrea',
+  'Andrés',
+  // These two need to be in the middle.
+  'Aaran', // Does not exist, don't look for it.
+  'Aarón',
+  'Ángel',
+  'Anthony',
+  'Antonella',
+  'Antonia',
+  'Antonio',
+  'Ariadna',
+  'Ariana',
+  'Ashley',
+  'Axel'
+];
+
+const ABC = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'];
+export function charCode(letter) {
+  let idx = ABC.indexOf(letter.toLowerCase());
+
+  if (idx === -1) {
+    return null;
+  }
+
+  return idx + 65;
+}

--- a/tests/integration/components/power-select/disabled-test.js
+++ b/tests/integration/components/power-select/disabled-test.js
@@ -157,7 +157,8 @@ module('Integration | Component | Ember Power Select (Disabled)', function(hooks
 
   test('BUGFIX: When searching by pressing keys on a focused & closed select, disabled options are ignored', async function(assert) {
     assert.expect(3);
-    this.countriesWithDisabled = countriesWithDisabled;
+    this.countriesWithDisabled = countriesWithDisabled.map((country) => Object.assign({}, country));
+    this.countriesWithDisabled[0].disabled = true;
 
     await render(hbs`
      {{#power-select options=countriesWithDisabled searchField='name' selected=foo onchange=(action (mut foo)) as |country|}}
@@ -168,7 +169,7 @@ module('Integration | Component | Ember Power Select (Disabled)', function(hooks
     let trigger = find('.ember-power-select-trigger');
     trigger.focus();
     assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is closed');
-    keyEvent(trigger, 'keydown', 79); // o
+    keyEvent(trigger, 'keydown', 85); // u
     assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is still closed');
     assert.equal(trigger.textContent.trim(), 'United Kingdom', '"United Kingdom" has been selected');
   });

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -657,7 +657,8 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
   test('Typing on an opened single select highlights skips disabled options', async function(assert) {
     assert.expect(4);
 
-    this.countries = countriesWithDisabled;
+    this.countries = countriesWithDisabled.map((country) => Object.assign({}, country));
+    this.countries[0].disabled = true;
     await render(hbs`
       {{#power-select options=countries selected=selected onchange=(action (mut selected)) searchField="name" as |country|}}
         {{country.name}}
@@ -667,7 +668,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
     let trigger = find('.ember-power-select-trigger');
     clickTrigger();
     assert.ok(find('.ember-power-select-dropdown'),  'The dropdown is open');
-    triggerKeydown(trigger, 79); // o
+    triggerKeydown(trigger, 85); // u
     assert.equal(trigger.textContent.trim(), '', 'nothing has been selected');
     assert.equal(find('.ember-power-select-option[aria-current=true]').textContent.trim(), 'United Kingdom', 'The option containing "United Kingdom" has been highlighted');
     assert.ok(find('.ember-power-select-dropdown'),  'The dropdown is still closed');

--- a/tests/integration/components/power-select/type-ahead-test.js
+++ b/tests/integration/components/power-select/type-ahead-test.js
@@ -1,0 +1,139 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { optionAtIndex } from 'ember-power-select/utils/group-utils';
+import { triggerKeydown, clickTrigger } from 'ember-power-select/test-support/helpers';
+import { charCode, namesStartingWithA } from '../constants';
+import { find } from 'ember-native-dom-helpers';
+
+const WITH_EPS_CLOSED = {
+  beforeInteraction(trigger, assert) {
+    trigger.focus();
+    assert.equal(trigger.textContent.trim(), '', 'no value selected');
+    assert.notOk(find('.ember-power-select-dropdown'), 'The dropdown is closed');
+  },
+
+  checkSelectedValue(value, trigger, assert) {
+    // -1 adjust the position for the implicit placeholder
+    assert.equal(trigger.textContent.trim(), value);
+    assert.notOk(find('.ember-power-select-dropdown'), 'The dropdown is still closed');
+  },
+
+  valueAt(coll, _idx, isGrouped = false) {
+    let idx = isGrouped ? _idx - 1 : (_idx - 1) % coll.length;
+    return optionAtIndex(coll, idx).option;
+  }
+};
+
+const WITH_EPS_OPEN = {
+  beforeInteraction(trigger, assert) {
+    clickTrigger();
+    assert.ok(find('.ember-power-select-dropdown'), 'The dropdown is open');
+  },
+
+  checkSelectedValue(value, trigger, assert) {
+    assert.equal(trigger.textContent.trim(), '', 'nothing is selected');
+    assert.equal(find('.ember-power-select-option[aria-current=true]').textContent.trim(), value);
+    assert.ok(find('.ember-power-select-dropdown'), 'The dropdown is still open');
+  },
+
+  valueAt(coll, _idx, isGrouped = false) {
+    let idx = isGrouped ? _idx : _idx % coll.length;
+    return optionAtIndex(coll, idx).option;
+  }
+};
+
+function typeString(trigger, str, times = 1) {
+  for (let j = 0; j < times; j++) {
+    for (let i = 0; i < str.length; i++) {
+      triggerKeydown(trigger, charCode(str.charAt(i)));
+    }
+  }
+}
+
+moduleForComponent('ember-power-select', 'Integration | Component | Ember Power Select (Type Ahead Native Behaviour)', {
+  integration: true
+});
+
+[['Closed', WITH_EPS_CLOSED], ['Open', WITH_EPS_OPEN]].forEach(([state, helpers]) => {
+  test(`(${state}) Repeating the first character cycles through the results`, function(assert) {
+    this.names = namesStartingWithA;
+    this.render(hbs`
+    {{#power-select options=names onchange=(action (mut selected)) selected=selected searchEnabled=false as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+
+    let trigger = find('.ember-power-select-trigger');
+    helpers.beforeInteraction(trigger, assert);
+    typeString(trigger, 'aaa');
+    helpers.checkSelectedValue(helpers.valueAt(this.names, 'aaa'.length), trigger, assert);
+  });
+
+  test(`(${state}) When going over all the possible results, it goes back to the first`, function(assert) {
+    this.names = namesStartingWithA;
+    this.render(hbs`
+      {{#power-select options=names onchange=(action (mut selected)) selected=selected searchEnabled=false as |option|}}
+        {{option}}
+      {{/power-select}}
+    `);
+
+    let trigger = find('.ember-power-select-trigger');
+    helpers.beforeInteraction(trigger, assert);
+    let { length } = namesStartingWithA;
+    typeString(trigger, 'a', length + 1);
+    helpers.checkSelectedValue(helpers.valueAt(this.names, length + 1), trigger, assert);
+  });
+
+  test(`(${state}) Though repeating the first char, the whole search term is remembered`, function(assert) {
+    this.names = namesStartingWithA;
+    this.render(hbs`
+      {{#power-select options=names onchange=(action (mut selected)) selected=selected searchEnabled=false as |option|}}
+        {{option}}
+      {{/power-select}}
+    `);
+
+    let trigger = find('.ember-power-select-trigger');
+    helpers.beforeInteraction(trigger, assert);
+    typeString(trigger, 'aa');
+    helpers.checkSelectedValue(helpers.valueAt(this.names, 'aa'.length), trigger, assert);
+    typeString(trigger, 'r');
+    helpers.checkSelectedValue('Aaran', trigger, assert);
+    assert.notEqual('Aaran', helpers.valueAt(this.names, 'aar'.length), 'Aaran would not be selected unless aa was remembered');
+  });
+
+  test(`(${state}) Typing the first character after typing a different one does not set again the cycling behaviour`, function(assert) {
+    this.names = namesStartingWithA;
+    this.render(hbs`
+      {{#power-select options=names onchange=(action (mut selected)) selected=selected searchEnabled=false as |option|}}
+        {{option}}
+      {{/power-select}}
+    `);
+
+    let trigger = find('.ember-power-select-trigger');
+    helpers.beforeInteraction(trigger, assert);
+    typeString(trigger, 'aara');
+    helpers.checkSelectedValue('Aaran', trigger, assert);
+  });
+
+  test(`(${state}) Cycling characters works with grouped items`, function(assert) {
+    this.names = [
+      { groupName: 'First', options: ['Faa', 'Fab', 'Fac'] },
+      { groupName: 'Second', options: ['Fba', { groupName: '2.1', options: ['FFba'] }, 'Fbb'] }
+    ];
+    this.render(hbs`
+      {{#power-select options=names onchange=(action (mut selected)) selected=selected searchEnabled=false as |option|}}
+        {{option}}
+      {{/power-select}}
+    `);
+    let trigger = find('.ember-power-select-trigger');
+    helpers.beforeInteraction(trigger, assert);
+    typeString(trigger, 'f', state === 'Open' ? 1 : 2); // Normalize open closed behaviour
+    helpers.checkSelectedValue('Fab', trigger, assert);
+    typeString(trigger, 'f', 2);
+    helpers.checkSelectedValue('Fba', trigger, assert);
+    typeString(trigger, 'f');
+    helpers.checkSelectedValue('FFba', trigger, assert);
+    typeString(trigger, 'f');
+    helpers.checkSelectedValue('Fbb', trigger, assert);
+  });
+});

--- a/tests/unit/utils/group-utils-test.js
+++ b/tests/unit/utils/group-utils-test.js
@@ -1,5 +1,6 @@
 import { isGroup, indexOfOption, optionAtIndex, filterOptions, filterOptionsWithOffset, stripDiacritics, countOptions } from 'ember-power-select/utils/group-utils';
 import { module, test } from 'qunit';
+import { defaultTypeAheadMatcher } from '../../../addon/utils/group-utils';
 
 const groupedOptions = [
   { groupName: 'Smalls', options: ['zero', 'one', 'two', 'three'] },
@@ -193,5 +194,20 @@ module('Unit | Utility | Group utils', function() {
 
   test('#countOptions returns the number of options, transversing the groups with no depth level', function(assert) {
     assert.equal(countOptions(groupedOptions), 16);
+  });
+});
+
+test('#defaultTypeAheadMatcher', function(assert) {
+  [
+    ['Aaron', 'Aa'],
+    ['Álvaro', 'alv']
+  ].forEach(([value, text]) => {
+    assert.equal(defaultTypeAheadMatcher(value, text), 1, `${value} is matched by ${text}`);
+  });
+
+  [
+    ['Fabiola', 'Ab']
+  ].forEach(([value, text]) => {
+    assert.equal(defaultTypeAheadMatcher(value, text), -1, `${value} is not matched by ${text}`);
   });
 });

--- a/tests/unit/utils/group-utils-test.js
+++ b/tests/unit/utils/group-utils-test.js
@@ -1,4 +1,4 @@
-import { isGroup, indexOfOption, optionAtIndex, filterOptions, stripDiacritics, countOptions } from 'ember-power-select/utils/group-utils';
+import { isGroup, indexOfOption, optionAtIndex, filterOptions, filterOptionsWithOffset, stripDiacritics, countOptions } from 'ember-power-select/utils/group-utils';
 import { module, test } from 'qunit';
 
 const groupedOptions = [
@@ -111,44 +111,76 @@ module('Unit | Utility | Group utils', function() {
       },
       'one thousand'
     ]);
-
-    assert.deepEqual(filterOptions(groupedOptions, 'imposible', matcher), []);
-    assert.deepEqual(filterOptions(groupedOptions, '', matcher), groupedOptions);
   });
 
-  test('#filterOptions skips disabled options and groups if it receives a truty values as 4th arguments', function(assert) {
-    let matcher = function(value, searchText) {
-      return new RegExp(searchText, 'i').test(value) ? 0 : -1;
-    };
-    assert.deepEqual(filterOptions(groupedOptionsWithDisabledThings, 'zero', matcher, true), [{ groupName: 'Smalls', options: ['zero'] }]);
-    assert.deepEqual(filterOptions(groupedOptionsWithDisabledThings, 'one', matcher, true), ['one hundred', 'one thousand']);
-    assert.deepEqual(filterOptions(groupedOptionsWithDisabledThings, 'ele', matcher, true), []);
-    assert.deepEqual(filterOptions(groupedOptionsWithDisabledThings, 't', matcher, true), [
-      { groupName: 'Smalls', options: ['two', 'three'] },
-      'one thousand'
-    ]);
+  let FILTER_METHODS = [
+    ['filterOptions', filterOptions],
+    ['filterOptionsWithOffset', (options, text, matcher, skipDisabled = false) => filterOptionsWithOffset(options, text, matcher, 0, skipDisabled)]
+  ];
 
-    assert.deepEqual(filterOptions(groupedOptionsWithDisabledThings, 'imposible', matcher, true), []);
-    assert.deepEqual(filterOptions(groupedOptionsWithDisabledThings, '', matcher, true), [
-      {
-        'groupName': 'Smalls',
-        'options': [
-          'zero',
-          'two',
-          'three'
-        ]
-      },
-      {
-        'groupName': 'Mediums',
-        'options': [
-          'four',
-          'five',
-          'six'
-        ]
-      },
-      'one hundred',
-      'one thousand'
-    ]);
+  FILTER_METHODS.forEach(([name, fn]) => {
+    test(`#${name} generates new options respecting groups when the matches returns a number, taking negative numbers as "not found" and positive as matches`, function(assert) {
+      let matcher = function(value, searchText) {
+        return new RegExp(searchText, 'i').test(value) ? 0 : -1;
+      };
+      assert.deepEqual(fn(groupedOptions, 'zero', matcher), [{ groupName: 'Smalls', options: ['zero'] }]);
+      assert.deepEqual(fn(groupedOptions, 'ele', matcher), [
+        {
+          groupName: 'Bigs',
+          options: [{ groupName: 'Really big', options: ['eleven'] }]
+        }
+      ]);
+      assert.deepEqual(fn(groupedOptions, 't', matcher), [
+        { groupName: 'Smalls', options: ['two', 'three'] },
+        {
+          groupName: 'Bigs',
+          options: [
+            { groupName: 'Fairly big', options: ['eight'] },
+            { groupName: 'Really big', options: ['ten', 'twelve'] },
+            'thirteen'
+          ]
+        },
+        'one thousand'
+      ]);
+
+      assert.deepEqual(fn(groupedOptions, 'imposible', matcher), []);
+      assert.deepEqual(fn(groupedOptions, '', matcher), groupedOptions);
+    });
+
+    test(`#${name} skips disabled options and groups if it receives a truty values as 4th arguments`, function(assert) {
+      let matcher = function(value, searchText) {
+        return new RegExp(searchText, 'i').test(value) ? 0 : -1;
+      };
+      assert.deepEqual(fn(groupedOptionsWithDisabledThings, 'zero', matcher, true), [{ groupName: 'Smalls', options: ['zero'] }]);
+      assert.deepEqual(fn(groupedOptionsWithDisabledThings, 'one', matcher, true), ['one hundred', 'one thousand']);
+      assert.deepEqual(fn(groupedOptionsWithDisabledThings, 'ele', matcher, true), []);
+      assert.deepEqual(fn(groupedOptionsWithDisabledThings, 't', matcher, true), [
+        { groupName: 'Smalls', options: ['two', 'three'] },
+        'one thousand'
+      ]);
+
+      assert.deepEqual(fn(groupedOptionsWithDisabledThings, 'imposible', matcher, true), []);
+      assert.deepEqual(fn(groupedOptionsWithDisabledThings, '', matcher, true), [
+        {
+          'groupName': 'Smalls',
+          'options': [
+            'zero',
+            'two',
+            'three'
+          ]
+        },
+        {
+          'groupName': 'Mediums',
+          'options': [
+            'four',
+            'five',
+            'six'
+          ]
+        },
+        'one hundred',
+        'one thousand'
+      ]);
+    });
   });
 
   test('#stripDiacritics returns the given string with diacritics normalized into simple letters', function(assert) {

--- a/tests/unit/utils/group-utils-test.js
+++ b/tests/unit/utils/group-utils-test.js
@@ -1,6 +1,5 @@
-import { isGroup, indexOfOption, optionAtIndex, filterOptions, filterOptionsWithOffset, stripDiacritics, countOptions } from 'ember-power-select/utils/group-utils';
+import { isGroup, indexOfOption, optionAtIndex, filterOptions, filterOptionsWithOffset, stripDiacritics, countOptions, defaultTypeAheadMatcher } from 'ember-power-select/utils/group-utils';
 import { module, test } from 'qunit';
-import { defaultTypeAheadMatcher } from '../../../addon/utils/group-utils';
 
 const groupedOptions = [
   { groupName: 'Smalls', options: ['zero', 'one', 'two', 'three'] },


### PR DESCRIPTION
**NOTE** For this behaviour to work when the select is open, the user
needs to disable the search.

About this PR
======

This PR aims to give EPS a native-like behaviour.

What's the UX in current browsers?
======

For this, we compared safari, chrome, and firefox. Both safari and
chrome have different behaviours depending on whether the select is
open or closed. Firefox does not. We believe the select should behave
the same in both states, and a deeper look at blink's code seem to proof
it. For the purposes of this PR, the behaviour explained and implemented
is the one reproducible when the select is closed in safari and chrome
(firefox only implement such behaviour).

When a user focuses on a select, does not matter the state, they can
go to the next option that matches the treated input. The value the user
enters does not need to be the one that is used for matching, but
whatever the user types, it might not be what it's used for looking for
matches. The system keeps its 1s memory before forgetting the previous
search term (as it does now). Furthermore, the threshold in EPS is the
same we can find in webkit and blink.

The differences that this PR implements are two: search offsets and
cycling through the results. These behaviour are explained in depth
next.

Search offset
======

The original implementation applies an offset when looking for matching
results. If we are in _cycling mode_ (see next part) or starting a new
search (by focusing or not typing for 1s), the select will start looking
one result after the current highlighted / selected option. That means
that if we have selected an option that matches our current intention,
the user will not stay there, but go to the next option (if any). Once
you think about it, seems natural that if the user is interacting with
the component, it is because it is not interested in the current
selection.

On the other hand, if the user is typing a longer search term, the
offset can be 0, since the current option might be a valid one (changing
the original selection was already done when typing the first character,
see paragraph above).

In any case, current highlighted / selection index is added to the offset
above.

Cycling through the results
======

When a user focuses on a select and types a letter, let's say _a_, the
select will show the first result that matches _a_. If the user, within
the time threshold, types _a_ again, the select will go to the next
result that matches _a_ and not _aa_. That way, typing again the same
first letter several times let us cycle through the results.

It is important to note that this only works for the first character.
For example, _Unittt_ will not cycle through the result for _Unit_ in
a country selection.

Also, the repetitions need to be remembered. In a select full of names,
typing _aar_ will take us to the right selection (_Aaron_) and not to
a result for _ar_.

Show me the (original) code!
======

> Files linked here are pinned to the latest commit they were changed in.

The inital research was done via manual testing. Then, after inspecting
[blink's HTMLSelectElement
implementation](https://github.com/ChromiumWebApps/blink/blob/f26b5a9078d12d954a236c557776f4b1395726c6/Source/core/html/HTMLSelectElement.cpp), I studied
[blink's
TypeAhead](https://github.com/ChromiumWebApps/blink/blob/b6720b1767fb5208aa421237c087f062093929e7/Source/core/html/forms/TypeAhead.cpp). Current implementation is thought as a mix of
[TypeAhead::handleEvent](https://github.com/ChromiumWebApps/blink/blob/b6720b1767fb5208aa421237c087f062093929e7/Source/core/html/forms/TypeAhead.cpp#L60)
and
[filterOptions](https://github.com/cibernox/ember-power-select/blob/6b1e472d394a9322f9a25a668cf0686bbeb2ad2c/addon/utils/group-utils.js#L74-L95).

I stated above that the lack of cycling behaviour when the select is
open is quite likely a bug because of
[this comment that can be found in blink's
PopupListBox](https://github.com/ChromiumWebApps/blink/blob/f26b5a9078d12d954a236c557776f4b1395726c6/Source/web/PopupListBox.cpp#L320-L321).

Native matcher
======

The native matcher behaviour is just to look for a prefix.

```js
import { stripDiacritics } from 'ember-power-select/utils/group-utils';

function nativeMatcher(value, text) {
  return stripDiacritics(value).toUpperCase().startsWith(stripDiacritics(text).toUpperCase()) ? 1 : -1;
}
```

A new option has been added to tweak this behaviour: `typeAheadMatcher`.

Live example
======

You can find the behaviour of this PR in http://power-test.surge.sh/

- Try looking for _Aaron_
- Cycling behaviour is better done with the "F" (shorter and the group
in the second select is repeated).

TODO
======

- [x] Tests for power-select
- [x] Tests for filterWithOffset
- [x] Refactor filterWithOffset to findOption?