### PR TITLE
Support both ember-concurrency 1.x and 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
     - env: EMBER_TRY_SCENARIO=node-tests
+    - env: EMBER_TRY_SCENARIO=ember-concurrency-1.x
+    - env: EMBER_TRY_SCENARIO=ember-concurrency-2.x
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -58,6 +58,22 @@ module.exports = async function() {
             'jquery-integration': true
           })
         }
+      },
+      {
+        name: 'ember-concurrency-1.x',
+        npm: {
+          dependencies: {
+            'ember-concurrency': '^1.3.0'
+          }
+        }
+      },
+      {
+        name: 'ember-concurrency-2.x',
+        npm: {
+          dependencies: {
+            'ember-concurrency': '^2.0.0-beta.1'
+          }
+        }
       }
     ]
   };

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-cli-babel": "^7.21.0",
     "ember-cli-htmlbars": "^5.2.0",
     "ember-cli-typescript": "^3.1.4",
-    "ember-concurrency": "^1.2.1",
+    "ember-concurrency": ">=1.0.0 <3",
     "ember-concurrency-decorators": "^2.0.0",
     "ember-text-measurer": "^0.6.0",
     "ember-truth-helpers": "^2.1.0"


### PR DESCRIPTION
We've just released ember-concurrency 2.0.0-beta.1. It's a largely API-compatible re-engineering of ember-concurrency's internals to support tracked properties and decouple from Ember (shedding EmberObject, etc.). As a popular library which depends on ember-concurrency, it would be nice for `ember-power-select` to support both 1.x and 2.x versions concurrently so that folks can upgrade the version of ember-concurrency in their applications at their leisure without waiting for all the add-ons they use to switch over to a newer version (and risk leaving folks who cannot upgrade yet behind.)

This PR adds some scenarios to ember-try to enable testing against both major releases and relaxes the version restriction.