### PR TITLE
Make `results` and `resultCount` computed properties

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -2,6 +2,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action, get, computed } from '@ember/object';
+import { dependentKeyCompat } from '@ember/object/compat';
 import { addObserver, removeObserver } from '@ember/object/observers';
 import { scheduleOnce } from '@ember/runloop';
 import { isEqual } from '@ember/utils';
@@ -93,6 +94,7 @@ export default class PowerSelect extends Component {
     }
   }
 
+  @dependentKeyCompat
   get options() {
     return this._resolvedOptions || this.args.options;
   }

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -1,7 +1,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action, get } from '@ember/object';
+import { action, get, computed } from '@ember/object';
 import { addObserver, removeObserver } from '@ember/object/observers';
 import { scheduleOnce } from '@ember/runloop';
 import { isEqual } from '@ember/utils';
@@ -80,6 +80,7 @@ export default class PowerSelect extends Component {
       && (!this.args.search || this.lastSearchedText.length > 0);
   }
 
+  @computed('searchText', '_searchResult', 'options')
   get results() {
     if (this.searchText.length > 0) {
       if (this.args.search) {
@@ -96,6 +97,7 @@ export default class PowerSelect extends Component {
     return this._resolvedOptions || this.args.options;
   }
 
+  @computed('results')
   get resultsCount() {
     return countOptions(this.results);
   }

--- a/tests/dummy/app/templates/playground.hbs
+++ b/tests/dummy/app/templates/playground.hbs
@@ -4,6 +4,7 @@
   @options={{this.cities}}
   @selected={{this.destination}}
   @onChange={{fn (mut this.destination)}}
+  @searchEnabled={{true}}
   as |city|>
   {{city}}
 </PowerSelect>


### PR DESCRIPTION
If those properties are just getters, they get called pretty often: `results`
was called 4 times for every keystroke in the search box, and `resultsCount` 
twice.

Since filtering iterates over every element of the list (potentially a hundreds 
of elements), calling it so ofter was possibly inefficient. 
Counting the results also is a function that iterates all options (and suboptions 
if there are groups) so it better to cache the result.

From a first swipe of the component, those two seem the only getters worth caching