### PR TITLE
Adding ability to override defaults in config

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { getWithDefault, computed } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import { isEqual } from '@ember/utils';
@@ -23,6 +23,9 @@ import {
   defaultTypeAheadMatcher
 } from '../utils/group-utils';
 import { task, timeout } from 'ember-concurrency';
+import config from 'ember-get-config';
+
+const globalConfig = config['ember-power-select']; // Import app config object
 
 // Copied from Ember. It shouldn't be necessary in Ember 2.5+
 const assign = Object.assign || function EmberAssign(original, ...args) {
@@ -76,7 +79,7 @@ export default Component.extend({
 
   // Options
   searchEnabled: fallbackIfUndefined(true),
-  matchTriggerWidth: fallbackIfUndefined(true),
+  matchTriggerWidth: fallbackIfUndefined(getWithDefault(globalConfig, 'matchTriggerWidth',  true)),
   preventScroll: fallbackIfUndefined(false),
   matcher: fallbackIfUndefined(defaultMatcher),
   loadingMessage: fallbackIfUndefined('Loading options...'),

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-cli-babel": "^6.10.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-concurrency": "^0.8.12",
+    "ember-get-config": "^0.2.4",
     "ember-text-measurer": "^0.4.0",
     "ember-truth-helpers": "^2.0.0"
   },


### PR DESCRIPTION
This is only a proof of concept to see if you are happy with the idea, and if so we can extend it to all/any of the parameters you want to be able to set the defaults for in config.

The basic idea here is: you have a sensible default set for `matchTriggerWidth` on ember-power-select but I need this default to be different for **all instances** of ember-power-select across my codebase.

Using a trick similar to we use in [ember-cli-notifications](https://github.com/stonecircle/ember-cli-notifications/blob/master/addon/services/notification-messages-service.js#L26) I have been able to test this locally with a linked ember-power-select. If you like the idea I can (try) implement some tests using https://github.com/tomdale/ember-cli-addon-tests.