### PR TITLE
Prefer ember-native-dom-helpers helpers in tests

### DIFF
--- a/tests/integration/components/power-select/customization-with-components-test.js
+++ b/tests/integration/components/power-select/customization-with-components-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { countries } from '../constants';
 import { groupedNumbers } from '../constants';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
-import { find, findAll, click } from 'ember-native-dom-helpers';
+import { find, findAll, click, focus } from 'ember-native-dom-helpers';
 import { get } from '@ember/object';
 import Component from '@ember/component';
 import { isPresent } from '@ember/utils';
@@ -193,7 +193,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
       {{/power-select}}
     `);
 
-    find('#focusable-input').focus();
+    focus('#focusable-input');
   });
 
   test('the search message can be customized passing `searchMessageComponent`', async function(assert) {

--- a/tests/integration/components/power-select/disabled-test.js
+++ b/tests/integration/components/power-select/disabled-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
 import { clickTrigger, typeInSearch } from 'ember-power-select/test-support/helpers';
 import { numbers, countriesWithDisabled } from '../constants';
-import { find, findAll, triggerEvent, keyEvent, click } from 'ember-native-dom-helpers';
+import { find, findAll, triggerEvent, keyEvent, click, focus } from 'ember-native-dom-helpers';
 
 module('Integration | Component | Ember Power Select (Disabled)', function(hooks) {
   setupRenderingTest(hooks);
@@ -167,7 +167,7 @@ module('Integration | Component | Ember Power Select (Disabled)', function(hooks
     `);
 
     let trigger = find('.ember-power-select-trigger');
-    trigger.focus();
+    focus(trigger);
     assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is closed');
     keyEvent(trigger, 'keydown', 85); // u
     assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is still closed');

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -1009,7 +1009,7 @@ module('Integration | Component | Ember Power Select (General behavior)', functi
 
     assert.ok(!find('.ember-power-select-trigger').classList.contains('ember-power-select-trigger--active'), 'The select doesn\'t have the class yet');
     clickTrigger();
-    run(() => focus('.ember-power-select-search-input'));
+    focus('.ember-power-select-search-input');
     assert.ok(find('.ember-power-select-trigger').classList.contains('ember-power-select-trigger--active'), 'The select has the class now');
   });
 

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -14,7 +14,7 @@ import {
 } from '../constants';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ArrayProxy from '@ember/array/proxy';
-import { find, findAll, click, keyEvent, triggerEvent } from 'ember-native-dom-helpers';
+import { find, findAll, click, keyEvent, triggerEvent, focus } from 'ember-native-dom-helpers';
 
 const PromiseArrayProxy = ArrayProxy.extend(PromiseProxyMixin);
 
@@ -1009,7 +1009,7 @@ module('Integration | Component | Ember Power Select (General behavior)', functi
 
     assert.ok(!find('.ember-power-select-trigger').classList.contains('ember-power-select-trigger--active'), 'The select doesn\'t have the class yet');
     clickTrigger();
-    run(() => find('.ember-power-select-search-input').focus());
+    run(() => focus('.ember-power-select-search-input'));
     assert.ok(find('.ember-power-select-trigger').classList.contains('ember-power-select-trigger--active'), 'The select has the class now');
   });
 

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { triggerKeydown, clickTrigger, typeInSearch } from 'ember-power-select/test-support/helpers';
 import { numbers, numerals, countries, countriesWithDisabled, groupedNumbers, groupedNumbersWithDisabled } from '../constants';
-import { find, keyEvent } from 'ember-native-dom-helpers';
+import { find, keyEvent, focus } from 'ember-native-dom-helpers';
 import { run } from '@ember/runloop';
 
 module('Integration | Component | Ember Power Select (Keyboard control)', function(hooks) {
@@ -229,7 +229,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
       {{/power-select}}
     `);
 
-    run(() => find('.ember-power-select-trigger').focus());
+    run(() => focus('.ember-power-select-trigger'));
     assert.notOk(find('.ember-power-select-dropdown'), 'The select is closed');
     keyEvent('.ember-power-select-trigger', 'keydown', 13);
     assert.ok(find('.ember-power-select-dropdown'), 'The select is opened');
@@ -247,7 +247,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
       {{/power-select}}
     `);
 
-    run(() => find('.ember-power-select-trigger').focus());
+    run(() => focus('.ember-power-select-trigger'));
     assert.notOk(find('.ember-power-select-dropdown'), 'The select is closed');
     keyEvent('.ember-power-select-trigger', 'keydown', 32);
     assert.ok(find('.ember-power-select-dropdown'), 'The select is opened');
@@ -265,7 +265,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
       {{/power-select}}
     `);
 
-    run(() => find('.ember-power-select-trigger').focus());
+    run(() => focus('.ember-power-select-trigger'));
     assert.notOk(find('.ember-power-select-dropdown'), 'The select is closed');
     keyEvent('.ember-power-select-trigger', 'keydown', 40);
     assert.ok(find('.ember-power-select-dropdown'), 'The select is opened');
@@ -281,7 +281,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
       {{/power-select}}
     `);
 
