### PR TITLE
Add option to not close select on tab keypress

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -84,6 +84,7 @@ export default Component.extend({
   noMatchesMessage: fallbackIfUndefined('No results found'),
   searchMessage: fallbackIfUndefined('Type to search'),
   closeOnSelect: fallbackIfUndefined(true),
+  closeOnTab: fallbackIfUndefined(true),
   defaultHighlighted: fallbackIfUndefined(defaultHighlighted),
   typeAheadMatcher: fallbackIfUndefined(defaultTypeAheadMatcher),
   highlightOnHover: fallbackIfUndefined(true),
@@ -669,7 +670,9 @@ export default Component.extend({
   },
 
   _handleKeyTab(e) {
-    this.get('publicAPI').actions.close(e);
+    if (this.get('closeOnTab')) {
+      this.get('publicAPI').actions.close(e);
+    }
   },
 
   _handleKeyESC(e) {

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -81,6 +81,14 @@
       </td>
     </tr>
     <tr>
+      <td>closeOnTab</td>
+      <td><code>boolean</code></td>
+      <td>
+        Defaults to true. When false, the component won't be closed if the user hits the "Tab" key
+        when the dropdown is open.
+      </td>
+    </tr>
+    <tr>
       <td>defaultHighlighted</td>
       <td><code>any or function</code></td>
       <td>By default when the select opens, the highlighted element is the selected one, or the first if none. If you want to change this behaviour, pass an option or a function that receives the publicAPI and resolves to the highlighted option.</td>

--- a/tests/integration/components/power-select/keyboard-control-test.js
+++ b/tests/integration/components/power-select/keyboard-control-test.js
@@ -189,7 +189,7 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
     assert.dom('.ember-power-select-trigger').isFocused('The trigger is focused');
   });
 
-  test('Pressing TAB closes the select WITHOUT selecting the highlighed element and focuses the trigger', async function(assert) {
+  test('If closeOnTab=true, pressing TAB closes the select WITHOUT selecting the highlighted element and focuses the trigger', async function(assert) {
     assert.expect(3);
 
     this.numbers = numbers;
@@ -204,7 +204,25 @@ module('Integration | Component | Ember Power Select (Keyboard control)', functi
     await triggerKeyEvent('.ember-power-select-search-input', 'keydown', 9);
     assert.dom('.ember-power-select-trigger').hasText('', 'The highlighted element wasn\'t selected');
     assert.dom('.ember-power-select-dropdown').doesNotExist('The dropdown is closed');
-    assert.dom('.ember-power-select-trigger').isFocused('The trigges is focused');
+    assert.dom('.ember-power-select-trigger').isFocused('The trigger is focused');
+  });
+
+  test('If closeOnTab=false, pressing TAB does not close the select, select the highlighted element, or focus the trigger', async function(assert) {
+    assert.expect(3);
+
+    this.numbers = numbers;
+    await render(hbs`
+      {{#power-select closeOnTab=false options=numbers onchange=(action (mut foo)) as |option|}}
+        {{option}}
+      {{/power-select}}
+    `);
+
+    await clickTrigger();
+    await triggerKeyEvent('.ember-power-select-search-input', 'keydown', 40);
+    await triggerKeyEvent('.ember-power-select-search-input', 'keydown', 9);
+    assert.dom('.ember-power-select-trigger').hasText('', 'The highlighted element wasn\'t selected');
+    assert.dom('.ember-power-select-dropdown').exists('The dropdown is open');
+    assert.dom('.ember-power-select-trigger').isNotFocused('The trigger is not focused');
   });
 
   test('The component is focusable using the TAB key as any other kind of input', async function(assert) {


### PR DESCRIPTION
I would like to add an optional property to the `power-select` component to allow the dropdown to stay open on a "Tab" keypress.  You currently can pass the `onkeydown` method to the component and do some customization that way.  You can then return `false` in this method to prevent the default closing behavior from occurring.  But my use case involves tabbing through / focusing content within the dropdown portion of the select.  If I were to return false in `onkeydown`, the default browser focus behavior would also be prevented.  Creating this property allows the `power-select's` default tab behavior to be avoided, while allowing the browser's default tab behavior to be preserved.