### PR TITLE
use .set() to avoid assertion failure under Ember 3.4

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -228,7 +228,7 @@ export default Component.extend({
         return false;
       }
       if (e) {
-        this.openingEvent = e;
+        this.set('openingEvent', e);
         if (e.type === 'keydown' && (e.keyCode === 38 || e.keyCode === 40)) {
           e.preventDefault();
         }
@@ -242,7 +242,7 @@ export default Component.extend({
         return false;
       }
       if (e) {
-        this.openingEvent = null;
+        this.set('openingEvent', null);
       }
       this.updateState({ highlighted: undefined });
     },


### PR DESCRIPTION
While updating Ember to 3.4.2, we encountered issues with ember-power-select throwing:

<img width="1066" alt="screen shot 2018-09-26 at 10 58 49 am" src="https://user-images.githubusercontent.com/1727840/46099284-3a6a8e00-c17b-11e8-94a5-1e17e52676e5.png">

This pr changes two instances where `openingEvent` is set to use `Ember.set` as opposed to `=`.