### PR TITLE
add no matches message component

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -71,6 +71,7 @@ export default @tagName('') @layout(templateLayout) class PowerSelect extends Co
   @fallbackIfUndefined('power-select/power-select-group') groupComponent
   @fallbackIfUndefined('power-select/trigger') triggerComponent
   @fallbackIfUndefined('power-select/search-message') searchMessageComponent
+  @fallbackIfUndefined('power-select/no-matches-message') noMatchesMessageComponent
   @fallbackIfUndefined('power-select/placeholder') placeholderComponent
   @fallbackIfUndefined(option => option) buildSelection
   @fallbackIfUndefined("button") triggerRole

--- a/addon/components/power-select/no-matches-message.js
+++ b/addon/components/power-select/no-matches-message.js
@@ -1,0 +1,6 @@
+import { layout, tagName } from "@ember-decorators/component";
+import Component from '@ember/component';
+import templateLayout from '../../templates/components/power-select/no-matches-message';
+
+export default @tagName('') @layout(templateLayout) class NoMatchesMessage extends Component {
+}

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -76,11 +76,9 @@
       {{#if (hasBlock "inverse")}}
         {{yield to="inverse"}}
       {{else if noMatchesMessage}}
-        <ul class="ember-power-select-options" role="listbox">
-          <li class="ember-power-select-option ember-power-select-option--no-matches-message" role="option">
-            {{this.noMatchesMessage}}
-          </li>
-        </ul>
+        {{#let (component this.noMatchesMessageComponent) as |NoMatchesMessage|}}
+          <NoMatchesMessage @noMatchesMessage={{this.noMatchesMessage}} @select={{this.publicAPI}}/>
+        {{/let}}
       {{/if}}
     {{else}}
       {{#let (component this.optionsComponent) as |Options|}}

--- a/addon/templates/components/power-select/no-matches-message.hbs
+++ b/addon/templates/components/power-select/no-matches-message.hbs
@@ -1,0 +1,5 @@
+<ul class="ember-power-select-options" role="listbox">
+  <li class="ember-power-select-option ember-power-select-option--no-matches-message" role="option">
+    {{@noMatchesMessage}}
+  </li>
+</ul>

--- a/app/components/power-select/no-matches-message.js
+++ b/app/components/power-select/no-matches-message.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-power-select/components/power-select/no-matches-message';

--- a/tests/dummy/app/templates/public-pages/docs/architecture.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/architecture.hbs
@@ -53,7 +53,7 @@
 </p>
 
 <p>
-  At the moment there is a total of 7 "holes" you can fill.
+  At the moment there is a total of 8 "holes" you can fill.
   <ul>
     <li><code>triggerComponent</code>: Replaces the entire trigger markup and logic.</li>
     <li><code>selectedItemComponent</code>: Replaces only the selected option(s) inside the trigger. By default it just yields the block given to the component.</li>
@@ -61,6 +61,7 @@
     <li><code>optionsComponent</code>: Contains the list of options. The content of each option is the block given to the component.</li>
     <li><code>afterOptionsComponent</code>: Contains any markup and logic displayed after the list of options. Unused by default.</li>
     <li><code>searchMessageComponent</code>: Displays the "Type to search" message. By default it just displays the <code>searchMessage</code>.</li>
+    <li><code>noMatchesMessageComponent</code>: Displays the "No results found" message. By default it just displays the <code>noMatchesMessage</code>.</li>
   </ul>
 </p>
 

--- a/tests/integration/components/power-select/customization-with-components-test.js
+++ b/tests/integration/components/power-select/customization-with-components-test.js
@@ -272,6 +272,24 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.dom('.ember-power-select-dropdown #custom-search-message-p-tag').exists('The custom component is rendered instead of the usual message');
   });
 
+  test('the no matches message can be customized passing `@noMatchesMessageComponent`', async function(assert) {
+    assert.expect(1);
+
+    this.options = [];
+    this.owner.register('component:custom-no-matches-message', Component.extend({
+      layout: hbs`<p id="custom-no-matches-message-p-tag">Customized no results!</p>`
+    }));
+
+    await render(hbs`
+      <PowerSelect @options={{options}} @noMatchesMessageComponent="custom-no-matches-message" @onChange={{action (mut foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+    assert.dom('.ember-power-select-dropdown #custom-no-matches-message-p-tag').exists('The custom component is rendered instead of the usual message');
+  });
+
   test('placeholder can be customized using `@placeholderComponent`', async function(assert) {
     assert.expect(2);
     this.owner.register('component:custom-placeholder', Component.extend({


### PR DESCRIPTION
This applies the same treatment of the `searchMessageComponent` to the no matches message.

This could prove useful to build more complex interactions when a search text is not found (e.g create a new item with the search text?).