-    run(() => find('.ember-power-select-trigger').focus());
+    run(() => focus('.ember-power-select-trigger'));
     assert.notOk(find('.ember-power-select-dropdown'), 'The select is closed');
     keyEvent('.ember-power-select-trigger', 'keydown', 38);
     assert.ok(find('.ember-power-select-dropdown'), 'The select is opened');
@@ -465,7 +465,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
     `);
 
     let trigger = find('.ember-power-select-trigger');
-    trigger.focus();
+    focus(trigger);
     assert.notOk(find('.ember-power-select-dropdown'), 'The dropdown is closed');
     keyEvent(trigger, 'keydown', 78); // n
     keyEvent(trigger, 'keydown', 73); // i
@@ -485,7 +485,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
     `);
 
     let trigger = find('.ember-power-select-trigger');
-    trigger.focus();
+    focus(trigger);
     assert.notOk(find('.ember-power-select-dropdown'), 'The dropdown is closed');
     keyEvent(trigger, 'keydown', 82, { ctrlKey: true }); // r
     assert.notEqual(trigger.textContent.trim(), 'three', '"three" is not selected');
@@ -578,7 +578,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
     `);
 
     let trigger = find('.ember-power-select-trigger');
-    trigger.focus();
+    focus(trigger);
     assert.notOk(find('.ember-power-select-dropdown'),  'The dropdown is closed');
     triggerKeydown(trigger, 84); // t
     triggerKeydown(trigger, 87); // w
@@ -603,7 +603,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
     `);
 
     let trigger = find('.ember-power-select-trigger');
-    trigger.focus();
+    focus(trigger);
     assert.equal(trigger.textContent.trim(), '', 'nothing is selected');
     triggerKeydown(trigger, 78); // n
     triggerKeydown(trigger, 73); // i
@@ -823,7 +823,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
       {{/power-select}}
     `);
     let trigger = find('.ember-power-select-trigger');
-    trigger.focus();
+    focus(trigger);
     assert.equal(find('.ember-power-select-selected-item').textContent.trim(), '25');
     assert.expectAssertion(() => {
       triggerKeydown(trigger, 67); // c

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -5,7 +5,6 @@ import hbs from 'htmlbars-inline-precompile';
 import { triggerKeydown, clickTrigger, typeInSearch } from 'ember-power-select/test-support/helpers';
 import { numbers, numerals, countries, countriesWithDisabled, groupedNumbers, groupedNumbersWithDisabled } from '../constants';
 import { find, keyEvent, focus } from 'ember-native-dom-helpers';
-import { run } from '@ember/runloop';
 
 module('Integration | Component | Ember Power Select (Keyboard control)', function(hooks) {
   setupRenderingTest(hooks);
@@ -229,7 +228,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
       {{/power-select}}
     `);
 
-    run(() => focus('.ember-power-select-trigger'));
+    focus('.ember-power-select-trigger');
     assert.notOk(find('.ember-power-select-dropdown'), 'The select is closed');
     keyEvent('.ember-power-select-trigger', 'keydown', 13);
     assert.ok(find('.ember-power-select-dropdown'), 'The select is opened');
@@ -247,7 +246,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
       {{/power-select}}
     `);
 
-    run(() => focus('.ember-power-select-trigger'));
+    focus('.ember-power-select-trigger');
     assert.notOk(find('.ember-power-select-dropdown'), 'The select is closed');
     keyEvent('.ember-power-select-trigger', 'keydown', 32);
     assert.ok(find('.ember-power-select-dropdown'), 'The select is opened');
@@ -265,7 +264,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
       {{/power-select}}
     `);
 
-    run(() => focus('.ember-power-select-trigger'));
+    focus('.ember-power-select-trigger');
     assert.notOk(find('.ember-power-select-dropdown'), 'The select is closed');
     keyEvent('.ember-power-select-trigger', 'keydown', 40);
     assert.ok(find('.ember-power-select-dropdown'), 'The select is opened');
@@ -281,7 +280,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
       {{/power-select}}
     `);
 
-    run(() => focus('.ember-power-select-trigger'));
+    focus('.ember-power-select-trigger');
     assert.notOk(find('.ember-power-select-dropdown'), 'The select is closed');
     keyEvent('.ember-power-select-trigger', 'keydown', 38);
     assert.ok(find('.ember-power-select-dropdown'), 'The select is opened');

--- a/tests/integration/components/power-select/multiple-test.js
+++ b/tests/integration/components/power-select/multiple-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { typeInSearch, clickTrigger } from 'ember-power-select/test-support/helpers';
 import { numbers, names, countries, countriesWithDisabled } from '../constants';
-import { find, findAll, click, tap, keyEvent } from 'ember-native-dom-helpers';
+import { find, findAll, click, tap, keyEvent, focus } from 'ember-native-dom-helpers';
 import RSVP from 'rsvp';
 import EmberObject, { get } from '@ember/object';
 import { isEmpty } from '@ember/utils';
@@ -289,7 +289,7 @@ module('Integration | Component | Ember Power Select (Multiple)', function(hooks
     `);
 
     let trigger = find('.ember-power-select-trigger');
