### PR TITLE
Remove console.log from test helper

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -39,7 +39,6 @@ export async function selectChoose(cssPathOrTrigger, valueOrSelector, optionInde
   if (potentialTargets.length === 0) {
     potentialTargets = document.querySelectorAll(`#${contentId} ${valueOrSelector}`);
   }
-  console.log("PT", potentialTargets)
   if (potentialTargets.length > 1) {
     let filteredTargets = [].slice.apply(potentialTargets).filter((t) => t.textContent.trim() === valueOrSelector);
     if (optionIndex === undefined) {


### PR DESCRIPTION
Remove a console.log, which clutters the test output. See #1114 .