### PR TITLE
Address issue with isActive handling on ember-release

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -280,7 +280,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   @action
   handleFocus(event: FocusEvent): void {
     if (!this.isDestroying) {
-      this.isActive = true;
+      scheduleOnce('actions', this, this._updateIsActive, true);
     }
     if (this.args.onFocus) {
       this.args.onFocus(this.storedAPI, event);
@@ -290,7 +290,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   @action
   handleBlur(event: FocusEvent): void {
     if (!this.isDestroying) {
-      this.isActive = false;
+      scheduleOnce('actions', this, this._updateIsActive, false);
     }
     if (this.args.onBlur) {
       this.args.onBlur(this.storedAPI, event);
@@ -476,6 +476,10 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
       this._searchResult = searchResult;
       this._resetHighlighted();
     }
+  }
+
+  _updateIsActive(value: boolean) {
+    this.isActive = value;
   }
 
   _defaultBuildSelection(option: any): any {


### PR DESCRIPTION
There are a few failing tests on ember-release scenario. [Example build](https://travis-ci.org/github/cibernox/ember-power-select/jobs/736488969)

The tests are failing with a message like:

```
Error: Assertion Failed: You attempted to update `isActive` on `PowerSelect`, but it had already been used previously in the same computation.  Attempting to update a value after using it in a computation can cause logical errors, infinite revalidation bugs, and performance issues, and is not supported.

`isActive` was first used:

- While rendering:
  application
    index
      power-select
        basic-dropdown
          basic-dropdown-trigger
            -dynamic-element
              (result of a `ifHelper` helper)
                (result of a `assign` helper).isActive
                  (result of a `assign` helper)
```

This happens when `@disabled` is changed and `handleBlur` run in one runloop, like in this test:

https://github.com/cibernox/ember-power-select/blob/1fcb26e8ce7b48dc9e3617b406c9c81c77c4c23d/tests/integration/components/power-select/disabled-test.js#L256-L271
Running `isActive` mutation later solves the issue. Running it later for `focus` event is required for ordering consistency.