### PR TITLE
fix IE11 placeholder workaround on ember 3.1

### DIFF
--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -68,7 +68,7 @@ export default Component.extend({
 
   maybePlaceholder: computed('placeholder', 'select.selected.length', function() {
     if (isIE) {
-      return null;
+      return;
     }
     let select = this.get('select');
     return (!select.selected || get(select.selected, 'length') === 0) ? (this.get('placeholder') || '') : '';


### PR DESCRIPTION
After upgrading from ember 2.18.2 to 3.1.1, the IE11 bug fixed by #355 reappeared. Evidently you need to return `undefined` now instead of `null`.