### PR TITLE
Prepend missing @ to arguments

### DIFF
--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -11,7 +11,7 @@
   @calculatePosition={{@calculatePosition}}
   @closeOnSelect={{@closeOnSelect}}
   @defaultHighlighted={{@defaultHighlighted}}
-  @destination={{destination}}
+  @destination={{@destination}}
   @disabled={{@disabled}}
   @dropdownClass={{@dropdownClass}}
   @extra={{@extra}}
@@ -36,7 +36,7 @@
   @preventScroll={{@preventScroll}}
   @registerAPI={{@registerAPI}}
   @renderInPlace={{@renderInPlace}}
-  @required={{required}}
+  @required={{@required}}
   @scrollTo={{@scrollTo}}
   @search={{@search}}
   @searchEnabled={{@searchEnabled}}

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -63,7 +63,7 @@
         @onFocus={{this.handleFocus}}
         @onBlur={{this.handleBlur}}
         @extra={{@extra}}
-        @placeholder={{placeholder}}
+        @placeholder={{@placeholder}}
         @placeholderComponent={{this.placeholderComponent}}
         @selectedItemComponent={{@selectedItemComponent}}/>
     {{/let}}


### PR DESCRIPTION
I believe these arguments should have `@` prepended. Please confirm.