-    trigger.focus();
+    focus(trigger);
     assert.notOk(find('.ember-power-select-dropdown'), 'Dropdown is not rendered');
     keyEvent(trigger, 'keydown', 13);
     assert.ok(find('.ember-power-select-dropdown'), 'Dropdown is rendered');

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -237,7 +237,7 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       {{/power-select}}
     `);
 
-    run(() => focus('.ember-power-select-trigger'));
+    focus('.ember-power-select-trigger');
   });
 
   test('The onfocus of multiple selects action receives the public API and the focus event', async function(assert) {
@@ -255,7 +255,7 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       {{/power-select-multiple}}
     `);
 
-    run(() => focus('.ember-power-select-trigger'));
+    focus('.ember-power-select-trigger');
   });
 
   test('The onfocus of multiple selects also gets called when the thing getting the focus is the searbox', async function(assert) {
@@ -273,7 +273,7 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       {{/power-select-multiple}}
     `);
 
-    run(() => focus('.ember-power-select-trigger-multiple-input'));
+    focus('.ember-power-select-trigger-multiple-input');
   });
 
   test('The onblur of single selects action receives the public API and the event', async function(assert) {
@@ -292,8 +292,8 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       <input type="text" id="other-element"/>
     `);
 
-    run(() => focus('.ember-power-select-trigger'));
-    run(() => focus('#other-element'));
+    focus('.ember-power-select-trigger');
+    focus('#other-element');
   });
 
   test('The onblur of multiple selects action receives the public API and the focus event', async function(assert) {
@@ -312,8 +312,8 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       <input type="text" id="other-element"/>
     `);
 
-    run(() => focus('.ember-power-select-trigger-multiple-input'));
-    run(() => focus('#other-element'));
+    focus('.ember-power-select-trigger-multiple-input');
+    focus('#other-element');
   });
 
   test('The onblur of multiple selects also gets called when the thing getting the focus is the searbox', async function(assert) {

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -237,7 +237,7 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       {{/power-select}}
     `);
 
-    run(() => find('.ember-power-select-trigger').focus());
+    run(() => focus('.ember-power-select-trigger'));
   });
 
   test('The onfocus of multiple selects action receives the public API and the focus event', async function(assert) {
@@ -255,7 +255,7 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       {{/power-select-multiple}}
     `);
 
-    run(() => find('.ember-power-select-trigger').focus());
+    run(() => focus('.ember-power-select-trigger'));
   });
 
   test('The onfocus of multiple selects also gets called when the thing getting the focus is the searbox', async function(assert) {
@@ -273,7 +273,7 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       {{/power-select-multiple}}
     `);
 
-    run(() => find('.ember-power-select-trigger-multiple-input').focus());
+    run(() => focus('.ember-power-select-trigger-multiple-input'));
   });
 
   test('The onblur of single selects action receives the public API and the event', async function(assert) {
@@ -292,8 +292,8 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       <input type="text" id="other-element"/>
     `);
 
-    run(() => find('.ember-power-select-trigger').focus());
-    run(() => find('#other-element').focus());
+    run(() => focus('.ember-power-select-trigger'));
+    run(() => focus('#other-element'));
   });
 
   test('The onblur of multiple selects action receives the public API and the focus event', async function(assert) {
@@ -312,8 +312,8 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       <input type="text" id="other-element"/>
     `);
 
-    run(() => find('.ember-power-select-trigger-multiple-input').focus());
-    run(() => find('#other-element').focus());
+    run(() => focus('.ember-power-select-trigger-multiple-input'));
+    run(() => focus('#other-element'));
   });
 
   test('The onblur of multiple selects also gets called when the thing getting the focus is the searbox', async function(assert) {

--- a/tests/integration/components/power-select/type-ahead-test.js
+++ b/tests/integration/components/power-select/type-ahead-test.js
@@ -3,11 +3,11 @@ import hbs from 'htmlbars-inline-precompile';
 import { optionAtIndex } from 'ember-power-select/utils/group-utils';
 import { triggerKeydown, clickTrigger } from 'ember-power-select/test-support/helpers';
 import { charCode, namesStartingWithA } from '../constants';
-import { find } from 'ember-native-dom-helpers';
+import { find, focus } from 'ember-native-dom-helpers';
 
 const WITH_EPS_CLOSED = {
   beforeInteraction(trigger, assert) {
-    trigger.focus();
+    focus(trigger);
     assert.equal(trigger.textContent.trim(), '', 'no value selected');
     assert.notOk(find('.ember-power-select-dropdown'), 'The dropdown is closed');
   },


### PR DESCRIPTION
This PR replaces the calls to DOM methods `.focus()` and `.blur()` in tests
with helpers from `ember-native-dom-helpers`.

The corresponding `run` wrappers have also been removed.