### PR TITLE
pass in triggerComponent and contentComponent

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -11,9 +11,11 @@
   @verticalPosition={{@verticalPosition}}
   @disabled={{@disabled}}
   @calculatePosition={{this.calculatePosition}}
+  @triggerComponent={{this._ebdTriggerComponent}}
+  @contentComponent={{this._ebdContentComponent}}
   ...attributes as |dropdown|>
   <dropdown.Trigger
-    @htmlTag={{this._triggerTagName}}
+    @htmlTag={{this._ebdTriggerTagName}}
     @eventType={{or @eventType "mousedown"}}
     {{on "keydown" this.handleTriggerKeydown}}
     {{on "focus" this.handleTriggerFocus}}
@@ -51,7 +53,7 @@
       </Trigger>
     {{/let}}
   </dropdown.Trigger>
-  <dropdown.Content @htmlTag={{this._contentTagName}} class={{this.concatenatedDropdownClasses}}>
+  <dropdown.Content @htmlTag={{this._ebdContentTagName}} class={{this.concatenatedDropdownClasses}}>
     {{#let (component this.beforeOptionsComponent) as |BeforeOptions|}}
       <BeforeOptions
         @animationEnabled={{@animationEnabled}}

--- a/tests/integration/components/power-select/customization-with-components-test.js
+++ b/tests/integration/components/power-select/customization-with-components-test.js
@@ -426,4 +426,54 @@ module('Integration | Component | Ember Power Select (Customization using compon
 
     assert.dom('.ember-power-select-trigger .cool-flag-icon').exists({ count: 1 }, 'The custom selectedItemComponent renders with the extra.coolFlagIcon customization option triggering some state change.');
   });
+
+  test('ebd trigger can be customized using _ebdTriggerComponent', async function(assert) {
+    assert.expect(3);
+
+    this.owner.register('component:custom-ebd-trigger', Component.extend({
+      layout: hbs`
+        <div class="my-custom-trigger">{{yield}}</div>
+      `
+    }));
+
+    this.countries = countries;
+    this.country = countries[1]; // Spain
+
+    await render(hbs`
+      <PowerSelect @options={{countries}} @selected={{country}} @_ebdTriggerComponent="custom-ebd-trigger" @onChange={{action (mut foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    assert.dom('.ember-basic-dropdown-trigger').doesNotExist('The default ebd trigger component is not rendered');
+    assert.dom('.my-custom-trigger').exists('The custom trigger is rendered.');
+    assert.dom('.my-custom-trigger').hasText('Spain', 'With the country name as the text.');
+  });
+
+  test('ebd content can be customized using _ebdContentComponent', async function(assert) {
+    assert.expect(3);
+    this.owner.register('component:custom-ebd-content', Component.extend({
+      layout: hbs`
+        {{#if @dropdown.isOpen}}
+          <div class="custom-content">
+            {{yield}}
+          </div>
+        {{/if}}
+      `
+    }));
+    this.countries = countries;
+    this.country = countries[1]; // Spain
+
+    await render(hbs`
+      <PowerSelect @options={{countries}} @selected={{country}} @_ebdContentComponent="custom-ebd-content" @onChange={{action (mut foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+
+    assert.dom('.ember-basic-dropdown-content').doesNotExist('The default ebd content component is not rendered');
+    assert.dom('.custom-content').exists('The custom content is rendered.');
+    assert.dom('.ember-power-select-option').exists({ count: countries.length }, 'The options are rendered inside.');
+  });
 });


### PR DESCRIPTION
on #1311 I messed up because `this._triggerTagName` was already being used on the power select trigger, so setting that property meant setting both properties, which might not be desired.

To make this clearer, I prefixed the private ebd related properties with `ebd`.