### PR TITLE
Add highlightOnHoverEnabled to be used in options.js

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -86,7 +86,7 @@ export default Component.extend({
   closeOnSelect: fallbackIfUndefined(true),
   defaultHighlighted: fallbackIfUndefined(defaultHighlighted),
   typeAheadMatcher: fallbackIfUndefined(defaultTypeAheadMatcher),
-  highlightOnHoverEnabled: fallbackIfUndefined(true),
+  highlightOnHover: fallbackIfUndefined(true),
 
   afterOptionsComponent: fallbackIfUndefined(null),
   beforeOptionsComponent: fallbackIfUndefined('power-select/before-options'),

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -86,6 +86,7 @@ export default Component.extend({
   closeOnSelect: fallbackIfUndefined(true),
   defaultHighlighted: fallbackIfUndefined(defaultHighlighted),
   typeAheadMatcher: fallbackIfUndefined(defaultTypeAheadMatcher),
+  highlightOnHoverEnabled: fallbackIfUndefined(true),
 
   afterOptionsComponent: fallbackIfUndefined(null),
   beforeOptionsComponent: fallbackIfUndefined('power-select/before-options'),

--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -49,7 +49,9 @@ export default Component.extend({
       action(this._optionFromIndex(optionIndex), e);
     };
     this.element.addEventListener('mouseup', (e) => findOptionAndPerform(this.get('select.actions.choose'), e));
-    this.element.addEventListener('mouseover', (e) => findOptionAndPerform(this.get('select.actions.highlight'), e));
+    if (this.get('highlightOnHoverEnabled')) {
+      this.element.addEventListener('mouseover', (e) => findOptionAndPerform(this.get('select.actions.highlight'), e));
+    }
     if (this.get('isTouchDevice')) {
       this._addTouchEvents();
     }

--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -49,7 +49,7 @@ export default Component.extend({
       action(this._optionFromIndex(optionIndex), e);
     };
     this.element.addEventListener('mouseup', (e) => findOptionAndPerform(this.get('select.actions.choose'), e));
-    if (this.get('highlightOnHoverEnabled')) {
+    if (this.get('highlightOnHover')) {
       this.element.addEventListener('mouseover', (e) => findOptionAndPerform(this.get('select.actions.highlight'), e));
     }
     if (this.get('isTouchDevice')) {

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -91,7 +91,7 @@
         id=(readonly optionsId)
         options=(readonly publicAPI.results)
         optionsComponent=(readonly optionsComponent)
-        highlightOnHoverEnabled=(readonly highlightOnHoverEnabled)
+        highlightOnHover=(readonly highlightOnHover)
         groupComponent=(readonly groupComponent)
         select=(readonly publicAPI)
         as |option term|}}

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -91,6 +91,7 @@
         id=(readonly optionsId)
         options=(readonly publicAPI.results)
         optionsComponent=(readonly optionsComponent)
+        highlightOnHoverEnabled=(readonly highlightOnHoverEnabled)
         groupComponent=(readonly groupComponent)
         select=(readonly publicAPI)
         as |option term|}}

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -113,6 +113,11 @@
       <td>The component to render instead of the default one around the list of options that have groups</td>
     </tr>
     <tr>
+      <td>highlightOnHoverEnabled</td>
+      <td><code>boolean</code></td>
+      <td>Defaults to true. When false, when the user hovers over an option with the mouse, it will not be highlighted.</td>
+    </tr>
+    <tr>
       <td>horizontalPosition</td>
       <td><code>string</code></td>
       <td>

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -113,7 +113,7 @@
       <td>The component to render instead of the default one around the list of options that have groups</td>
     </tr>
     <tr>
-      <td>highlightOnHoverEnabled</td>
+      <td>highlightOnHover</td>
       <td><code>boolean</code></td>
       <td>Defaults to true. When false, when the user hovers over an option with the mouse, it will not be highlighted.</td>
     </tr>

--- a/tests/integration/components/power-select/mouse-control-test.js
+++ b/tests/integration/components/power-select/mouse-control-test.js
@@ -26,6 +26,24 @@ module('Integration | Component | Ember Power Select (Mouse control)', function(
     assert.dom('.ember-power-select-option:nth-child(4)').hasText('four');
   });
 
+  test('Mouseovering a list item does not highlight it when highlightOnHoverEnabled is false', async function(assert) {
+    assert.expect(3);
+
+    this.numbers = numbers;
+    await render(hbs`
+      {{#power-select highlightOnHoverEnabled=false options=numbers onchange=(action (mut foo)) as |option|}}
+        {{option}}
+      {{/power-select}}
+    `);
+
+    await clickTrigger();
+    assert.dom('.ember-power-select-option').hasAttribute('aria-current', 'true', 'The first element is highlighted');
+    await triggerEvent('.ember-power-select-option:nth-child(4)', 'mouseover');
+
+    assert.dom('.ember-power-select-option:nth-child(4)').hasAttribute('aria-current', 'false', 'The 4th element is not highlighted');
+    assert.dom('.ember-power-select-option:nth-child(1)').hasAttribute('aria-current', 'true', 'The 1st element is still highlighted');
+  });
+
   test('Clicking an item selects it, closes the dropdown and focuses the trigger', async function(assert) {
     assert.expect(4);
 

--- a/tests/integration/components/power-select/mouse-control-test.js
+++ b/tests/integration/components/power-select/mouse-control-test.js
@@ -26,12 +26,12 @@ module('Integration | Component | Ember Power Select (Mouse control)', function(
     assert.dom('.ember-power-select-option:nth-child(4)').hasText('four');
   });
 
-  test('Mouseovering a list item does not highlight it when highlightOnHoverEnabled is false', async function(assert) {
+  test('Mouseovering a list item does not highlight it when highlightOnHover is false', async function(assert) {
     assert.expect(3);
 
     this.numbers = numbers;
     await render(hbs`
-      {{#power-select highlightOnHoverEnabled=false options=numbers onchange=(action (mut foo)) as |option|}}
+      {{#power-select highlightOnHover=false options=numbers onchange=(action (mut foo)) as |option|}}
         {{option}}
       {{/power-select}}
     `);


### PR DESCRIPTION
When false, will disable automatically highlighting an option
when hovered over with the mouse. This will prevent unintentionally
selecting a new value when tabbing through a form with an EPS field
while the user's mouse is where the list will appear when the EPS
gains focus, it is set to automatically open onFocus, and then closes 
when it loses focus.