### PR TITLE
Fix search input element focus

### DIFF
--- a/addon/components/power-select/before-options.js
+++ b/addon/components/power-select/before-options.js
@@ -41,7 +41,7 @@ export default Component.extend({
   focusInput() {
     this.input = document.querySelector(`.ember-power-select-search-input[aria-controls="${this.get('listboxId')}"]`);
     if (this.input) {
-      later(this.input, 'focus', 0);
+      later(this.input, 'focus', {});
     }
   }
 });


### PR DESCRIPTION
Since upgrading to ember-source 3.10 (with EPS 2.3.5 and EBD 1.1.3) some of our tests failed with this issue:

```TypeError: Failed to execute 'focus' on 'HTMLElement': parameter 1 ('options') is not an object.```

<img width="1218" alt="Screenshot 2020-02-05 at 16 16 35" src="https://user-images.githubusercontent.com/7235537/73858714-2340b380-4839-11ea-98ea-845b51b8127b.png">


I'm not sure what exactly changed in 3.10 that made this fail, and I'm not sure what the `0` was doing here. But locally this made my specs pass.