### PR TITLE
[bugfix] remove remaining observer on PowerSelect teardown

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -349,9 +349,13 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
       }
 
       let currentSelectedPromise: PromiseProxy<any> = this.args.selected;
-      if (isPromiseProxyLike(currentSelectedPromise)) {
-        addObserver(currentSelectedPromise, 'content', this, this._selectedObserverCallback);
-      }
+      currentSelectedPromise.then(() => {
+        if (this.isDestroyed || this.isDestroying) return;
+        if (isPromiseProxyLike(currentSelectedPromise)) {
+          addObserver(currentSelectedPromise, 'content', this, this._selectedObserverCallback);
+        }
+      });
+
       this._lastSelectedPromise = currentSelectedPromise;
       this._lastSelectedPromise.then(resolvedSelected => {
         if (this._lastSelectedPromise === currentSelectedPromise) {

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -336,11 +336,12 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (!this.args.selected) return;
     if (typeof this.args.selected.then === 'function') {
       if (this._lastSelectedPromise === this.args.selected) return; // promise is still the same
+      if (this._lastSelectedPromise && isPromiseProxyLike(this._lastSelectedPromise)) {
+        removeObserver(this._lastSelectedPromise, 'content', this, this._selectedObserverCallback);
+      }
+
       let currentSelectedPromise: PromiseProxy<any> = this.args.selected;
       if (isPromiseProxyLike(currentSelectedPromise)) {
-        if (this._lastSelectedPromise) {
-          removeObserver(this._lastSelectedPromise, 'content', this, this._selectedObserverCallback);
-        }
         addObserver(currentSelectedPromise, 'content', this, this._selectedObserverCallback);
       }
       this._lastSelectedPromise = currentSelectedPromise;

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -92,6 +92,10 @@ const isPromiseLike = <T>(thing: any): thing is Promise<T> => {
   return typeof thing.then === 'function';
 }
 
+const isPromiseProxyLike = <T>(thing: any): thing is PromiseProxy<T> => {
+  return isPromiseLike(thing) && Object.hasOwnProperty.call(thing, 'content');
+}
+
 const isCancellablePromise = <T>(thing: any): thing is CancellablePromise<T> => {
   return typeof thing.cancel === 'function';
 }
@@ -333,7 +337,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (typeof this.args.selected.then === 'function') {
       if (this._lastSelectedPromise === this.args.selected) return; // promise is still the same
       let currentSelectedPromise: PromiseProxy<any> = this.args.selected;
-      if (Object.hasOwnProperty.call(currentSelectedPromise, 'content')) { // seems a PromiseProxy
+      if (isPromiseProxyLike(currentSelectedPromise)) {
         if (this._lastSelectedPromise) {
           removeObserver(this._lastSelectedPromise, 'content', this, this._selectedObserverCallback);
         }

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -133,6 +133,14 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     assert('<PowerSelect> requires an `@onChange` function', this.args.onChange && typeof this.args.onChange === 'function');
   }
 
+  willDestroy() {
+    if (this._lastSelectedPromise && isPromiseProxyLike(this._lastSelectedPromise)) {
+      removeObserver(this._lastSelectedPromise, 'content', this, this._selectedObserverCallback);
+      this._lastSelectedPromise = undefined;
+    }
+    super.willDestroy.apply(this, arguments);
+  }
+
   // Getters
   get highlightOnHover(): boolean {
     return this.args.highlightOnHover === undefined ? true : this.args.highlightOnHover

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -88,7 +88,7 @@ const isArrayable = <T>(coll: any): coll is Arrayable<T> => {
   return typeof coll.toArray === 'function';
 }
 
-const isPromiseProxy = <T>(thing: any): thing is PromiseProxy<T> => {
+const isPromiseLike = <T>(thing: any): thing is Promise<T> => {
   return typeof thing.then === 'function';
 }
 
@@ -299,7 +299,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   @action
   _updateOptions(): void {
     if (!this.args.options) return
-    if (isPromiseProxy(this.args.options)) {
+    if (isPromiseLike(this.args.options)) {
       if (this._lastOptionsPromise === this.args.options) return; // promise is still the same
       let currentOptionsPromise = this.args.options;
       this._lastOptionsPromise = currentOptionsPromise as PromiseProxy<any[]>;
@@ -435,7 +435,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
       return;
     }
     let searchResult = this.args.search(term, this.storedAPI);
-    if (searchResult && isPromiseProxy(searchResult)) {
+    if (searchResult && isPromiseLike(searchResult)) {
       this.loading = true;
       if (this._lastSearchPromise !== undefined && isCancellablePromise(this._lastSearchPromise)) {
         this._lastSearchPromise.cancel(); // Cancel ember-concurrency tasks

--- a/tests/integration/components/power-select/general-behaviour-test.js
+++ b/tests/integration/components/power-select/general-behaviour-test.js
@@ -1188,7 +1188,7 @@ module('Integration | Component | Ember Power Select (General behavior)', functi
       let promise = new RSVP.Promise((resolve) => {
         setTimeout(() => resolve(['one', 'two', 'three']), 500);
       });
-      this.set('options', PromiseArrayProxy.create({ content: [], promise }));
+      this.set('options', PromiseArrayProxy.create({ promise }));
     };
 
     await render(hbs`
@@ -1220,18 +1220,10 @@ module('Integration | Component | Ember Power Select (General behavior)', functi
 
   test('Constant PromiseProxy references are tracked when .content changes', async function(assert) {
     let initial = null;
-    //initial = countries[1];
-    this.proxy = PromiseObject.create({content: initial, promise: Promise.resolve(initial)});
-    //this.proxy = ObjectProxy.create({content: initial});
-    //ObjectProxy does work, because they are not 'unpacked' by the .then
-    // and the {{#if select.selected}} in the trigger will correctly call the ObjectProxy.isTruthy
-    // which will setup the dep chain
+    this.proxy = PromiseObject.create({ promise: Promise.resolve(initial) });
     this.countries = countries;
     this.updateProxy = () => {
-      //this.set('proxy', countries[0]);
-      //this.set('proxy', PromiseObject.create({content: countries[0], promise: Promise.resolve(countries[0])}));
       this.proxy.set('content', countries[0]);
-      this.proxy.set('promise', Promise.resolve(countries[0]));
     };
 
     await render(hbs`


### PR DESCRIPTION
PowerSelect Component instances accumulate in the JS Heap when the initial `selected` value is a PromiseProxy. That's because we [addObserver for PromiseProxies](https://github.com/cibernox/ember-power-select/blob/fb688e44c166e42e58d6c89de02ede553464e38a/addon/components/power-select.ts#L335-L341), but the observer is not removed prior to component teardown.

We now remove the observer on component teardown, which allows PowerSelect Component instances to be removed from the JS Heap when the Component is destroyed.

Fixes #1391

---

The initial state of the JS Heap contains **1** PowerSelect instance, and the final state contains **1** instances (even though we visited a page containing the PowerSelect with `selected` PromiseProxy a total of five times). When the component is destroyed, it is removed from the JS Heap. 

![Screen Recording 2020-09-04 at 11 25 AM](https://user-images.githubusercontent.com/8826403/92262879-62071c80-eea1-11ea-98fe-8f024e3763e6.gif)
