### PR TITLE
Adding getDropdownItems test helper to ease testing

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -5,7 +5,8 @@ import {
   selectChoose as _selectChoose,
   selectSearch as _selectSearch,
   removeMultipleOption as _removeMultipleOption,
-  clearSelected as _clearSelected
+  clearSelected as _clearSelected,
+  getDropdownItems as _getDropdownItems
 } from './index';
 /**
  * @private
@@ -70,6 +71,10 @@ export async function touchTrigger() {
 
 export async function selectChoose(cssPathOrTrigger, valueOrSelector, optionIndex) {
   return _selectChoose(cssPathOrTrigger, valueOrSelector, optionIndex);
+}
+
+export async function getDropdownItems(cssPathOrTrigger) {
+  return _getDropdownItems(cssPathOrTrigger);
 }
 
 export async function selectSearch(cssPathOrTrigger, value) {

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -73,6 +73,14 @@ export async function selectChoose(cssPathOrTrigger, valueOrSelector, optionInde
   return _selectChoose(cssPathOrTrigger, valueOrSelector, optionIndex);
 }
 
+/* *
+ * @param {String} selector CSS3 selector of the elements to check the content
+ * @returns {Array} returns all the elements present in the dropdown
+ *
+ * Usage in tests:
+ * let options = await getDropdownItems('.ember-power-select-trigger');
+ * assert.deepEqual(options, [1, 2, 3]);
+ * */
 export async function getDropdownItems(cssPathOrTrigger) {
   return _getDropdownItems(cssPathOrTrigger);
 }

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -136,3 +136,38 @@ export async function clearSelected(cssPath) {
     throw e;
   }
 }
+
+export async function getDropdownItems(cssPathOrTrigger) {
+  let trigger;
+
+  if (cssPathOrTrigger instanceof HTMLElement) {
+    if (cssPathOrTrigger.classList.contains('ember-power-select-trigger')) {
+      trigger = cssPathOrTrigger;
+    } else {
+      trigger = cssPathOrTrigger.querySelector('.ember-power-select-trigger');
+    }
+  } else {
+    trigger = document.querySelector(`${cssPathOrTrigger} .ember-power-select-trigger`);
+
+    if (!trigger) {
+      trigger = document.querySelector(cssPathOrTrigger);
+    }
+
+    if (!trigger) {
+      throw new Error(`You called "getDropdownItems('${cssPathOrTrigger}'" but no select was found using selector "${cssPathOrTrigger}"`);
+    }
+  }
+
+  if (trigger.scrollIntoView) {
+    trigger.scrollIntoView();
+  }
+
+  let contentId = await openIfClosedAndGetContentId(trigger);
+  // Select the option with the given selector
+  let options = document.querySelectorAll(`#${contentId} .ember-power-select-option`);
+  let obtainedOptions = [];
+  if (options.length > 0) {
+    [].slice.apply(options).map((opt) => obtainedOptions.push(opt.textContent.trim()));
+  }
+  return obtainedOptions;
+}

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -137,6 +137,10 @@ export async function clearSelected(cssPath) {
   }
 }
 
+/* *
+ * @param {String} selector CSS3 selector of the elements to check the content
+ * @returns {Array} returns all the elements present in the dropdown
+ * */
 export async function getDropdownItems(cssPathOrTrigger) {
   let trigger;
 

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -164,10 +164,10 @@ export async function getDropdownItems(cssPathOrTrigger) {
 
   let contentId = await openIfClosedAndGetContentId(trigger);
   // Select the option with the given selector
-  let options = document.querySelectorAll(`#${contentId} .ember-power-select-option`);
-  let obtainedOptions = [];
-  if (options.length > 0) {
-    [].slice.apply(options).map((opt) => obtainedOptions.push(opt.textContent.trim()));
+  let rawOptions = document.querySelectorAll(`#${contentId} .ember-power-select-option`);
+  let extractedOptions = [];
+  if (rawOptions.length > 0) {
+    [].slice.apply(rawOptions).map((opt) => extractedOptions.push(opt.textContent.trim()));
   }
-  return obtainedOptions;
+  return extractedOptions;
 }

--- a/tests/integration/components/power-select/helpers-test.js
+++ b/tests/integration/components/power-select/helpers-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { selectChoose } from 'ember-power-select/test-support/helpers';
+import { selectChoose, getDropdownItems } from 'ember-power-select/test-support/helpers';
 import { numbers } from '../constants';
 
 module('Integration | Helpers | selectChoose', function(hooks) {
@@ -38,5 +38,40 @@ module('Integration | Helpers | selectChoose', function(hooks) {
     assert.dom('.ember-power-select-multiple-option ').exists({ count: 1 }, 'There is one selected option');
     await selectChoose('.ember-power-select-trigger', 'five');
     assert.dom('.ember-power-select-multiple-option ').exists({ count: 2 }, 'There is one selected option');
+  });
+});
+
+module('Integration | Helpers | getDropdownItems', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('getDropdownItems should give the list of items in the select dropdown', async function(assert) {
+    assert.expect(1);
+
+    this.numbers = numbers;
+    await render(hbs`
+      <PowerSelect @options={{numbers}} @selected={{foo}} @onChange={{action (mut foo)}} as |option|>
+        {{option}}
+      </PowerSelect>
+    `);
+
+    let options = await getDropdownItems('.ember-power-select-trigger');
+    assert.deepEqual(options, numbers, 'elements from the dropdown should be same as passed elements');
+  });
+
+  test('getDropdownItems should throws an error when selector is not matched', async function(assert) {
+    assert.expect(1);
+
+    this.numbers = numbers;
+    await render(hbs`
+      <PowerSelect @options={{numbers}} @selected={{foo}} @onChange={{action (mut foo)}} as |option|>
+        {{option}}
+      </PowerSelect>
+    `);
+
+    try {
+      await getDropdownItems('.fake-ember-power-select-trigger');
+    } catch (error) {
+      assert.equal(error.message, 'You called "getDropdownItems(\'.fake-ember-power-select-trigger\'" but no select was found using selector ".fake-ember-power-select-trigger"', 'elements from the dropdown should be same as passed elements');
+    }
   });
 });


### PR DESCRIPTION
**summary:**

- Adding new test helper `getDropdownItems`.
- `getDropdownItems` will return all the displayed items in the `power-select` dropdown
- Using this test helper to assert the displayed drop down items.