### PR TITLE
Allow ember-concurrency 0.8.x & 0.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ember-basic-dropdown": "^1.1.0",
     "ember-cli-babel": "^7.2.0",
     "ember-cli-htmlbars": "^3.0.1",
-    "ember-concurrency": "^0.9.0",
+    "ember-concurrency": "^0.8.27 || ^0.9.0",
     "ember-text-measurer": "^0.5.0",
     "ember-truth-helpers": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,7 +3287,7 @@ ember-compatibility-helpers@^1.2.0:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-ember-concurrency@^0.9.0:
+"ember-concurrency@^0.8.27 || ^0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.9.0.tgz#0016652ff780fb665842e7f47815ee0601122ea1"
   integrity sha512-JDjvwSlZBUQwv1+qUj6YUqXXe0Y0/to4ppUTNXQ1EEiEAopkHJXQUn0ZcFOiQpEinrYp34Vg6+lUNskoJFL2Vg==


### PR DESCRIPTION
This PR allows both ember-concurrency@0.8.x as well as @0.9.x.

Fixes #1219 