### PR TITLE
Prevent scroll only if target is body

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -657,11 +657,12 @@ export default Component.extend({
   },
 
   _handleKeySpace(e) {
+    if (['TEXTAREA', 'INPUT'].includes(e.target.nodeName)) {
+      return false;
+    }
     let publicAPI = this.get('publicAPI');
     if (publicAPI.isOpen && publicAPI.highlighted !== undefined) {
-      if (e.target === document.body) {
-        e.preventDefault(); // Prevents scrolling of the page.
-      }
+      e.preventDefault(); // Prevents scrolling of the page.
       publicAPI.actions.choose(publicAPI.highlighted, e);
       return false;
     }

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -659,7 +659,9 @@ export default Component.extend({
   _handleKeySpace(e) {
     let publicAPI = this.get('publicAPI');
     if (publicAPI.isOpen && publicAPI.highlighted !== undefined) {
-      e.preventDefault(); // Prevents scrolling of the page.
+      if (e.target === document.body) {
+        e.preventDefault(); // Prevents scrolling of the page.
+      }
       publicAPI.actions.choose(publicAPI.highlighted, e);
       return false;
     }


### PR DESCRIPTION
~We should only prevent the scroll when the target is the body. I have an issue that my target is an input field with a custom `triggerComponent`. The `e.preventDefault()` is preventing me from typing in a space 😅~
We should not handle the spacebar if the node is a `textarea` or an `input` field. I have an issue when my target is an input field with a custom `triggerComponent`. 

**Before:**
![kapture 2019-02-03 at 11 48 43](https://user-images.githubusercontent.com/7160913/52176801-1a497c00-27b8-11e9-9f89-e62f645ac435.gif)


**After:**
![kapture 2019-02-03 at 11 50 00](https://user-images.githubusercontent.com/7160913/52176802-1d446c80-27b8-11e9-8c02-f0c6f83a27cd.gif)
