### PR TITLE
Bump eslint-plugin-ember to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ember-source-channel-url": "^1.1.0",
     "ember-try": "^1.1.0",
     "eslint": "^5.16.0",
-    "eslint-plugin-ember": "^6.3.0",
+    "eslint-plugin-ember": "^7.0.0",
     "eslint-plugin-node": "^9.0.1",
     "liquid-fire": "0.30.0",
     "loader.js": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5078,10 +5078,10 @@ escodegen@^1.11.0, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-ember@^6.3.0:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-6.10.1.tgz#ca7a5cc28b91a247c31b1686421a66281467f238"
-  integrity sha512-RZI0+UoR4xeD6UE3KQCUwbN2nZOIIPaFCCXqBIRXDr0rFuwvknAHqYtDPJVZicvTzNHa4TEZvAKqfbE8t7SztQ==
+eslint-plugin-ember@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-7.0.0.tgz#75412b62501a8489b5b6345ccb6adfb877ceb38a"
+  integrity sha512-cMdYuKs46hpF5DEPQ2cccNjgC5xy0C1GcFfP47qiHTKAAAkHUttD/6DdEH3OwlreK/uFbF4fFaHxuq84xkaOgA==
   dependencies:
     "@ember-data/rfc395-data" "^0.0.4"
     ember-rfc176-data "^0.3.11"


### PR DESCRIPTION
https://github.com/cibernox/ember-power-select/pull/1276 would have been caught by the recently added [no-ember-super-in-es-classes rule](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-ember-super-in-es-classes.md)

@cibernox is there any reason why you don't use something like dependabot? If you'd like I could open a PR to add the config (which I think would turn it on).

Thank you for the great work on this addon!