### PR TITLE
Remove requirement to provide a search field when using multiple select

### DIFF
--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -100,7 +100,6 @@ export default Component.extend({
               select.actions.search(lastSelection);
             } else {
               let searchField = this.get('searchField');
-              assert('`{{power-select-multiple}}` requires a `searchField` when the options are not strings to remove options using backspace', searchField);
               select.actions.search(get(lastSelection, searchField));
             }
             select.actions.open(e);


### PR DESCRIPTION
This field is not actually required, if you don't use it, you don't get the search filled in again when you press delete but that's not actually a problem if you dont' need that