### PR TITLE
Add animationEnabled to be passed down to ember-basic-dropdown

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -54,6 +54,7 @@
 
   {{#dropdown.content _contentTagName=_contentTagName class=(readonly concatenatedDropdownClasses)}}
     {{component beforeOptionsComponent
+      animationEnabled=(readonly animationEnabled)
       extra=(readonly extra)
       listboxId=(readonly optionsId)
       onInput=(action "onInput")

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -22,6 +22,11 @@
       <td>When truthy, single selects allow to nullify the selection</td>
     </tr>
     <tr>
+      <td>animationEnabled</td>
+      <td><code>boolean</code></td>
+      <td>Flag to determine whether the content will allow CSS animations. Defaults to true</td>
+    </tr>
+    <tr>
       <td>ariaDescribedBy</td>
       <td><code>string</code></td>
       <td>Sets <code>aria-describedby</code> on the component</td>


### PR DESCRIPTION
Need to pass in `animationEnabled` property through ember-power-select, so that it can be used by ember-basic-dropdown.

Been running into ember run loop errors related to animating dropdown when the component has already been destroyed, as it's scheduled afterRender here - https://github.com/cibernox/ember-basic-dropdown/blob/master/addon/components/basic-dropdown/content.js#L183

Had submitted a similar PR for this property to be passed in through ember-power-select-typeahead, which has been merged recently. 
https://github.com/cibernox/ember-power-select-typeahead/pull/77