### PR TITLE
Upgrade @glimmer/component to avoid deprecations with ember 3.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9011,9 +9011,9 @@
       }
     },
     "ember-basic-dropdown": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-3.0.9.tgz",
-      "integrity": "sha512-8ig2T97syby79ARR70KiHoGBFKCRgZkgjuSFyNawwwUaQXaaQS6lRT6gUQU6JuEYBD1wAlNl6w5jcW5g9EIs3A==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-3.0.10.tgz",
+      "integrity": "sha512-TabEKUIlLPQLZqyXx1N8M/tDhrf/2meXjK2mNw6RfiOvwMHYJ41MwIhJusnlQd/Rn7cL0MbA+EGCnjdI0HhB/w==",
       "requires": {
         "@ember/render-modifiers": "^1.0.2",
         "@glimmer/component": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9011,87 +9011,28 @@
       }
     },
     "ember-basic-dropdown": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-3.0.6.tgz",
-      "integrity": "sha512-2lUp/EZTTceRytDTtTuEg53i9fUYBfTq/ty4NlnF9EkQS1Shz98VNL3FOkFjvSzPyLG9/26tkmtqLBXmja43ug==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-3.0.9.tgz",
+      "integrity": "sha512-8ig2T97syby79ARR70KiHoGBFKCRgZkgjuSFyNawwwUaQXaaQS6lRT6gUQU6JuEYBD1wAlNl6w5jcW5g9EIs3A==",
       "requires": {
         "@ember/render-modifiers": "^1.0.2",
-        "@glimmer/component": "^1.0.0",
-        "@glimmer/tracking": "^1.0.0",
-        "ember-cli-babel": "^7.13.0",
-        "ember-cli-htmlbars": "^4.2.0",
+        "@glimmer/component": "^1.0.1",
+        "@glimmer/tracking": "^1.0.1",
+        "ember-cli-babel": "^7.21.0",
+        "ember-cli-htmlbars": "^5.2.0",
         "ember-cli-typescript": "^3.1.2",
         "ember-element-helper": "^0.2.0",
-        "ember-maybe-in-element": "^0.4.0",
+        "ember-maybe-in-element": "^2.0.1",
         "ember-truth-helpers": "2.1.0"
       },
       "dependencies": {
-        "broccoli-plugin": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-          "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+        "@glimmer/tracking": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@glimmer/tracking/-/tracking-1.0.1.tgz",
+          "integrity": "sha512-Jt8rn4/6S6CObILaotYUT0lFWNPq1xJubXdU/9p6zxWtMrBXYJalVvI5hFYrCh/hG8Z/aLoERGnb2YRWtBSyzw==",
           "requires": {
-            "broccoli-node-api": "^1.6.0",
-            "broccoli-output-wrapper": "^2.0.0",
-            "fs-merger": "^3.0.1",
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^2.3.4",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.3.1.tgz",
-          "integrity": "sha512-CW6AY/yzjeVqoRtItOKj3hcYzc5dWPRETmeCzr2Iqjt5vxiVtpl0z5VTqHqIlT5fsFx6sGWBQXNHIe+ivYsxXQ==",
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^3.0.1",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^2.3.1",
-            "broccoli-plugin": "^3.1.0",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.0",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^6.3.0",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.0.2"
-          }
-        },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "strip-bom": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
+            "@glimmer/env": "^0.1.7",
+            "@glimmer/validator": "^0.44.0"
           }
         }
       }
@@ -13002,6 +12943,131 @@
         "ember-cli-babel": "^7.1.2"
       }
     },
+    "ember-in-element-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-in-element-polyfill/-/ember-in-element-polyfill-1.0.0.tgz",
+      "integrity": "sha512-0eSfWWgkOMvj7lcjo20VX8uX4HYxSOxm6MY3bAzqW5RpnHcpcrRf6o4y80xLGh5pp9z8FobiUfFwubphACP8mQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "ember-cli-babel": "^7.19.0",
+        "ember-cli-htmlbars": "^4.3.1",
+        "ember-cli-version-checker": "^5.0.2"
+      },
+      "dependencies": {
+        "babel-plugin-htmlbars-inline-precompile": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
+          "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg=="
+        },
+        "broccoli-plugin": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
+          "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+          "requires": {
+            "broccoli-node-api": "^1.6.0",
+            "broccoli-output-wrapper": "^2.0.0",
+            "fs-merger": "^3.0.1",
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ember-cli-htmlbars": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.4.0.tgz",
+          "integrity": "sha512-ohgctqk7dXIZR4TgN0xRoUYltWhghFJgqmtuswQTpZ7p74RxI9PKx+E8WV/95mGcPzraesvMNBg5utQNvcqgNg==",
+          "requires": {
+            "@ember/edition-utils": "^1.2.0",
+            "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
+            "broccoli-debug": "^0.6.5",
+            "broccoli-persistent-filter": "^2.3.1",
+            "broccoli-plugin": "^3.1.0",
+            "common-tags": "^1.8.0",
+            "ember-cli-babel-plugin-helpers": "^1.1.0",
+            "fs-tree-diff": "^2.0.1",
+            "hash-for-dep": "^1.5.1",
+            "heimdalljs-logger": "^0.1.10",
+            "json-stable-stringify": "^1.0.1",
+            "semver": "^6.3.0",
+            "strip-bom": "^4.0.0",
+            "walk-sync": "^2.0.2"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz",
+          "integrity": "sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==",
+          "requires": {
+            "resolve-package-path": "^2.0.0",
+            "semver": "^7.3.2",
+            "silent-error": "^1.1.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+              "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+            }
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "resolve-package-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+          "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.13.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
+        }
+      }
+    },
     "ember-inflector": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ember-inflector/-/ember-inflector-3.0.1.tgz",
