### PR TITLE
fix wrong component name in cookbook

### DIFF
--- a/tests/dummy/app/templates/public-pages/cookbook/index.hbs
+++ b/tests/dummy/app/templates/public-pages/cookbook/index.hbs
@@ -17,7 +17,7 @@
 </p>
 
 <p>
-  Inside your app's <code>/app/components</code> folder create a <code>ember-power-select.js</code>
+  Inside your app's <code>/app/components</code> folder create a <code>power-select.js</code>
   file:
 </p>
 


### PR DESCRIPTION
The cookbook says you should create a file `ember-power-select.js` for global configuration, but the file must be named `power-select.js`.