### PR TITLE
Ensure multiple select <ul> has only <li> children

### DIFF
--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -26,34 +26,38 @@
     </li>
   {{else}}
     {{#if (and @placeholder (not @searchEnabled))}}
-      <span class="ember-power-select-placeholder">{{@placeholder}}</span>
+      <li>
+        <span class="ember-power-select-placeholder">{{@placeholder}}</span>
+      </li>
     {{/if}}
   {{/each}}
   {{#if @searchEnabled}}
-    <input
-      type="search"
-      role="combobox"
-      class="ember-power-select-trigger-multiple-input"
-      aria-activedescendant={{if @select.isOpen @ariaActiveDescendant}}
-      aria-haspopup="listbox"
-      aria-expanded={{if @select.isOpen "true" "false"}}
-      autocomplete="off"
-      autocorrect="off"
-      autocapitalize="off"
-      spellcheck={{false}}
-      id="ember-power-select-trigger-multiple-input-{{@select.uniqueId}}"
-      value={{@select.searchText}}
-      aria-controls={{@listboxId}}
-      style={{this.triggerMultipleInputStyle}}
-      placeholder={{this.maybePlaceholder}}
-      disabled={{@select.disabled}}
-      tabindex={{@tabindex}}
-      form="power-select-fake-form"
-      {{on "focus" @onFocus}}
-      {{on "blur" @onBlur}}
-      {{on "input" this.handleInput}}
-      {{on "keydown" this.handleKeydown}}
-      {{did-insert this.storeInputStyles}}>
+    <li>
+      <input
+        type="search"
+        role="combobox"
+        class="ember-power-select-trigger-multiple-input"
+        aria-activedescendant={{if @select.isOpen @ariaActiveDescendant}}
+        aria-haspopup="listbox"
+        aria-expanded={{if @select.isOpen "true" "false"}}
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+        spellcheck={{false}}
+        id="ember-power-select-trigger-multiple-input-{{@select.uniqueId}}"
+        value={{@select.searchText}}
+        aria-controls={{@listboxId}}
+        style={{this.triggerMultipleInputStyle}}
+        placeholder={{this.maybePlaceholder}}
+        disabled={{@select.disabled}}
+        tabindex={{@tabindex}}
+        form="power-select-fake-form"
+        {{on "focus" @onFocus}}
+        {{on "blur" @onBlur}}
+        {{on "input" this.handleInput}}
+        {{on "keydown" this.handleKeydown}}
+        {{did-insert this.storeInputStyles}}>
+    </li>
   {{/if}}
 </ul>
 <span class="ember-power-select-status-icon"></span>

--- a/app/styles/ember-power-select/base.less
+++ b/app/styles/ember-power-select/base.less
@@ -70,16 +70,23 @@
 }
 
 // Multiple select
+.ember-power-select-multiple-options {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+}
+
 .ember-power-select-trigger-multiple-input {
   font-family: inherit;
   font-size: inherit;
   border: none;
-  display: inline-block;
   line-height: inherit;
   -webkit-appearance: none;
   outline: none;
   padding: 0;
-  float: left;
   background-color: transparent;
   text-indent: 2px;
   &:disabled {
@@ -104,18 +111,13 @@
   }
 }
 
-.ember-power-select-multiple-options {
-  padding: 0; margin: 0;
-}
 .ember-power-select-multiple-option {
   border: @ember-power-select-multiple-option-border;
   border-radius: @ember-power-select-multiple-option-border-radius;
   color: @ember-power-select-multiple-selection-color;
   background-color: @ember-power-select-multiple-selection-background-color;
   padding: @ember-power-select-multiple-option-padding;
-  display: inline-block;
   line-height: @ember-power-select-multiple-option-line-height;
-  float: left;
   margin: 2px 0 2px 3px;
 }
 .ember-power-select-multiple-remove-btn {

--- a/app/styles/ember-power-select/base.scss
+++ b/app/styles/ember-power-select/base.scss
@@ -73,16 +73,23 @@
 }
 
 // Multiple select
+.ember-power-select-multiple-options {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+}
+
 .ember-power-select-trigger-multiple-input {
   font-family: inherit;
   font-size: inherit;
   border: none;
-  display: inline-block;
   line-height: inherit;
   -webkit-appearance: none;
   outline: none;
   padding: 0;
-  float: left;
   background-color: transparent;
   text-indent: 2px;
   &:disabled {
@@ -107,18 +114,13 @@
   }
 }
 
-.ember-power-select-multiple-options {
-  padding: 0; margin: 0;
-}
 .ember-power-select-multiple-option {
   border: $ember-power-select-multiple-option-border;
   border-radius: $ember-power-select-multiple-option-border-radius;
   color: $ember-power-select-multiple-selection-color;
   background-color: $ember-power-select-multiple-selection-background-color;
   padding: $ember-power-select-multiple-option-padding;
-  display: inline-block;
   line-height: $ember-power-select-multiple-option-line-height;
-  float: left;
   margin: 2px 0 2px 3px;
 }
 .ember-power-select-multiple-remove-btn {


### PR DESCRIPTION
ember-a11y-testing (or more specifically, axe) complains that a `<ul>` has to have `<li>` children only.
This PR slightly changes the DOM structure of the multi-select trigger to accomodate that.

I have tried it, and it should look/feel/behave the same!