### PR TITLE
#1352 Expose PublicAPI to AfterOptionsComponent

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -116,6 +116,7 @@
       {{#let (component @afterOptionsComponent) as |AfterOptions|}}
         <AfterOptions
           @extra={{@extra}}
+          @select={{publicAPI}}
         />
       {{/let}}
     </dropdown.Content>


### PR DESCRIPTION
It fixes the issue #1352 (missing `@select` after code refactoring).