### PR TITLE
[bugfix] Remove event listeners on destroy

### DIFF
--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -1,4 +1,4 @@
-<ul role="listbox" aria-controls="ember-power-select-trigger-{{@select.uniqueId}}" {{did-insert this.addHandlers}} ...attributes>
+<ul role="listbox" aria-controls="ember-power-select-trigger-{{@select.uniqueId}}" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
   {{! template-lint-disable no-unnecessary-concat }}
   {{#if @select.loading}}
     {{#if @loadingMessage}}

--- a/addon/components/power-select/options.ts
+++ b/addon/components/power-select/options.ts
@@ -102,6 +102,15 @@ export default class Options extends Component<Args> {
     }
   }
 
+  @action
+  removeHandlers(element: Element) {
+    element.removeEventListener('mouseup', this.mouseUpHandler);
+    element.removeEventListener('mouseover', this.mouseOverHandler);
+    element.removeEventListener('touchstart', this.touchStartHandler);
+    element.removeEventListener('touchmove', this.touchMoveHandler);
+    element.removeEventListener('touchend', this.touchEndHandler);
+  }
+
   _optionFromIndex(index: string) {
     let parts = index.split('.');
     let option = this.args.options[parseInt(parts[0], 10)];


### PR DESCRIPTION
An extra `PowerSelect` Component instance remains in the JS Heap until the `PowerSelect/Options` Component is re-rendered. That's because we [addEventListeners in PowerSelect/Options](https://github.com/cibernox/ember-power-select/blob/fb688e44c166e42e58d6c89de02ede553464e38a/addon/components/power-select/options.ts#L57-L72) but the listeners are not removed prior to component teardown.

This PR eagerly removes all event listeners on component teardown, which allows PowerSelect Component instances to be removed from the JS Heap when the Component is destroyed.  This implementation may attempt to remove listeners that have not been added. This is okay since calling removeEventListener() with arguments that do not identify any currently registered EventListener on the EventTarget has no effect.

Fixes #1393 

---

The initial state of the JS Heap contains **1** PowerSelect instance, and only **1** instance is ever allocated at any one time in memory throughout the life of the demonstration. When the component is destroyed, it is removed from the JS Heap.

![Screen Recording 2020-09-08 at 08 13 PM](https://user-images.githubusercontent.com/8826403/92542981-db8b6b80-f20f-11ea-9967-4578e26cc193.gif)