@@ -13445,11 +13511,40 @@
       }
     },
     "ember-maybe-in-element": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ember-maybe-in-element/-/ember-maybe-in-element-0.4.0.tgz",
-      "integrity": "sha512-ADQ9jewz46Y2MWiTAKrheIukHiU6p0QHn3xqz1BBDDOmubW1WdAjSrvtkEWsJQ08DyxIn3RdMuNDzAUo6HN6qw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ember-maybe-in-element/-/ember-maybe-in-element-2.0.1.tgz",
+      "integrity": "sha512-Mp/HTVOGu9H7kWoq5xncVLEvPFgRuHdsqWyZ1v/gBA8Y3d2q2LdrmDK9Zg59i+cCs4oa9LrMeFyKMAbBS3vyDw==",
       "requires": {
-        "ember-cli-babel": "^7.1.0"
+        "ember-cli-babel": "^7.21.0",
+        "ember-cli-htmlbars": "^5.2.0",
+        "ember-cli-version-checker": "^5.1.1",
+        "ember-in-element-polyfill": "^1.0.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz",
+          "integrity": "sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==",
+          "requires": {
+            "resolve-package-path": "^2.0.0",
+            "semver": "^7.3.2",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "resolve-package-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+          "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.13.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
       }
     },
     "ember-modifier-manager-polyfill": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2076,9 +2076,9 @@
       }
     },
     "@glimmer/component": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@glimmer/component/-/component-1.0.0.tgz",
-      "integrity": "sha512-1ERZYNLZRuC8RYbcfkJeAWn3Ly7W2VdoHLQIHCmhQH/m7ubkNOdLQcTnUzje7OnRUs9EJ6DjfoN57XRX9Ux4rA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/component/-/component-1.0.1.tgz",
+      "integrity": "sha512-Bo+R6e2fnydZz0JQrV6E5cAIYvCEUQVh6mmXexVSgFmPr/7Q1DB/afAgTQrpK5vXUGRAU7sBB8gzoO0t7vl+Ng==",
       "requires": {
         "@glimmer/di": "^0.1.9",
         "@glimmer/env": "^0.1.7",
@@ -2092,6 +2092,7 @@
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-typescript": "3.0.0",
+        "ember-cli-version-checker": "^3.1.3",
         "ember-compatibility-helpers": "^1.1.2"
       },
       "dependencies": {
@@ -2106,9 +2107,9 @@
           }
         },
         "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -2158,9 +2159,9 @@
           }
         },
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -2207,13 +2208,14 @@
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "walk-sync": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
-          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0"
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
           }
         },
         "which": {
@@ -12025,7 +12027,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
       "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
-      "dev": true,
       "requires": {
         "resolve-package-path": "^1.2.6",
         "semver": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "@ember-decorators/component": "^6.1.0",
-    "@glimmer/component": "^1.0.0",
+    "@glimmer/component": "^1.0.1",
     "@glimmer/tracking": "^1.0.0",
     "ember-assign-helper": "^0.3.0",
     "ember-basic-dropdown": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@glimmer/component": "^1.0.1",
     "@glimmer/tracking": "^1.0.0",
     "ember-assign-helper": "^0.3.0",
-    "ember-basic-dropdown": "^3.0.3",
+    "ember-basic-dropdown": "^3.0.9",
     "ember-cli-babel": "^7.21.0",
     "ember-cli-htmlbars": "^5.2.0",
     "ember-cli-typescript": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@glimmer/component": "^1.0.1",
     "@glimmer/tracking": "^1.0.0",
     "ember-assign-helper": "^0.3.0",
-    "ember-basic-dropdown": "^3.0.9",
+    "ember-basic-dropdown": "^3.0.10",
     "ember-cli-babel": "^7.21.0",
     "ember-cli-htmlbars": "^5.2.0",
     "ember-cli-typescript": "^3.1.4",


### PR DESCRIPTION
After upgrading my apps to ember 3.20, deprecation warnings began appearing due to the use of `setSourceDestroying`.  It seems these were stemming from dependencies of `@glimmer/component` lower than version 1.0.1 (the deprecation warnings were addressed in that [version](https://github.com/glimmerjs/glimmer.js/releases/tag/v1.0.1)).

Upgrading the `@glimmer/component` version here, as well as `ember-basic-dropdown` (who updated `@glimmer/component` [recently](https://github.com/cibernox/ember-basic-dropdown/pull/571)) should remove these deprecations in apps using ember 3.20.