### PR TITLE
Fix Issue 1057 - component tag rendering twice

### DIFF
--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -11,7 +11,6 @@
     beforeOptionsComponent=beforeOptionsComponent
     buildSelection=(action "buildSelection")
     calculatePosition=calculatePosition
-    class=class
     closeOnSelect=closeOnSelect
     defaultHighlighted=defaultHighlighted
     destination=destination
@@ -50,7 +49,6 @@
     selected=selected
     selectedItemComponent=selectedItemComponent
     tabindex=computedTabIndex
-    tagName=tagName
     eventType=eventType
     title=title
     triggerClass=concatenatedTriggerClass
@@ -75,7 +73,6 @@
     beforeOptionsComponent=beforeOptionsComponent
     buildSelection=(action "buildSelection")
     calculatePosition=calculatePosition
-    class=class
     closeOnSelect=closeOnSelect
     defaultHighlighted=defaultHighlighted
     destination=destination
@@ -114,7 +111,6 @@
     selected=selected
     selectedItemComponent=selectedItemComponent
     tabindex=computedTabIndex
-    tagName=tagName
     eventType=eventType
     title=title
     triggerClass=concatenatedTriggerClass


### PR DESCRIPTION
cf https://github.com/cibernox/ember-power-select/issues/1057

When we set a `tagName` on a `power-select-multiple`, this tag is rendering twice because `tagName` is set for `power-select-multiple` but it is transmit to `power-select` also. I removed `class` too.

improvment idea: Perhaps could we set a default "div" `tagName` when a `class` is setted?