### PR TITLE
Remove native dom helpers

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,5 +1,4 @@
 import { click, fillIn, settled } from '@ember/test-helpers';
-import { find, findAll } from 'ember-native-dom-helpers';
 import { warn } from '@ember/debug';
 
 export async function selectChoose(cssPathOrTrigger, valueOrSelector, optionIndex) {
@@ -8,13 +7,13 @@ export async function selectChoose(cssPathOrTrigger, valueOrSelector, optionInde
     if (cssPathOrTrigger.classList.contains('ember-power-select-trigger')) {
       trigger = cssPathOrTrigger;
     } else {
-      trigger = find('.ember-power-select-trigger', cssPathOrTrigger);
+      trigger = cssPathOrTrigger.querySelector('.ember-power-select-trigger');
     }
   } else {
-    trigger = find(`${cssPathOrTrigger} .ember-power-select-trigger`);
+    trigger = document.querySelector(`${cssPathOrTrigger} .ember-power-select-trigger`);
 
     if (!trigger) {
-      trigger = find(cssPathOrTrigger);
+      trigger = document.querySelector(cssPathOrTrigger);
     }
 
     if (!trigger) {
@@ -27,7 +26,7 @@ export async function selectChoose(cssPathOrTrigger, valueOrSelector, optionInde
   }
 
   let contentId = `${trigger.attributes['aria-owns'].value}`;
-  let content = find(`#${contentId}`);
+  let content = document.querySelector(`#${contentId}`);
   // If the dropdown is closed, open it
   if (!content || content.classList.contains('ember-basic-dropdown-content-placeholder')) {
     await click(trigger);
@@ -35,11 +34,12 @@ export async function selectChoose(cssPathOrTrigger, valueOrSelector, optionInde
   }
 
   // Select the option with the given text
-  let options = findAll(`#${contentId} .ember-power-select-option`);
-  let potentialTargets = options.filter((opt) => opt.textContent.indexOf(valueOrSelector) > -1);
+  let options = document.querySelectorAll(`#${contentId} .ember-power-select-option`);
+  let potentialTargets = [].slice.apply(options).filter((opt) => opt.textContent.indexOf(valueOrSelector) > -1);
   if (potentialTargets.length === 0) {
-    potentialTargets = findAll(`#${contentId} ${valueOrSelector}`);
+    potentialTargets = document.querySelectorAll(`#${contentId} ${valueOrSelector}`);
   }
+  console.log("PT", potentialTargets)
   if (potentialTargets.length > 1) {
     let filteredTargets = [].slice.apply(potentialTargets).filter((t) => t.textContent.trim() === valueOrSelector);
     if (optionIndex === undefined) {
@@ -63,10 +63,10 @@ export async function selectSearch(cssPathOrTrigger, value) {
     trigger = cssPathOrTrigger;
   } else {
     let triggerPath = `${cssPathOrTrigger} .ember-power-select-trigger`;
-    trigger = find(triggerPath);
+    trigger = document.querySelector(triggerPath);
     if (!trigger) {
       triggerPath = cssPathOrTrigger;
-      trigger = find(triggerPath);
+      trigger = document.querySelector(triggerPath);
     }
 
     if (!trigger) {
@@ -79,24 +79,24 @@ export async function selectSearch(cssPathOrTrigger, value) {
   }
 
   let contentId = `${trigger.attributes['aria-owns'].value}`;
-  let isMultipleSelect = !!find('.ember-power-select-trigger-multiple-input', trigger);
+  let isMultipleSelect = !!trigger.querySelector('.ember-power-select-trigger-multiple-input');
 
-  let content = find(`#${contentId}`);
+  let content = document.querySelector(`#${contentId}`);
   let dropdownIsClosed = !content || content.classList.contains('ember-basic-dropdown-content-placeholder');
   if (dropdownIsClosed) {
     await click(trigger);
     await settled();
   }
-  let isDefaultSingleSelect = !!find('.ember-power-select-search-input');
+  let isDefaultSingleSelect = !!document.querySelector('.ember-power-select-search-input');
 
   if (isMultipleSelect) {
-    await fillIn(find('.ember-power-select-trigger-multiple-input', trigger), value);
+    await fillIn(trigger.querySelector('.ember-power-select-trigger-multiple-input'), value);
   } else if (isDefaultSingleSelect) {
     await fillIn('.ember-power-select-search-input', value);
   } else { // It's probably a customized version
-    let inputIsInTrigger = !!find('.ember-power-select-trigger input[type=search]', trigger);
+    let inputIsInTrigger = !!trigger.querySelector('.ember-power-select-trigger input[type=search]');
     if (inputIsInTrigger) {
-      await fillIn(find('input[type=search]', trigger), value);
+      await fillIn(trigger.querySelector('input[type=search]'), value);
     } else {
       await fillIn(`#${contentId} .ember-power-select-search-input[type=search]`, 'input');
     }
@@ -106,10 +106,10 @@ export async function selectSearch(cssPathOrTrigger, value) {
 
 export async function removeMultipleOption(cssPath, value) {
   let elem;
-  let items = findAll(`${cssPath} .ember-power-select-multiple-options > li`);
-  let item = items.find((el) => el.textContent.indexOf(value) > -1);
+  let items = document.querySelectorAll(`${cssPath} .ember-power-select-multiple-options > li`);
+  let item = [].slice.apply(items).find((el) => el.textContent.indexOf(value) > -1);
   if (item) {
-    elem = find('.ember-power-select-multiple-remove-btn', item);
+    elem = item.querySelector('.ember-power-select-multiple-remove-btn');
   }
   try {
     await click(elem);
@@ -121,7 +121,7 @@ export async function removeMultipleOption(cssPath, value) {
 }
 
 export async function clearSelected(cssPath) {
-  let elem = find(`${cssPath} .ember-power-select-clear-btn`);
+  let elem = document.querySelector(`${cssPath} .ember-power-select-clear-btn`);
   try {
     await click(elem);
     return settled();

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "ember-href-to": "1.15.1",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-native-dom-helpers": "^0.6.2",
     "ember-qunit-assert-helpers": "^0.2.1",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,13 +2769,6 @@ ember-maybe-in-element@^0.1.3:
   dependencies:
     ember-cli-babel "^6.11.0"
 
-ember-native-dom-helpers@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.2.tgz#ad1f82d64ac9abdd612022f4f390bdb6653b3d39"
-  dependencies:
-    broccoli-funnel "^1.1.0"
-    ember-cli-babel "^6.6.0"
-
 ember-qunit-assert-helpers@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ember-qunit-assert-helpers/-/ember-qunit-assert-helpers-0.2.1.tgz#4a77f8ff252e47cc53db6fa7fb4becb426de8d29"


### PR DESCRIPTION
Fixes https://github.com/cibernox/ember-power-select/issues/1095

Following up with https://github.com/cibernox/ember-power-select/commit/d696c282ecb922b82e49d60ad246bd6439652af8, this PR removes the last references to ember-native-dom-helpers in the codebase.

The build fails, but only for the same reasons that master is failing currently.