### PR TITLE
Added new option allowEmptySearch

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -79,6 +79,7 @@ export default Component.extend({
   matchTriggerWidth: fallbackIfUndefined(true),
   preventScroll: fallbackIfUndefined(false),
   matcher: fallbackIfUndefined(defaultMatcher),
+  allowEmptySearch: fallbackIfUndefined(false),
   loadingMessage: fallbackIfUndefined('Loading options...'),
   noMatchesMessage: fallbackIfUndefined('No results found'),
   searchMessage: fallbackIfUndefined('Type to search'),
@@ -186,7 +187,9 @@ export default Component.extend({
 
   mustShowSearchMessage: computed('publicAPI.{loading,searchText,resultsCount}', 'search', 'searchMessage', function() {
     let publicAPI = this.get('publicAPI');
-    return !publicAPI.loading && publicAPI.searchText.length === 0
+    let allowEmptySearch = this.get('allowEmptySearch');
+    return !publicAPI.loading
+      && !allowEmptySearch && publicAPI.searchText.length === 0
       && !!this.get('search') && !!this.get('searchMessage')
       && publicAPI.resultsCount === 0;
   }),
@@ -270,7 +273,7 @@ export default Component.extend({
     },
 
     search(term) {
-      if (isBlank(term)) {
+      if (!this.get('allowEmptySearch') && isBlank(term)) {
         this._resetSearch();
       } else if (this.get('search')) {
         this._performSearch(term);

--- a/tests/integration/components/power-select/custom-search-test.js
+++ b/tests/integration/components/power-select/custom-search-test.js
@@ -841,5 +841,45 @@ module('Integration | Component | Ember Power Select (Custom search function)', 
       done();
     }, 250);
   });
+
+  test('If allowEmptySearch is true, still perform a search even when search box is empty', async function(assert) {
+    assert.expect(4);
+    let done = assert.async();
+
+    this.searchFn = function(term) {
+      return new RSVP.Promise(function(resolve) {
+        later(function() {
+          resolve(countries.filter((country) => country.name.indexOf(term) > -1));
+        }, 50);
+      });
+    };
+
+    await render(hbs`
+      {{#power-select search=searchFn allowEmptySearch=true onchange=(action (mut foo)) as |country|}}
+        {{country.name}}
+      {{/power-select}}
+    `);
+
+    clickTrigger();
+    typeInSearch('Brazil');
+    later(() => {
+      assert.equal(findAll('.ember-power-select-option').length, 1, 'There should be one option');
+      typeInSearch('I\'m invalid contry');
+    }, 60);
+
+    later(() => {
+      assert.equal(findAll('.ember-power-select-option--no-matches-message').length, 1, 'There should be no option.');
+      typeInSearch('');
+    }, 120);
+
+    later(() => {
+      assert.equal(findAll('.ember-power-select-option--no-matches-message').length, 0, 'There should have result.');
+      assert.ok(findAll('.ember-power-select-option').length > 1, 'There should be at least one option.');
+    }, 180);
+
+    later(function() {
+      done();
+    }, 200);
+  });
 });
 


### PR DESCRIPTION
Added a new option `allowEmptySearch`, to ensure `search` method is still be called even when the search box is empty.

The background case is like that. We are having a large array to list in power-select. If we show all of them when first open the panel, the performance is bad. We decide to use a custom `search`  to only show top 20 matched items, even when the search box is empty. But right now, when search box is empty, power select automatically skip calling search. That's why we need this option.