### PR TITLE
Enables screen readers to announce highlighted select options.

### DIFF
--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -27,7 +27,7 @@
           aria-disabled={{if opt.disabled "true"}}
           aria-current="{{eq opt @select.highlighted}}"
           data-option-index="{{@groupIndex}}{{index}}"
-          role="option">
+          role={{if (eq opt @select.highlighted) "alert" "option"}}>
           {{yield opt @select}}
         </li>
       {{/if}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-power-select",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -40,7 +40,7 @@ module('Integration | Component | Ember Power Select (Accesibility)', function(h
     [].slice.call(nestedOptionList).forEach((e) => assert.dom(e).hasAttribute('role', 'group'));
   });
 
-  test('Single-select: All options have `role=option`', async function(assert) {
+  test('Single-select: All options have `role=option` except highlighted options which have `role=alert`', async function(assert) {
     assert.expect(15);
 
     this.groupedNumbers = groupedNumbers;
@@ -51,10 +51,17 @@ module('Integration | Component | Ember Power Select (Accesibility)', function(h
     `);
 
     await clickTrigger();
-    [].slice.call(document.querySelectorAll('.ember-power-select-option')).forEach((e) => assert.dom(e).hasAttribute('role', 'option'));
+
+    [].slice.call(document.querySelectorAll('li.ember-power-select-option[aria-current="true"]')).forEach((e) => {
+      assert.dom(e).hasAttribute('role', 'alert');
+    });
+
+    [].slice.call(document.querySelectorAll('li.ember-power-select-option[aria-current="false"]')).forEach((e) => {
+      assert.dom(e).hasAttribute('role', 'option');
+    });
   });
 
-  test('Multiple-select: All options have `role=option`', async function(assert) {
+  test('Multiple-select: All options have `role=option` except highlighted options which have `role=alert`', async function(assert) {
     assert.expect(15);
 
     this.groupedNumbers = groupedNumbers;
@@ -65,7 +72,14 @@ module('Integration | Component | Ember Power Select (Accesibility)', function(h
     `);
 
     await clickTrigger();
-    [].slice.call(document.querySelectorAll('.ember-power-select-option')).forEach((e) => assert.dom(e).hasAttribute('role', 'option'));
+
+    [].slice.call(document.querySelectorAll('li.ember-power-select-option[aria-current="true"]')).forEach((e) => {
+      assert.dom(e).hasAttribute('role', 'alert');
+    });
+
+    [].slice.call(document.querySelectorAll('li.ember-power-select-option[aria-current="false"]')).forEach((e) => {
+      assert.dom(e).hasAttribute('role', 'option');
+    });
   });
 
   test('Single-select: The selected option has `aria-selected=true` and the rest `aria-selected=false`', async function(assert) {
@@ -135,6 +149,42 @@ module('Integration | Component | Ember Power Select (Accesibility)', function(h
     await triggerKeyEvent('.ember-power-select-search-input', 'keydown', 40);
     assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('aria-current', 'false', 'the first option has now aria-current=false');
     assert.dom(findContains('.ember-power-select-option', 'two')).hasAttribute('aria-current', 'true', 'the second option has now aria-current=false');
+  });
+
+  test('Single-select: The highlighted option has `role=alert` and the rest have `role=option`', async function(assert) {
+    assert.expect(4);
+
+    this.numbers = numbers;
+    await render(hbs`
+      <PowerSelect @options={{numbers}} @selected={{selected}} @onChange={{action (mut selected)}} @searchEnabled={{true}} as |option|>
+        {{option}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+    assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('role', 'alert', 'the highlighted option has role=alert');
+    assert.dom('.ember-power-select-option[role="option"]').exists({ count: numbers.length - 1 }, 'All other options have role=option');
+    await triggerKeyEvent('.ember-power-select-search-input', 'keydown', 40);
+    assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('role', 'option', 'the first option now has role=option');
+    assert.dom(findContains('.ember-power-select-option', 'two')).hasAttribute('role', 'alert', 'the second option now has role=alert');
+  });
+
+  test('Multiple-select: The highlighted option has `role=alert` and the rest `role=option`', async function(assert) {
+    assert.expect(4);
+
+    this.numbers = numbers;
+    await render(hbs`
+      <PowerSelect @options={{numbers}} @selected={{selected}} @onChange={{action (mut selected)}} @searchEnabled={{true}} as |option|>
+        {{option}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+    assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('role', 'alert', 'the highlighted option has role=alert');
+    assert.dom('.ember-power-select-option[role="option"]').exists({ count: numbers.length - 1 }, 'All other options have role=option');
+    await triggerKeyEvent('.ember-power-select-search-input', 'keydown', 40);
+    assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('role', 'option', 'the first option now has role=option');
+    assert.dom(findContains('.ember-power-select-option', 'two')).hasAttribute('role', 'alert', 'the second option now has role=alert');
   });
 
   test('Single-select: Options with a disabled field have `aria-disabled=true`', async function(assert) {


### PR DESCRIPTION
Hola Miguel @cibernox! 🎉

My team is currently working through a VPAT accessibility audit. One of the most pressing blockers surfaced is that highlighted select options are not spoken by any of the screen readers - Major (VoiceOver, NVDA, JAWS) or Minor (ChromeVox, etc).

This PR enables screen readers to announce highlighted select options by alerting screen readers to highlighted select options. 

_VoiceOver Demo_
https://youtu.be/n2qYc0gI5i0
https://deploy-preview-1409--rubber-tapper-eddies-44787.netlify.app/


Just want to say Thanks for all the hard work leading `ember-power-select`, I know it isn't easy! 