### PR TITLE
Widen `ember-truth-helpers` dependency constraint to allow v3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember-concurrency": ">=1.0.0 <3",
     "ember-concurrency-decorators": "^2.0.0",
     "ember-text-measurer": "^0.6.0",
-    "ember-truth-helpers": "^2.1.0"
+    "ember-truth-helpers": "^2.1.0 || ^3.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",


### PR DESCRIPTION
same as https://github.com/cibernox/ember-basic-dropdown/pull/584

This avoids users having to use resolutions to update to ember-truth-helpers v3 :)