### PR TITLE
Add wrapper div around options & afterOptionsComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Master
 
+# 2.0.7
+- [BUGFIX] Avoid polyfilling the DOM in fastboot.
+
 # 2.0.6
 - [BUGFIX] Better support `ObjectProxy` to adapt to changes in EmberData > 3.1
 

--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -3,24 +3,26 @@ import { computed } from '@ember/object';
 import layout from '../../templates/components/power-select/options';
 
 const isTouchDevice = (!!window && 'ontouchstart' in window);
-(function(ElementProto) {
-  if (typeof ElementProto.matches !== 'function') {
-    ElementProto.matches = ElementProto.msMatchesSelector || ElementProto.mozMatchesSelector || ElementProto.webkitMatchesSelector;
-  }
+if(typeof FastBoot === undefined){
+  (function(ElementProto) {
+    if (typeof ElementProto.matches !== 'function') {
+      ElementProto.matches = ElementProto.msMatchesSelector || ElementProto.mozMatchesSelector || ElementProto.webkitMatchesSelector;
+    }
 
-  if (typeof ElementProto.closest !== 'function') {
-    ElementProto.closest = function closest(selector) {
-      let element = this;
-      while (element && element.nodeType === 1) {
-        if (element.matches(selector)) {
-          return element;
+    if (typeof ElementProto.closest !== 'function') {
+      ElementProto.closest = function closest(selector) {
+        let element = this;
+        while (element && element.nodeType === 1) {
+          if (element.matches(selector)) {
+            return element;
+          }
+          element = element.parentNode;
         }
-        element = element.parentNode;
-      }
-      return null;
-    };
-  }
-})(window.Element.prototype);
+        return null;
+      };
+    }
+  })(window.Element.prototype);
+}
 
 export default Component.extend({
   isTouchDevice,

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -66,36 +66,39 @@
       searchPlaceholder=(readonly searchPlaceholder)
       select=(readonly publicAPI)
       selectedItemComponent=(readonly selectedItemComponent)}}
-    {{#if mustShowSearchMessage}}
-      {{component searchMessageComponent
-        searchMessage=(readonly searchMessage)
-        select=(readonly publicAPI)
-      }}
-    {{else if mustShowNoMessages}}
-      {{#if (hasBlock "inverse")}}
-        {{yield to="inverse"}}
-      {{else if noMatchesMessage}}
-        <ul class="ember-power-select-options" role="listbox">
-          <li class="ember-power-select-option ember-power-select-option--no-matches-message" role="option">
-            {{noMatchesMessage}}
-          </li>
-        </ul>
+
+    <div class="ember-power-select-options-wrapper">
+      {{#if mustShowSearchMessage}}
+        {{component searchMessageComponent
+          searchMessage=(readonly searchMessage)
+          select=(readonly publicAPI)
+        }}
+      {{else if mustShowNoMessages}}
+        {{#if (hasBlock "inverse")}}
+          {{yield to="inverse"}}
+        {{else if noMatchesMessage}}
+          <ul class="ember-power-select-options" role="listbox">
+            <li class="ember-power-select-option ember-power-select-option--no-matches-message" role="option">
+              {{noMatchesMessage}}
+            </li>
+          </ul>
+        {{/if}}
+      {{else}}
+        {{#component optionsComponent
+          class="ember-power-select-options"
+          extra=(readonly extra)
+          groupIndex=""
+          loadingMessage=(readonly loadingMessage)
+          id=(readonly optionsId)
+          options=(readonly publicAPI.results)
+          optionsComponent=(readonly optionsComponent)
+          groupComponent=(readonly groupComponent)
+          select=(readonly publicAPI)
+          as |option term|}}
+          {{yield option term}}
+        {{/component}}
       {{/if}}
-    {{else}}
-      {{#component optionsComponent
-        class="ember-power-select-options"
-        extra=(readonly extra)
-        groupIndex=""
-        loadingMessage=(readonly loadingMessage)
-        id=(readonly optionsId)
-        options=(readonly publicAPI.results)
-        optionsComponent=(readonly optionsComponent)
-        groupComponent=(readonly groupComponent)
-        select=(readonly publicAPI)
-        as |option term|}}
-        {{yield option term}}
-      {{/component}}
-    {{/if}}
-    {{component afterOptionsComponent select=(readonly publicAPI) extra=(readonly extra)}}
+      {{component afterOptionsComponent select=(readonly publicAPI) extra=(readonly extra)}}
+    </div>
   {{/dropdown.content}}
 {{/basic-dropdown}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-power-select",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "The extensible select component built for ember",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
@cibernox this is the second feature request I made in Discord. This enables the following change: https://github.com/weddingshoppe/ember-model-select/pull/6/files#diff-6cd7a1538e5e1eb6201624d486136991 meaning the loading mask height is independent of any style changes that are made to the search component.