### PR TITLE
close -> clone

### DIFF
--- a/tests/dummy/app/templates/public-pages/cookbook/css-animations.hbs
+++ b/tests/dummy/app/templates/public-pages/cookbook/css-animations.hbs
@@ -50,7 +50,7 @@
 </p>
 
 <p>
-  Now lets dive in something more serious. Debounding searches.
+  Now lets dive in something more serious. Debouncing searches.
 </p>
 
 <div class="doc-page-nav">

--- a/tests/dummy/app/templates/public-pages/cookbook/css-animations.hbs
+++ b/tests/dummy/app/templates/public-pages/cookbook/css-animations.hbs
@@ -20,7 +20,7 @@
     replaced by <code>.ember-basic-dropdown--transitioned-in</code>.
   </li>
   <li>
-    When closed, EPS replaces its content with a close and adds a <code>.ember-basic-dropdown--transitioning-out</code> to it.
+    When closed, EPS replaces its content with a clone and adds a <code>.ember-basic-dropdown--transitioning-out</code> to it.
   </li>
   <li>
     Once all closing animations or transitions have finished, the "ghost" clone is finally removed.


### PR DESCRIPTION
'clone' is the intended word in the context, and the spelling error 'close' may cause some confusion to the reader