### PR TITLE
Prevent mouse click on input text from clearing text

### DIFF
--- a/addon/components/power-select-multiple/trigger.js
+++ b/addon/components/power-select-multiple/trigger.js
@@ -109,6 +109,12 @@ export default Component.extend({
       } else if (e.keyCode >= 48 && e.keyCode <= 90 || e.keyCode === 32) { // Keys 0-9, a-z or SPACE
         e.stopPropagation();
       }
+    },
+
+    onMousedown(e) {
+      if (this.input.value) {
+        e.stopPropagation();
+      }
     }
   },
 

--- a/addon/templates/components/power-select-multiple/trigger.hbs
+++ b/addon/templates/components/power-select-multiple/trigger.hbs
@@ -33,7 +33,9 @@
       onfocus={{onFocus}}
       onblur={{onBlur}}
       tabindex={{tabindex}}
-      onkeydown={{action "onKeydown"}}>
+      onkeydown={{action "onKeydown"}}
+      onmousedown={{action "onMousedown"}}>
+
   {{/if}}
 </ul>
 <span class="ember-power-select-status-icon"></span>


### PR DESCRIPTION
As noted in #646, clicking inside a power-select-multiple input field after typing text clears the text. This proposed fix stops the propagation of the mousedown event if there is text in the input field. 

**To reproduce:** 
This issue can be seen on the Ember Power Select multiple-selection page (https://ember-power-select.com/docs/multiple-selection). To reproduce, type some text into the input field (do not press "Enter"). Then click your mouse in the input field, as though you were adjusting the cursor on a Word document. The text vanishes and the dropdown is closed. 
![screen shot 2018-09-20 at 8 28 03 am](https://user-images.githubusercontent.com/22162337/45829200-39cf8480-bcaf-11e8-8cc1-03550502e9b7.png)
_Typing in the input_
![screen shot 2018-09-20 at 8 28 10 am](https://user-images.githubusercontent.com/22162337/45829208-3cca7500-bcaf-11e8-951e-bffaf53381b2.png)
_Text disappears on click_

**Expected behavior:** 
The cursor can be repositioned by clicking the mouse. 
![screen shot 2018-09-20 at 8 31 36 am](https://user-images.githubusercontent.com/22162337/45829365-9fbc0c00-bcaf-11e8-92c4-19f0e1957982.png)
_Cursor can be repositioned by clicking in the input_