### PR TITLE
Fix menu autoclose when content is rendered over trigger.

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -10,6 +10,7 @@
   @verticalPosition={{@verticalPosition}}
   @disabled={{@disabled}}
   @calculatePosition={{@calculatePosition}}
+  @rootEventType={{or @eventType "mousedown"}}
   ...attributes as |dropdown|>
   {{#let (assign dropdown (hash
     selected=this.selected


### PR DESCRIPTION
Fixes the issue - https://github.com/cibernox/ember-power-select/issues/1282

Issue: When moving the dropdown content to cover the trigger element for design reasons using CSS, the content prematurely closes on each click.

Further discussion on this issue [here](https://github.com/cibernox/ember-power-select/issues/1263#issuecomment-573091956)