### PR TITLE
onChange action receives Event as last arg on mouseup

### DIFF
--- a/addon/components/power-select/options.ts
+++ b/addon/components/power-select/options.ts
@@ -46,7 +46,7 @@ export default class Options extends Component<Args> {
     if (role === 'group') {
       return;
     }
-    let findOptionAndPerform = (action: Function, select: Select, e: Event): void => {
+    let findOptionAndPerform = (action: Function, e: Event): void => {
       if (e.target === null) return;
       let optionItem = (e.target as Element).closest('[data-option-index]');
       if (!optionItem) {
@@ -57,12 +57,12 @@ export default class Options extends Component<Args> {
       }
       let optionIndex = optionItem.getAttribute('data-option-index');
       if (optionIndex === null) return;
-      action(this._optionFromIndex(optionIndex), select, e);
+      action(this._optionFromIndex(optionIndex), e);
     };
-    this.mouseUpHandler = (e: MouseEvent): void => findOptionAndPerform(this.args.select.actions.choose, this.args.select, e);
+    this.mouseUpHandler = (e: MouseEvent): void => findOptionAndPerform(this.args.select.actions.choose, e);
     element.addEventListener('mouseup', this.mouseUpHandler);
     if (this.args.highlightOnHover) {
-      this.mouseOverHandler = (e: MouseEvent): void => findOptionAndPerform(this.args.select.actions.highlight, this.args.select, e);
+      this.mouseOverHandler = (e: MouseEvent): void => findOptionAndPerform(this.args.select.actions.highlight, e);
       element.addEventListener('mouseover', this.mouseOverHandler);
     }
     if (this.isTouchDevice) {

--- a/tests/integration/components/power-select/mouse-control-test.js
+++ b/tests/integration/components/power-select/mouse-control-test.js
@@ -45,12 +45,13 @@ module('Integration | Component | Ember Power Select (Mouse control)', function(
   });
 
   test('Clicking an item selects it, closes the dropdown and focuses the trigger', async function(assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     this.numbers = numbers;
-    this.foo = (val, dropdown) => {
+    this.foo = (val, dropdown, event) => {
       assert.equal(val, 'four', 'The action is invoked with the selected value as first parameter');
       assert.ok(dropdown.actions.close, 'The action is invoked with the the dropdown object as second parameter');
+      assert.ok(event instanceof window.Event, 'The third argument is an event');
     };
     await render(hbs`
       <PowerSelect @options={{numbers}} @onChange={{foo}} as |option|>


### PR DESCRIPTION
This change ensures that when an option in the `PowerSelect/Options` component is clicked, the action registered on `mouseup` will pass the`mouseup` `Event` all the way to the `onChoose` action.

Previously, the second AND third event passed to the onChoose action was the dropdown, aka `this.storedAPI`, due to arguments not being passed as expected from the `mouseup` handler, and the Event was never received by the `onChoose` action.

A test has been included in this change. 

Fixes #1412