### PR TITLE
Fix a11y issues with inputs

### DIFF
--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -47,7 +47,7 @@
         aria-labelledby={{@ariaLabelledBy}}
         aria-label={{@ariaLabel}}
         value={{@select.searchText}}
-        aria-controls={{@listboxId}}
+        aria-controls={{if @select.isOpen @listboxId}}
         style={{this.triggerMultipleInputStyle}}
         placeholder={{this.maybePlaceholder}}
         disabled={{@select.disabled}}

--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -35,7 +35,6 @@
     <li>
       <input
         type="search"
-        role="combobox"
         class="ember-power-select-trigger-multiple-input"
         aria-activedescendant={{if @select.isOpen @ariaActiveDescendant}}
         aria-haspopup="listbox"
@@ -45,6 +44,8 @@
         autocapitalize="off"
         spellcheck={{false}}
         id="ember-power-select-trigger-multiple-input-{{@select.uniqueId}}"
+        aria-labelledby={{@ariaLabelledBy}}
+        aria-label={{@ariaLabel}}
         value={{@select.searchText}}
         aria-controls={{@listboxId}}
         style={{this.triggerMultipleInputStyle}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -124,7 +124,13 @@
             (component 'power-select/search-message')
           ) 
         as |SearchMessage|}}
-          <SearchMessage @searchMessage={{this.searchMessage}} @select={{publicAPI}}/>
+          <SearchMessage 
+            @searchMessage={{this.searchMessage}}
+            @select={{publicAPI}}
+            id={{listboxId}} 
+            aria-label={{@ariaLabel}}
+            aria-labelledby={{@ariaLabelledBy}} 
+          /> 
         {{/let}}
       {{else if this.mustShowNoMessages}}
         {{#let 
@@ -134,7 +140,13 @@
             (component 'power-select/no-matches-message')
           ) 
          as |NoMatchesMessage|}}
-          <NoMatchesMessage @noMatchesMessage={{this.noMatchesMessage}} @select={{publicAPI}} />
+          <NoMatchesMessage 
+            @noMatchesMessage={{this.noMatchesMessage}} 
+            @select={{publicAPI}} 
+            id={{listboxId}} 
+            aria-label={{@ariaLabel}}
+            aria-labelledby={{@ariaLabelledBy}} 
+          />
         {{/let}}
       {{else}}
         {{#let 

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -81,6 +81,8 @@
             (component 'power-select/placeholder')
           }}
           @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
+          @ariaLabelledBy={{@ariaLabelledBy}}
+          @ariaLabel={{@ariaLabel}}
           as |opt term|>
           {{yield opt term}}
         </Trigger>

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -111,6 +111,8 @@
             @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
             @selectedItemComponent={{ensure-safe-component @selectedItemComponent}}
             @searchPlaceholder={{@searchPlaceholder}}
+            @ariaLabel={{@ariaLabel}}
+            @ariaLabelledBy={{@ariaLabelledBy}}
           />
         {{/let}}
       {{/if}}

--- a/addon/components/power-select/before-options.hbs
+++ b/addon/components/power-select/before-options.hbs
@@ -1,14 +1,18 @@
 {{#if @searchEnabled}}
   <div class="ember-power-select-search">
-    <input type="search" autocomplete="off"
-      autocorrect="off" autocapitalize="off"
-      spellcheck={{false}} role="combobox"
+    <input type="search"
+      autocomplete="off"
+      autocorrect="off"
+      autocapitalize="off"
+      spellcheck={{false}}
       class="ember-power-select-search-input"
       value={{@select.searchText}}
       aria-activedescendant={{@ariaActiveDescendant}}
       aria-controls={{@listboxId}}
       aria-haspopup="listbox"
       placeholder={{@searchPlaceholder}}
+      aria-label={{@ariaLabel}}
+      aria-labelledby={{@ariaLabelledBy}}
       {{on "input" @onInput}}
       {{on "focus" @onFocus}}
       {{on "blur" @onBlur}}

--- a/addon/components/power-select/search-message.hbs
+++ b/addon/components/power-select/search-message.hbs
@@ -1,4 +1,4 @@
-<ul class="ember-power-select-options" role="listbox">
+<ul class="ember-power-select-options" role="listbox" ...attributes>
   <li class="ember-power-select-option ember-power-select-option--search-message" role="option">
     {{@searchMessage}}
   </li>

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -652,7 +652,7 @@ module(
     });
 
     test('Dropdown with search enabled has proper aria attributes to associate search box with the options', async function (assert) {
-      assert.expect(5);
+      assert.expect(4);
       this.numbers = numbers;
 
       await render(hbs`
@@ -676,9 +676,7 @@ module(
           'aria-controls',
           document.querySelector('.ember-power-select-dropdown').id
         );
-      assert
-        .dom('.ember-power-select-search-input')
-        .hasAttribute('role', 'combobox');
+
       assert
         .dom('.ember-power-select-search-input')
         .hasAttribute('aria-haspopup', 'listbox');

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -815,7 +815,7 @@ module(
     });
 
     test('PowerSelectMultiple with search enabled has proper aria attributes', async function (assert) {
-      assert.expect(11);
+      assert.expect(10);
       this.numbers = numbers;
 
       await render(hbs`
@@ -852,13 +852,6 @@ module(
 
       await clickTrigger();
 
-      assert
-        .dom('.ember-power-select-trigger-multiple-input')
-        .hasAttribute(
-          'role',
-          'combobox',
-          'Multi select search box has role combobox'
-        );
       assert
         .dom('.ember-power-select-trigger-multiple-input')
         .hasAttribute(


### PR DESCRIPTION
This PR fixes (or at least allows to fix) lingering accessibility issues reported by axe (via ember-a11y-testing):

* Pass `aria-label` & `aria-labelled-by` to all search inputs
* Remove `role="combobox"` from search input (See https://github.com/dequelabs/axe-core/issues/1580)

It builds on top of #1305 - I can change that, if required.

With these changes, I could get axe to pass - as long as I added a label, like this:

```hbs
<label id='my-label'>Label here</label>
<PowerSelect
  @ariaLabelledBy='my-label'
  ...
>
```

IMHO it would be nice to add this somewhere to the docs, maybe to the cookbook? But that is a separate issue :)