### PR TITLE
pass correct number of arguments to `action` function

### DIFF
--- a/addon/components/power-select/options.ts
+++ b/addon/components/power-select/options.ts
@@ -52,7 +52,7 @@ export default class Options extends Component<Args> {
       }
       let optionIndex = optionItem.getAttribute('data-option-index');
       if (optionIndex === null) return;
-      action(this._optionFromIndex(optionIndex), select, e);
+      action(this._optionFromIndex(optionIndex), e);
     };
     element.addEventListener('mouseup', (e) => findOptionAndPerform(this.args.select.actions.choose, this.args.select, e));
     if (this.args.highlightOnHover) {


### PR DESCRIPTION
`this.args.select.actions.choose` ([`_choose` definition](https://github.com/cibernox/ember-power-select/blob/master/addon/components/power-select.ts#L376))  accepts only 2 arguments but in `findOptionAndPerform` we are passing 3 so removed redundant one, happy to add tests if you hint where it should be added