### PR TITLE
Fix premature close with content placed over trigger

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -24,7 +24,7 @@
     actions=(assign dropdown.actions this._publicAPIActions)
   )) (concat "ember-power-select-options-" dropdown.uniqueId) as |publicAPI listboxId|}}
     <dropdown.Trigger
-      @eventType={{or @eventType "mousedown"}}
+      @eventType={{or @eventType "click"}}
       {{did-insert this._updateOptions @options}}
       {{did-update this._updateOptions @options}}
       {{did-insert this._updateSelected @selected}}

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -146,7 +146,7 @@
       <td>eventType</td>
       <td><code>string</code></td>
       <td>
-        Defaults to <code>"mousedown"</code>. Indicates the type of event the trigger component will be listening to
+        Defaults to <code>"click"</code>. Indicates the type of event the trigger component will be listening to
         open or close.
       </td>
     </tr>

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, triggerKeyEvent, focus } from '@ember/test-helpers';
+import { render, click, triggerKeyEvent, focus, blur } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { clickTrigger, typeInSearch } from 'ember-power-select/test-support/helpers';
 import { numbers } from '../constants';
@@ -286,11 +286,10 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       <PowerSelect @options={{numbers}} @selected={{foo}} @onBlur={{handleBlur}} @onChange={{action (mut foo)}} as |number|>
         {{number}}
       </PowerSelect>
-      <input type="text" id="other-element"/>
     `);
 
     await focus('.ember-power-select-trigger');
-    await focus('#other-element');
+    await blur('.ember-power-select-trigger');
   });
 
   test('The onBlur of multiple selects action receives the public API and the focus event', async function(assert) {
@@ -306,11 +305,10 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       <PowerSelectMultiple @options={{numbers}} @selected={{foo}} @onBlur={{handleBlur}} @onChange={{action (mut foo)}} @searchEnabled={{true}} as |number|>
         {{number}}
       </PowerSelectMultiple>
-      <input type="text" id="other-element"/>
     `);
 
     await focus('.ember-power-select-trigger-multiple-input');
-    await focus('#other-element');
+    await blur('.ember-power-select-trigger-multiple-input');
   });
 
   test('The onBlur of multiple selects also gets called when the thing getting the focus is the searbox', async function(assert) {
@@ -324,11 +322,10 @@ module('Integration | Component | Ember Power Select (Public actions)', function
       <PowerSelect @options={{numbers}} @selected={{foo}} @onBlur={{handleBlur}} @onChange={{action (mut foo)}} as |number|>
         {{number}}
       </PowerSelect>
-      <input type="text" id="other-element"/>
     `);
 
     await clickTrigger();
-    await focus('#other-element');
+    await blur('.ember-power-select-trigger');
   });
 
   test('the `@onOpen` action is invoked just before the dropdown opens', async function(assert) {


### PR DESCRIPTION
### Related issues

- Addresses https://github.com/cibernox/ember-power-select/issues/1334
- Addresses https://github.com/cibernox/ember-power-select/issues/1282
- Addresses https://github.com/cibernox/ember-power-select/issues/1263

### Background

Using a value of `mousedown` for the `eventType` that is set on the Ember Basic Dropdown trigger is problematic in some cases, especially when content overlaps the trigger. The reason for this is that the subsequent `mouseup` event handler that is set in the `addHandlers` action in the `options.ts` file is triggered immediately after the `mousedown` that opens the dropdown content in the first place. The `mouseup` event handler calls `findOptionAndPerform` which will select any valid, (though in this case accidentally) highlighted option and then immediate close the dropdown when it makes the selection.

Note that even if the above `mouseup` event listener is bypassed, Ember Basic Dropdown _will still immediately close_ the dropdown, though this time without Power Select having made a selection. This happens because, in the `basic-dropdown-content.ts` file, in the `setup` action adds a `click` event listener (based on the value of `this.args.rootEventType`) to the document, to ensure the content is closed when the user clicks away from the menu.... but when the resulting `handleRootMouseDown` function is called the `click` event target is `body`, which signals EBD to close the content. It's not clear to me why the `target` is `body` in this function, but I suspect it may be related to the `mousedown` and `mouseup` targets differing here, when the content appears above the trigger.

Specifying `@eventType='click'` instead bypasses both problems because `click` is fired _only after_ the `mousedown` and `mouseup` events, resulting in more predictable behavior, regardless of location of the content in relation to the trigger.

### Other Notes

- Also fixes unrelated, intermittent test failures

### Related, alternative PR

- https://github.com/cibernox/ember-power-select/pull/1333