### PR TITLE
typo: Remove this._super to use native super

### DIFF
--- a/addon/components/power-select/before-options.js
+++ b/addon/components/power-select/before-options.js
@@ -8,7 +8,7 @@ export default @tagName('') @layout(templateLayout) class BeforeOptions extends 
   autofocus = true;
 
   willDestroyElement() {
-    this._super(...arguments);
+    super.willDestroyElement(...arguments);
     if (this.searchEnabled) {
       scheduleOnce('actions', this, this.select.actions.search, '');
     }


### PR DESCRIPTION
This was the only usage of `this._super` in a native class. A last occurence is remaining in the tests but in an Object: `Component.extend({})`.

#### Context
As explained [here](https://blog.emberjs.com/2019/01/26/emberjs-native-class-update-2019-edition.html), native `super` should be used over `this._super` in native classes. 