### PR TITLE
Rename argument to what it actually is

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -47,8 +47,8 @@
       searchField=(readonly searchField)
       select=(readonly publicAPI)
       selectedItemComponent=(readonly selectedItemComponent)
-      as |opt term|}}
-      {{yield opt term}}
+      as |opt select|}}
+      {{yield opt select}}
     {{/component}}
   {{/dropdown.trigger}}
 
@@ -94,8 +94,8 @@
         highlightOnHover=(readonly highlightOnHover)
         groupComponent=(readonly groupComponent)
         select=(readonly publicAPI)
-        as |option term|}}
-        {{yield option term}}
+        as |option select|}}
+        {{yield option select}}
       {{/component}}
     {{/if}}
     {{component afterOptionsComponent select=(readonly publicAPI) extra=(readonly extra)}}


### PR DESCRIPTION
Sub-components probably used to yield a `term` back but instead now yield the `publicAPI` back, so this simply renames the argument for consistency (in the sub-components, `publicAPI` is called `select` and that is what is yielded back).