### PR TITLE
Allows to customise the caret of the trigger

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -94,6 +94,7 @@ export default Component.extend({
   triggerComponent: fallbackIfUndefined('power-select/trigger'),
   searchMessageComponent: fallbackIfUndefined('power-select/search-message'),
   placeholderComponent: fallbackIfUndefined('power-select/placeholder'),
+  caretComponent: fallbackIfUndefined('power-select/caret'),
   buildSelection: fallbackIfUndefined(function buildSelection(option) {
     return option;
   }),

--- a/addon/components/power-select/caret.js
+++ b/addon/components/power-select/caret.js
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+import layout from '../../templates/components/power-select/caret';
+
+export default Component.extend({
+  layout,
+  classNames: ['ember-power-select-caret']
+});

--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -35,6 +35,7 @@
     optionsComponent=optionsComponent
     placeholder=placeholder
     placeholderComponent=placeholderComponent
+    caretComponent=caretComponent
     preventScroll=preventScroll
     registerAPI=(readonly registerAPI)
     renderInPlace=renderInPlace
@@ -95,6 +96,7 @@
     optionsComponent=optionsComponent
     placeholder=placeholder
     placeholderComponent=placeholderComponent
+    caretComponent=caretComponent
     preventScroll=preventScroll
     registerAPI=(readonly registerAPI)
     renderInPlace=renderInPlace

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -36,4 +36,4 @@
       onkeydown={{action "onKeydown"}}>
   {{/if}}
 </ul>
-<span class="ember-power-select-status-icon"></span>
+{{component caretComponent select=select}}

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -40,6 +40,7 @@
       onInput=(action "onInput")
       placeholder=(readonly placeholder)
       placeholderComponent=(readonly placeholderComponent)
+      caretComponent=(readonly caretComponent)
       onKeydown=(action "onKeydown")
       searchEnabled=(readonly searchEnabled)
       searchField=(readonly searchField)

--- a/addon/templates/components/power-select/caret.hbs
+++ b/addon/templates/components/power-select/caret.hbs
@@ -1,0 +1,1 @@
+<span class="ember-power-select-status-icon"></span>

--- a/addon/templates/components/power-select/trigger.hbs
+++ b/addon/templates/components/power-select/trigger.hbs
@@ -10,4 +10,4 @@
 {{else}}
   {{component placeholderComponent placeholder=placeholder}}
 {{/if}}
-<span class="ember-power-select-status-icon"></span>
+{{component caretComponent select=select}}

--- a/app/components/power-select/caret.js
+++ b/app/components/power-select/caret.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-power-select/components/power-select/caret';

--- a/tests/integration/components/power-select/caret-test.js
+++ b/tests/integration/components/power-select/caret-test.js
@@ -1,0 +1,12 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import { find } from 'ember-native-dom-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('power-select/caret', 'Integration | Component | power select/caret', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.render(hbs`{{power-select/caret}}`);
+  assert.ok(find('.ember-power-select-caret > .ember-power-select-status-icon'), 'the caret is correctly rendered');
+});

--- a/tests/integration/components/power-select/customization-with-components-test.js
+++ b/tests/integration/components/power-select/customization-with-components-test.js
@@ -211,6 +211,39 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.ok(find('.ember-power-select-dropdown #custom-search-message-p-tag'), 'The custom component is rendered instead of the usual message');
   });
 
+  test('A caret is displayed', async function(assert) {
+    this.countries = countries;
+
+    await render(hbs`
+      {{#power-select
+        options=countries
+        onchange=(action (mut foo)) as |country|}}
+        {{country.name}}
+      {{/power-select}}
+    `);
+
+    assert.ok(find('.ember-power-select-caret > .ember-power-select-status-icon'), 'The default caret appears.');
+  });
+
+  test('The caret can be customizd using caretComponent', async function(assert) {
+    this.countries = countries;
+
+    this.owner.register('component:custom-caret', Component.extend({
+      classNames: ['my-custom-caret']
+    }));
+
+    await render(hbs`
+      {{#power-select
+        options=countries
+        caretComponent="custom-caret"
+        onchange=(action (mut foo)) as |country|}}
+        {{country.name}}
+      {{/power-select}}
+    `);
+
+    assert.ok(find('.my-custom-caret'), 'The custom caret appears.');
+  });
+
   test('placeholder can be customized using placeholderComponent', async function(assert) {
     assert.expect(2);
 


### PR DESCRIPTION
This PR is on the same track as the customisation od the Placeholder component, but dedicated to the caret (right-hand side arrow).

Our use case for this feature is the ability to use an `x` sign instead to clear the selection, which implies:
* changing the design (hence markup etc.)
* binding actions
