### PR TITLE
Add 2.3.5 back into the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@
 - [BREAKING] All actions starting with `on` (e.g. `onchange` and `onopen`) are now spelled with camelCase (`@onChange` and `@onOpen`)
 - [BREAKING] @searchEnabled is now false by default
 
+# 2.3.5
+- [BUGFIX] Could not find module ember-compatibility-helpers
+
 # 2.3.4
 - [BUGFIX] Add back node 6 in the list of supported engines
 


### PR DESCRIPTION
2.3.5 shows up in our package-lock when we had "ember-power-select": "^2.0.0",
`, and I was looking for clues as to why we're seeing a weird error in our Ember 2.16 app during our production build process:

```
...
+- didFail
Error: Build Canceled: Broccoli Builder ran into an error with `broccoli-persistent-filter:Babel > [Babel: ember-basic-dropdown]` plugin. 💥
Worker is terminated
Error: Worker is terminated
...
```

...then I noticed 2.3.5 doesn't show up in the changelog!

I looked in the releases and found a change to changelog mentioning 2.3.5 in https://github.com/karlbecker/ember-power-select/commit/1e71541f52f0f24419e60c3cf621127ab1a5605a - was this version still supposed to be available to people? 

I think the error we're dealing with is unrelated to 2.3.4 vs 2.3.5, but since I noticed 2.3.5 wasn't in the changelog, I think it's worth adding it back in.
