### PR TITLE
[ENHANCEMENT] Propagate aria to options component

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -169,6 +169,18 @@ export default Component.extend({
     }
   }),
 
+  optionIds: computed('options.[]','publicAPI.optionsId', function() {
+    debugger
+    return this.get('options').reduce((acc, option, index) => {
+      acc[option]=`${this.get('optionsId')}-option-${index}`;
+      return acc;
+    }, {});
+  }),
+
+  activeDescendant: computed('optionIds', 'publicAPI.highlighted', function() {
+    return this.get('optionIds')[this.get('publicAPI.highlighted')];
+  }),
+
   optionMatcher: optionsMatcher('matcher', defaultMatcher),
 
   typeAheadOptionMatcher: optionsMatcher('typeAheadMatcher', defaultTypeAheadMatcher),

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -85,7 +85,7 @@ export default Component.extend({
   closeOnSelect: fallbackIfUndefined(true),
   defaultHighlighted: fallbackIfUndefined(defaultHighlighted),
   typeAheadMatcher: fallbackIfUndefined(defaultTypeAheadMatcher),
-
+  triggerRole: fallbackIfUndefined('combobox'),
   afterOptionsComponent: fallbackIfUndefined(null),
   beforeOptionsComponent: fallbackIfUndefined('power-select/before-options'),
   optionsComponent: fallbackIfUndefined('power-select/options'),

--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -26,7 +26,12 @@ export default Component.extend({
   isTouchDevice,
   layout,
   tagName: 'ul',
-  attributeBindings: ['role', 'aria-controls'],
+  attributeBindings: [
+    'role',
+    'aria-controls',
+    'ariaLabel:aria-label',
+    'ariaLabelledBy:aria-labelledby'
+  ],
   role: 'listbox',
 
   // Lifecycle hooks

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -83,6 +83,8 @@
     {{else}}
       {{#component optionsComponent
         class="ember-power-select-options"
+        ariaLabel=(readonly ariaLabel)
+        ariaLabelledBy=(readonly ariaLabelledBy)
         extra=(readonly extra)
         groupIndex=""
         loadingMessage=(readonly loadingMessage)

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -56,6 +56,7 @@
     {{component beforeOptionsComponent
       extra=(readonly extra)
       listboxId=(readonly optionsId)
+      ariaActivedescendant=ariaActivedescendant
       onInput=(action "onInput")
       onKeydown=(action "onKeydown")
       searchEnabled=(readonly searchEnabled)

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -15,6 +15,7 @@
   as |dropdown|}}
 
   {{#dropdown.trigger
+    aria-activedescendant=activeDescendant
     role=(readonly triggerRole)
     tagName=(readonly _triggerTagName)
     ariaDescribedBy=(readonly ariaDescribedBy)
@@ -83,6 +84,7 @@
     {{else}}
       {{#component optionsComponent
         class="ember-power-select-options"
+        optionIds=optionIds
         ariaLabel=(readonly ariaLabel)
         ariaLabelledBy=(readonly ariaLabelledBy)
         extra=(readonly extra)

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -17,6 +17,7 @@
   {{#dropdown.trigger
     aria-activedescendant=activeDescendant
     role=(readonly triggerRole)
+    aria-autocomplete=(if searchEnabled "list" "none")
     tagName=(readonly _triggerTagName)
     ariaDescribedBy=(readonly ariaDescribedBy)
     ariaInvalid=(readonly ariaInvalid)
@@ -56,7 +57,7 @@
     {{component beforeOptionsComponent
       extra=(readonly extra)
       listboxId=(readonly optionsId)
-      ariaActivedescendant=ariaActivedescendant
+      ariaActivedescendant=activeDescendant
       onInput=(action "onInput")
       onKeydown=(action "onKeydown")
       searchEnabled=(readonly searchEnabled)

--- a/addon/templates/components/power-select/before-options.hbs
+++ b/addon/templates/components/power-select/before-options.hbs
@@ -6,6 +6,8 @@
       class="ember-power-select-search-input"
       value={{select.searchText}}
       aria-controls={{listboxId}}
+      aria-owns={{listboxId}}
+      aria-activedescendant={{ariaActivedescendant}}
       placeholder={{searchPlaceholder}}
       oninput={{onInput}}
       onfocus={{onFocus}}

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -26,9 +26,8 @@
     <li
       id="{{get optionIds opt}}"
       class="ember-power-select-option"
-      aria-selected="{{ember-power-select-is-selected opt select.selected}}"
       aria-disabled={{ember-power-select-true-string-if-present opt.disabled}}
-      aria-current="{{eq opt select.highlighted}}"
+      aria-selected="{{or (eq opt select.highlighted)}}"
       data-option-index="{{groupIndex}}{{index}}"
       role="option">
       {{yield opt select}}

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -23,7 +23,9 @@
       {{/component}}
     {{/component}}
   {{else}}
-    <li class="ember-power-select-option"
+    <li
+      id="{{get optionIds opt}}"
+      class="ember-power-select-option"
       aria-selected="{{ember-power-select-is-selected opt select.selected}}"
       aria-disabled={{ember-power-select-true-string-if-present opt.disabled}}
       aria-current="{{eq opt select.highlighted}}"


### PR DESCRIPTION
propagates label of push button to listbox element.
![image](https://user-images.githubusercontent.com/1640136/39200422-aec2f584-481e-11e8-84ea-bc4dcf518927.png)

Still need to explore the other 2 `role="listbox"` elements.
May break if a different options component is used.

**Motivation**

https://github.com/tradegecko/ember-semantic-test-helpers/pull/3



**Edit**

Trying to get voice over to announce the currently selected item as you use the up and down arrows.

- problem 1 active-descendent does not support button.

so i moved to the power select with search box, 

- problem 2 aria-selected is the only thing that gets announced as you use the up and down arrows

so i made aria-selected the currently highlighted element.

- problem 3 now it announces the item previous item when i press up and down :'(

resouces
https://www.w3.org/TR/wai-aria-1.1/#aria-selected
https://www.w3.org/TR/wai-aria-1.1/#aria-current
https://www.w3.org/TR/wai-aria-1.1/#aria-activedescendant

https://codepen.io/billybonks/full/jxMYpr/ ( trying to get this behavior )