### PR TITLE
move option template into power-select/option component

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -106,6 +106,7 @@
             @optionsComponent={{Options}}
             @extra={{@extra}}
             @highlightOnHover={{this.highlightOnHover}}
+            @optionComponent={{or @optionComponent "power-select/option"}}
             @groupComponent={{or @groupComponent "power-select/power-select-group"}}
             id={{listboxId}}
             class="ember-power-select-options" as |option select|>

--- a/addon/templates/components/power-select/option.hbs
+++ b/addon/templates/components/power-select/option.hbs
@@ -1,0 +1,9 @@
+
+<li class="ember-power-select-option"
+  aria-selected="{{ember-power-select-is-selected @option @select.selected}}"
+  aria-disabled={{if @option.disabled "true"}}
+  aria-current="{{eq @option @select.highlighted}}"
+  data-option-index="{{@fullIndex}}"
+  role="option">
+  {{yield}}
+</li>

--- a/addon/templates/components/power-select/options.hbs
+++ b/addon/templates/components/power-select/options.hbs
@@ -5,7 +5,7 @@
       <li class="ember-power-select-option ember-power-select-option--loading-message" role="option">{{@loadingMessage}}</li>
     {{/if}}
   {{/if}}
-  {{#let (component @groupComponent) (component @optionsComponent) as |Group Options|}}
+  {{#let (component @groupComponent) (component @optionsComponent) (component @optionComponent) as |Group Options Option|}}
     {{#each @options as |opt index|}}
       {{#if (ember-power-select-is-group opt)}}
         <Group @group={{opt}} @select={{@select}} @extra={{@extra}}>
@@ -14,6 +14,7 @@
             @select={{@select}}
             @groupIndex="{{@groupIndex}}{{index}}."
             @optionsComponent={{@optionsComponent}}
+            @optionComponent={{@optionComponent}}
             @groupComponent={{@groupComponent}}
             @extra={{@extra}}
             role="group"
@@ -22,14 +23,12 @@
           </Options>
         </Group>
       {{else}}
-        <li class="ember-power-select-option"
-          aria-selected="{{ember-power-select-is-selected opt @select.selected}}"
-          aria-disabled={{if opt.disabled "true"}}
-          aria-current="{{eq opt @select.highlighted}}"
-          data-option-index="{{@groupIndex}}{{index}}"
-          role="option">
-          {{yield opt @select}}
-        </li>
+      <Option
+        @option={{opt}}
+        @select={{@select}}
+        @fullIndex="{{@groupIndex}}{{index}}">
+        {{yield opt @select}}
+      </Option>
       {{/if}}
     {{/each}}
   {{/let}}

--- a/app/templates/components/power-select/option.js
+++ b/app/templates/components/power-select/option.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-power-select/templates/components/power-select/option';


### PR DESCRIPTION
This serves as the basis for a PR to provide an option for groups to be selected.

Submitting this separately, since it's hopefully an un-controversial refactoring, whereas the other has some non-trivial API design questions

related -- moving groupName to a component: #467