### PR TITLE
fixes nested native getter

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -138,7 +138,7 @@ export default Component.extend({
       return null;
     },
     set(_, selected) {
-      if (selected && selected.then) {
+      if (selected && get(selected, 'then')) {
         this.get('_updateSelectedTask').perform(selected);
       } else {
         scheduleOnce('actions', this, this.updateSelection, selected);


### PR DESCRIPTION
This fixes #1094 

I just used the `get` function here, although i suspect there's probably a more elegant way to see if an object is `then-able`. 

I'm not sure how to write a test for this, but my fix doesn't break any existing tests and It Works On My Machine (and in my app) (TM). 
