### PR TITLE
guard against destroying hook when calling deactivate

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -377,7 +377,9 @@ export default Component.extend({
     },
 
     onTriggerBlur(_, event) {
-      this.send('deactivate');
+      if (!this.isDestroying) {
+        this.send('deactivate');
+      }
       let action = this.get('onblur');
       if (action) {
         action(this.get('publicAPI'), event);
@@ -385,7 +387,9 @@ export default Component.extend({
     },
 
     onBlur(event) {
-      this.send('deactivate');
+      if (!this.isDestroying) {
+        this.send('deactivate');
+      }
       let action = this.get('onblur');
       if (action) {
         action(this.get('publicAPI'), event);


### PR DESCRIPTION
In Ember 3.2, a new assertion was added that prevents sending actions to objects that are already destroyed.

`ember-power-select` does this specifically with the `deactivate` action, and in our Ember 3.2 app this causing test failures because these actions are being sent after the component itself has been cleaned up.

Here are some examples of where this issue has come up elsewhere:
- https://github.com/emberjs/ember.js/issues/16820
- https://github.com/emberjs/ember.js/issues/16778

This PR prevents this error by wrapping calls to `deactivate` in `if (!this.isDestroying)`.