### PR TITLE
Import click and fillIn from ember-native-dom-helpers / Fix #1085

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,5 +1,5 @@
-import { click, fillIn, settled } from '@ember/test-helpers';
-import { find, findAll } from 'ember-native-dom-helpers';
+import { settled } from '@ember/test-helpers';
+import { click, fillIn, find, findAll } from 'ember-native-dom-helpers';
 import { warn } from '@ember/debug';
 
 export async function selectChoose(cssPathOrTrigger, valueOrSelector, optionIndex) {

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -1007,7 +1007,7 @@ export function stripDiacritics(text) {
   function match(a) {
     return DIACRITICS[a] || a;
   }
-  
+
   return `${text}`.replace(/[^\u0000-\u007E]/g, match); // eslint-disable-line
 }
 

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -1007,8 +1007,9 @@ export function stripDiacritics(text) {
   function match(a) {
     return DIACRITICS[a] || a;
   }
-
+  /* eslint-disable */
   return `${text}`.replace(/[^\u0000-\u007E]/g, match);
+  /* eslint-enable */
 }
 
 export function defaultMatcher(value, text) {

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -1007,6 +1007,7 @@ export function stripDiacritics(text) {
   function match(a) {
     return DIACRITICS[a] || a;
   }
+  
   return `${text}`.replace(/[^\u0000-\u007E]/g, match); // eslint-disable-line
 }
 

--- a/addon/utils/group-utils.js
+++ b/addon/utils/group-utils.js
@@ -1007,9 +1007,7 @@ export function stripDiacritics(text) {
   function match(a) {
     return DIACRITICS[a] || a;
   }
-  /* eslint-disable */
-  return `${text}`.replace(/[^\u0000-\u007E]/g, match);
-  /* eslint-enable */
+  return `${text}`.replace(/[^\u0000-\u007E]/g, match); // eslint-disable-line
 }
 
 export function defaultMatcher(value, text) {


### PR DESCRIPTION
Importing `click` and `fillIn` directly from `@ember/test-helpers` causes #1085. This change was introduced on Version `2.0.0-beta.3`. Here: https://github.com/cibernox/ember-power-select/commit/87b898f40bf5909d4149d7891f084bcbff352ec1#diff-aeaa9ea987e086a3faddb603853d857aR1