### PR TITLE
selectedItemComponent into beforeOptionsComponent

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -62,7 +62,8 @@
       placeholder=(readonly placeholder)
       placeholderComponent=(readonly placeholderComponent)
       searchPlaceholder=(readonly searchPlaceholder)
-      select=(readonly publicAPI)}}
+      select=(readonly publicAPI)
+      selectedItemComponent=(readonly selectedItemComponent)}}
     {{#if mustShowSearchMessage}}
       {{component searchMessageComponent
         searchMessage=(readonly searchMessage)


### PR DESCRIPTION
Make `selectedItemComponent` available in `beforeOptionsComponent`. This will allow for a persistent header showing the overall selected items inside of `power-select-multiple`. This matters in the case where the list ends up scrolling.