### PR TITLE
Avoid unnecessary listbox attribute

### DIFF
--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -90,8 +90,8 @@
         {{/let}}
       {{else if this.mustShowNoMessages}}
         {{#if this.noMatchesMessage}}
-          <ul class="ember-power-select-options" role="listbox">
-            <li class="ember-power-select-option ember-power-select-option--no-matches-message" role="option">
+          <ul class="ember-power-select-options">
+            <li class="ember-power-select-option ember-power-select-option--no-matches-message">
               {{this.noMatchesMessage}}
             </li>
           </ul>

--- a/addon/templates/components/power-select/search-message.hbs
+++ b/addon/templates/components/power-select/search-message.hbs
@@ -1,5 +1,5 @@
-<ul class="ember-power-select-options" role="listbox">
-  <li class="ember-power-select-option ember-power-select-option--search-message" role="option">
+<ul class="ember-power-select-options">
+  <li class="ember-power-select-option ember-power-select-option--search-message">
     {{@searchMessage}}
   </li>
 </ul>


### PR DESCRIPTION
There is `role='listbox'` declared on some lists that don't need it. In fact axe complains about them. This is easily fixed by simply removing the role, which doesn't improve accessibility in this case anyhow - this can simply be a normal `<ul>` list.