### PR TITLE
package.json: Move `@ember-decorators/component` into `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "vendor"
   ],
   "dependencies": {
-    "@ember-decorators/component": "^6.1.0",
     "@glimmer/component": "^1.0.1",
     "@glimmer/tracking": "^1.0.0",
     "ember-assign-helper": "^0.3.0",
@@ -62,6 +61,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
+    "@ember-decorators/component": "^6.1.0",
     "@types/ember": "^3.16.0",
     "@types/ember-data": "^3.16.1",
     "@types/ember-qunit": "^3.4.9",


### PR DESCRIPTION
Now that we use glimmer components this dependency is no longer needed. There is still one usage in the dummy app though, so we can move it to `devDependencies` for now.