### PR TITLE
[Embroider] replace with safe component

### DIFF
--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -16,7 +16,7 @@
         </span>
       {{/unless}}
       {{#if @selectedItemComponent}}
-        {{component @selectedItemComponent extra=@extra option=opt select=@select}}
+        {{component (ensure-safe-component @selectedItemComponent) extra=@extra option=opt select=@select}}
       {{else}}
         {{yield opt @select}}
       {{/if}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -46,7 +46,7 @@
       id={{@triggerId}}
       tabindex={{and (not @disabled) (or @tabindex "0")}}
       >
-      {{#let (or (component (ensure-safe-component @triggerComponent)) (component "power-select/trigger")) as |Trigger|}}
+      {{#let (if (eq @triggerComponent undefined) (component "power-select/trigger") (component (ensure-safe-component @triggerComponent))) as |Trigger|}}
         <Trigger
           @allowClear={{@allowClear}}
           @buildSelection={{@buildSelection}}
@@ -62,7 +62,7 @@
           @onInput={{this.handleInput}}
           @onKeydown={{this.handleKeydown}}
           @placeholder={{@placeholder}}
-          @placeholderComponent={{this.placeholderComponent}}
+          @placeholderComponent={{if @placeholderComponent (component (ensure-safe-component @placeholderComponent)) (component 'power-select/placeholder')}}
           as |opt term|>
           {{yield opt term}}
         </Trigger>
@@ -78,7 +78,7 @@
           @onFocus={{this.handleFocus}}
           @onBlur={{this.handleBlur}}
           @placeholder={{@placeholder}}
-          @placeholderComponent={{this.placeholderComponent}}
+          @placeholderComponent={{if @placeholderComponent (component (ensure-safe-component @placeholderComponent)) (component 'power-select/placeholder')}}
           @extra={{@extra}}
           @listboxId={{listboxId}}
           @selectedItemComponent={{@selectedItemComponent}}
@@ -86,15 +86,15 @@
           />
       {{/let}}
       {{#if this.mustShowSearchMessage}}
-        {{#let (or (component (ensure-safe-component @searchMessageComponent)) (component "power-select/search-message")) as |SearchMessage|}}
+        {{#let (if (eq @searchMessageComponent undefined) (component "power-select/search-message") (component (ensure-safe-component @searchMessageComponent))) as |SearchMessage|}}
           <SearchMessage @searchMessage={{this.searchMessage}} @select={{publicAPI}}/>
         {{/let}}
       {{else if this.mustShowNoMessages}}
-        {{#let (or (component (ensure-safe-component @noMatchesMessageComponent)) (component "power-select/no-matches-message")) as |NoMatchesMessage|}}
+        {{#let (if (eq @noMatchesMessageComponent undefined) (component "power-select/no-matches-message") (component (ensure-safe-component @noMatchesMessageComponent))) as |NoMatchesMessage|}}
           <NoMatchesMessage @noMatchesMessage={{this.noMatchesMessage}} @select={{publicAPI}} />
         {{/let}}
       {{else}}
-        {{#let (or (component (ensure-safe-component @optionsComponent)) (component "power-select/options")) as |Options|}}
+        {{#let (if (eq @optionsComponent undefined) (component "power-select/options") (component (ensure-safe-component @optionsComponent))) as |Options|}}
           <Options
             @loadingMessage={{or @loadingMessage "Loading options..."}}
             @select={{publicAPI}}
@@ -184,7 +184,7 @@
         @onBlur={{this.handleBlur}}
         @extra={{@extra}}
         @placeholder={{@placeholder}}
-        @placeholderComponent={{this.placeholderComponent}}
+        @placeholderComponent={{if @placeholderComponent (component (ensure-safe-component @placeholderComponent)) (component 'power-select/placeholder')}}
         @selectedItemComponent={{@selectedItemComponent}}/>
     {{/let}}
     {{#if this.mustShowSearchMessage}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -46,7 +46,7 @@
       id={{@triggerId}}
       tabindex={{and (not @disabled) (or @tabindex "0")}}
       >
-      {{#let (component (or (ensure-safe-component @triggerComponent) "power-select/trigger")) as |Trigger|}}
+      {{#let (or (component (ensure-safe-component @triggerComponent)) (component "power-select/trigger")) as |Trigger|}}
         <Trigger
           @allowClear={{@allowClear}}
           @buildSelection={{@buildSelection}}
@@ -69,7 +69,7 @@
       {{/let}}
     </dropdown.Trigger>
     <dropdown.Content class="ember-power-select-dropdown{{if publicAPI.isActive " ember-power-select-dropdown--active"}} {{@dropdownClass}}">
-      {{#let (component (if (eq @beforeOptionsComponent undefined) "power-select/before-options" (ensure-safe-component @beforeOptionsComponent))) as |BeforeOptions|}}
+      {{#let (if (eq @beforeOptionsComponent undefined) (component "power-select/before-options") (component (ensure-safe-component @beforeOptionsComponent))) as |BeforeOptions|}}
         <BeforeOptions
           @select={{publicAPI}}
           @searchEnabled={{@searchEnabled}}
@@ -86,15 +86,15 @@
           />
       {{/let}}
       {{#if this.mustShowSearchMessage}}
-        {{#let (component (or (ensure-safe-component @searchMessageComponent) "power-select/search-message")) as |SearchMessage|}}
+        {{#let (or (component (ensure-safe-component @searchMessageComponent)) (component "power-select/search-message")) as |SearchMessage|}}
           <SearchMessage @searchMessage={{this.searchMessage}} @select={{publicAPI}}/>
         {{/let}}
       {{else if this.mustShowNoMessages}}
-        {{#let (component (or (ensure-safe-component @noMatchesMessageComponent) "power-select/no-matches-message")) as |NoMatchesMessage|}}
+        {{#let (or (component (ensure-safe-component @noMatchesMessageComponent)) (component "power-select/no-matches-message")) as |NoMatchesMessage|}}
           <NoMatchesMessage @noMatchesMessage={{this.noMatchesMessage}} @select={{publicAPI}} />
         {{/let}}
       {{else}}
-        {{#let (component (or (ensure-safe-component @optionsComponent) "power-select/options")) as |Options|}}
+        {{#let (or (component (ensure-safe-component @optionsComponent)) (component "power-select/options")) as |Options|}}
           <Options
             @loadingMessage={{or @loadingMessage "Loading options..."}}
             @select={{publicAPI}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -46,7 +46,7 @@
       id={{@triggerId}}
       tabindex={{and (not @disabled) (or @tabindex "0")}}
       >
-      {{#let (component (or @triggerComponent "power-select/trigger")) as |Trigger|}}
+      {{#let (component (or (ensure-safe-component @triggerComponent) "power-select/trigger")) as |Trigger|}}
         <Trigger
           @allowClear={{@allowClear}}
           @buildSelection={{@buildSelection}}
@@ -69,7 +69,7 @@
       {{/let}}
     </dropdown.Trigger>
     <dropdown.Content class="ember-power-select-dropdown{{if publicAPI.isActive " ember-power-select-dropdown--active"}} {{@dropdownClass}}">
-      {{#let (component (if (eq @beforeOptionsComponent undefined) "power-select/before-options" @beforeOptionsComponent)) as |BeforeOptions|}}
+      {{#let (component (if (eq @beforeOptionsComponent undefined) "power-select/before-options" (ensure-safe-component @beforeOptionsComponent))) as |BeforeOptions|}}
         <BeforeOptions
           @select={{publicAPI}}
           @searchEnabled={{@searchEnabled}}
@@ -86,15 +86,15 @@
           />
       {{/let}}
       {{#if this.mustShowSearchMessage}}
-        {{#let (component (or @searchMessageComponent "power-select/search-message")) as |SearchMessage|}}
+        {{#let (component (or (ensure-safe-component @searchMessageComponent) "power-select/search-message")) as |SearchMessage|}}
           <SearchMessage @searchMessage={{this.searchMessage}} @select={{publicAPI}}/>
         {{/let}}
       {{else if this.mustShowNoMessages}}
-        {{#let (component (or @noMatchesMessageComponent "power-select/no-matches-message")) as |NoMatchesMessage|}}
+        {{#let (component (or (ensure-safe-component @noMatchesMessageComponent) "power-select/no-matches-message")) as |NoMatchesMessage|}}
           <NoMatchesMessage @noMatchesMessage={{this.noMatchesMessage}} @select={{publicAPI}} />
         {{/let}}
       {{else}}
-        {{#let (component (or @optionsComponent "power-select/options")) as |Options|}}
+        {{#let (component (or (ensure-safe-component @optionsComponent) "power-select/options")) as |Options|}}
           <Options
             @loadingMessage={{or @loadingMessage "Loading options..."}}
             @select={{publicAPI}}
@@ -103,14 +103,14 @@
             @optionsComponent={{Options}}
             @extra={{@extra}}
             @highlightOnHover={{this.highlightOnHover}}
-            @groupComponent={{or @groupComponent "power-select/power-select-group"}}
+            @groupComponent={{or @groupComponent (component "power-select/power-select-group")}}
             id={{listboxId}}
             class="ember-power-select-options" as |option select|>
             {{yield option select}}
           </Options>
         {{/let}}
       {{/if}}
-      {{#let (component @afterOptionsComponent) as |AfterOptions|}}
+      {{#let (component (ensure-safe-component @afterOptionsComponent)) as |AfterOptions|}}
         <AfterOptions
           @extra={{@extra}}
           @select={{publicAPI}}
@@ -148,7 +148,7 @@
     aria-required={{@required}}
     title={{@title}}
     tabindex={{and (not @disabled) (or @tabindex "0")}}>
-    {{#let (component this.triggerComponent) as |Trigger|}}
+    {{#let (component (ensure-safe-component this.triggerComponent)) as |Trigger|}}
       <Trigger
         @htmlTag={{this._triggerTagName}}
         @allowClear={{@allowClear}}
@@ -171,7 +171,7 @@
     {{/let}}
   </dropdown.Trigger>
   <dropdown.Content @htmlTag={{this._contentTagName}} class={{this.concatenatedDropdownClasses}}>
-    {{#let (component this.beforeOptionsComponent) as |BeforeOptions|}}
+    {{#let (component (ensure-safe-component this.beforeOptionsComponent)) as |BeforeOptions|}}
       <BeforeOptions
         @animationEnabled={{@animationEnabled}}
         @select={{this.publicAPI}}
@@ -188,7 +188,7 @@
         @selectedItemComponent={{@selectedItemComponent}}/>
     {{/let}}
     {{#if this.mustShowSearchMessage}}
-      {{#let (component this.searchMessageComponent) as |SearchMessage|}}
+      {{#let (component (ensure-safe-component this.searchMessageComponent)) as |SearchMessage|}}
         <SearchMessage @searchMessage={{this.searchMessage}} @select={{this.publicAPI}}/>
       {{/let}}
     {{else if this.mustShowNoMessages}}
@@ -200,7 +200,7 @@
         </ul>
       {{/if}}
     {{else}}
-      {{#let (component this.optionsComponent) as |Options|}}
+      {{#let (component (ensure-safe-component this.optionsComponent)) as |Options|}}
         <Options
           @loadingMessage={{this.loadingMessage}}
           @groupIndex=""
@@ -216,7 +216,7 @@
         </Options>
       {{/let}}
     {{/if}}
-    {{#let (component this.afterOptionsComponent) as |AfterOptions|}}
+    {{#let (component (ensure-safe-component this.afterOptionsComponent)) as |AfterOptions|}}
       <AfterOptions @select={{this.publicAPI}} @extra={{@extra}}/>
     {{/let}}
   </dropdown.Content>

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -21,7 +21,6 @@ import { restartableTask } from 'ember-concurrency-decorators';
 // @ts-ignore
 import { timeout } from 'ember-concurrency';
 import { Dropdown, DropdownActions } from 'ember-basic-dropdown/addon/components/basic-dropdown';
-
 interface SelectActions extends DropdownActions {
   search: (term: string) => void
   highlight: (option: any) => void
@@ -144,9 +143,6 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   // Getters
   get highlightOnHover(): boolean {
     return this.args.highlightOnHover === undefined ? true : this.args.highlightOnHover
-  }
-  get placeholderComponent(): string {
-    return this.args.placeholderComponent || 'power-select/placeholder';
   }
 
   get searchMessage(): string {

--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -5,7 +5,7 @@
       <li class="ember-power-select-option ember-power-select-option--loading-message" role="option">{{@loadingMessage}}</li>
     {{/if}}
   {{/if}}
-  {{#let (component @groupComponent) (component @optionsComponent) as |Group Options|}}
+  {{#let (component (ensure-safe-component @groupComponent)) (component (ensure-safe-component @optionsComponent)) as |Group Options|}}
     {{#each @options as |opt index|}}
       {{#if (ember-power-select-is-group opt)}}
         <Group @group={{opt}} @select={{@select}} @extra={{@extra}}>

--- a/addon/components/power-select/trigger.hbs
+++ b/addon/components/power-select/trigger.hbs
@@ -1,6 +1,6 @@
 {{#if @select.selected}}
   {{#if @selectedItemComponent}}
-    {{component @selectedItemComponent extra=(readonly @extra) option=(readonly @select.selected) select=(readonly @select)}}
+    {{component (ensure-safe-component @selectedItemComponent) extra=(readonly @extra) option=(readonly @select.selected) select=(readonly @select)}}
   {{else}}
     <span class="ember-power-select-selected-item">{{yield @select.selected @select}}</span>
   {{/if}}
@@ -8,6 +8,6 @@
     <span class="ember-power-select-clear-btn" {{on "mousedown" this.clear}} {{on "touchstart" this.clear}}>&times;</span>
   {{/if}}
 {{else}}
-  {{component @placeholderComponent placeholder=@placeholder}}
+  {{component (ensure-safe-component @placeholderComponent) placeholder=@placeholder}}
 {{/if}}
 <span class="ember-power-select-status-icon"></span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,6 +1962,14 @@
         "ember-cli-babel": "^7.22.1"
       }
     },
+    "@embroider/util": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@embroider/util/-/util-0.31.0.tgz",
+      "integrity": "sha512-unfr1ucgrwyogpXHO2weZ63rw/M3+9oQnk5W2v+1Jlkj//CBtuz/F9U+k10IYu2YbrLxk4y8wY0ordLxoylqXQ==",
+      "requires": {
+        "ember-cli-babel": "^7.22.1"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "vendor"
   ],
   "dependencies": {
+    "@embroider/util": "0.31.0",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "ember-assign-helper": "^0.3.0",

--- a/tests/dummy/app/templates/helpers-testing.hbs
+++ b/tests/dummy/app/templates/helpers-testing.hbs
@@ -57,7 +57,7 @@
     @onChange={{fn (mut this.selected3)}}
     @search={{this.searchAsync}}
     @beforeOptionsComponent={{null}}
-    @triggerComponent="custom-trigger-with-search" as |num|>
+    @triggerComponent={{component "custom-trigger-with-search"}} as |num|>
     {{num}}
   </PowerSelect>
 </div>

--- a/tests/dummy/app/templates/public-pages.hbs
+++ b/tests/dummy/app/templates/public-pages.hbs
@@ -15,7 +15,7 @@
           @options={{this.mainSelectOptions}}
           @selected={{this.mainSelected}}
           @disabled={{this.disabled}}
-          @triggerComponent="main-header-select-trigger"
+          @triggerComponent={{component "main-header-select-trigger"}}
           @onChange={{this.changeOptions}}
           @dropdownClass="main-header-select-dropdown" as |opt|>
           {{opt}}

--- a/tests/dummy/app/templates/snippets/the-trigger-2.hbs
+++ b/tests/dummy/app/templates/snippets/the-trigger-2.hbs
@@ -2,7 +2,7 @@
   @searchEnabled={{true}}
   @options={{this.countries}}
   @selected={{this.country}}
-  @selectedItemComponent="selected-item-country"
+  @selectedItemComponent={{component "selected-item-country"}}
   @searchField="name"
   @onChange={{fn (mut this.country)}}
   as |country|>

--- a/tests/dummy/app/templates/snippets/the-trigger-4.hbs
+++ b/tests/dummy/app/templates/snippets/the-trigger-4.hbs
@@ -1,7 +1,7 @@
 <PowerSelect
   @options={{this.names}}
   @selected={{this.aName}}
-  @placeholderComponent="weird-placeholder"
+  @placeholderComponent={{component "weird-placeholder"}}
   @onChange={{fn (mut this.aName)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/tests/integration/components/power-select/customization-with-components-test.js
+++ b/tests/integration/components/power-select/customization-with-components-test.js
@@ -66,7 +66,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelect @options={{countries}} @selected={{country}} @selectedItemComponent="selected-item-country" @onChange={{action (mut foo)}} as |country|>
+      <PowerSelect @options={{countries}} @selected={{country}} @selectedItemComponent={{component "selected-item-country"}} @onChange={{action (mut foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);

--- a/tests/integration/components/power-select/customization-with-components-test.js
+++ b/tests/integration/components/power-select/customization-with-components-test.js
@@ -25,7 +25,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelect @options={{countries}} @selected={{country}} @triggerComponent="selected-country" @onChange={{action (mut foo)}} as |country|>
+      <PowerSelect @options={{countries}} @selected={{country}} @triggerComponent={{component "selected-country"}} @onChange={{action (mut foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);
@@ -46,7 +46,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
         @options={{this.countries}}
         @loadingMessage="hmmmm paella"
         @selected={{country}}
-        @triggerComponent="custom-trigger-component"
+        @triggerComponent={{component "custom-trigger-component"}}
         @onChange={{action (mut foo)}} as |country|>
         {{option}}
       </PowerSelect>
@@ -98,7 +98,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelect @options={{countries}} @selected={{country}} @optionsComponent="list-of-countries" @onChange={{action (mut foo)}} as |country|>
+      <PowerSelect @options={{countries}} @selected={{country}} @optionsComponent={{component "list-of-countries"}} @onChange={{action (mut foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);
@@ -130,7 +130,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelect @options={{countries}} @selected={{country}} @optionsComponent="list-of-countries" @onChange={{action (mut foo)}} @extra={{hash field="code"}} as |country|>
+      <PowerSelect @options={{countries}} @selected={{country}} @optionsComponent={{component "list-of-countries"}} @onChange={{action (mut foo)}} @extra={{hash field="code"}} as |country|>
         {{country.code}}
       </PowerSelect>
     `);
@@ -155,7 +155,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
       <PowerSelect
         @options={{countries}}
         @selected={{country}}
-        @beforeOptionsComponent="custom-before-options"
+        @beforeOptionsComponent={{component "custom-before-options"}}
         @placeholder="inception"
         @placeholderComponent={{component "power-select/placeholder"}}
         @onChange={{action (mut foo)}} as |country|>
@@ -182,7 +182,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
       <PowerSelect
         @options={{countries}}
         @selected={{country}}
-        @afterOptionsComponent="custom-after-options"
+        @afterOptionsComponent={{component "custom-after-options"}}
         @onChange={{action (mut foo)}}
         @searchEnabled={{true}} as |country|>
         {{country.name}}
@@ -214,8 +214,8 @@ module('Integration | Component | Ember Power Select (Customization using compon
         @options={{countries}}
         @selected={{country}}
         @onChange={{action (mut selected)}}
-        @afterOptionsComponent="custom-after-options2"
-        @beforeOptionsComponent="custom-before-options2"
+        @afterOptionsComponent={{component "custom-after-options2"}}
+        @beforeOptionsComponent={{component "custom-before-options2"}}
         @extra={{hash passedAction=(action someAction)}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -250,7 +250,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
         @options={{countries}}
         @selected={{country}}
         @onChange={{action (mut selected)}}
-        @triggerComponent="custom-trigger-that-handles-focus"
+        @triggerComponent={{component "custom-trigger-that-handles-focus"}}
         @onFocus={{this.didFocusInside}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -266,7 +266,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     }));
     this.searchFn = function() {};
     await render(hbs`
-      <PowerSelect @search={{searchFn}} @searchMessageComponent="custom-search-message" @onChange={{action (mut foo)}} as |country|>
+      <PowerSelect @search={{searchFn}} @searchMessageComponent={{component "custom-search-message"}} @onChange={{action (mut foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);
@@ -285,7 +285,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.options = [];
 
     await render(hbs`
-      <PowerSelect @options={{options}} @noMatchesMessageComponent="custom-no-matches-message" @noMatchesMessage="Nope" @onChange={{action (mut foo)}} as |option|>
+      <PowerSelect @options={{options}} @noMatchesMessageComponent={{component "custom-no-matches-message"}} @noMatchesMessage="Nope" @onChange={{action (mut foo)}} as |option|>
         {{option}}
       </PowerSelect>
     `);
@@ -311,7 +311,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
       <PowerSelect
         @options={{countries}}
         @placeholder="test"
-        @placeholderComponent="custom-placeholder"
+        @placeholderComponent={{component "custom-placeholder"}}
         @onChange={{action (mut foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -330,7 +330,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     }));
 
     await render(hbs`
-      <PowerSelect @options={{groupedNumbers}} @groupComponent="custom-group-component" @onChange={{action (mut foo)}} as |country|>
+      <PowerSelect @options={{groupedNumbers}} @groupComponent={{component "custom-group-component"}} @onChange={{action (mut foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);
@@ -358,7 +358,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     }));
 
     await render(hbs`
-      <PowerSelect @options={{groupedNumbers}} @groupComponent="custom-group-component" @extra={{extra}} @onChange={{action (mut foo)}} as |country|>
+      <PowerSelect @options={{groupedNumbers}} @groupComponent={{component "custom-group-component"}} @extra={{extra}} @onChange={{action (mut foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);
@@ -388,7 +388,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelectMultiple @options={{countries}} @selected={{country}} @optionsComponent="list-of-countries" @onChange={{action (mut foo)}} @extra={{hash field="code"}} as |country|>
+      <PowerSelectMultiple @options={{countries}} @selected={{country}} @optionsComponent={{component "list-of-countries"}} @onChange={{action (mut foo)}} @extra={{hash field="code"}} as |country|>
         {{country.code}}
       </PowerSelectMultiple>
     `);
@@ -411,7 +411,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelectMultiple @options={{this.countries}} @selected={{this.country}} @triggerComponent="selected-country" @onChange={{action (mut foo)}} @extra={{hash coolFlagIcon=true}} as |country|>
+      <PowerSelectMultiple @options={{this.countries}} @selected={{this.country}} @triggerComponent={{component "selected-country"}} @onChange={{action (mut foo)}} @extra={{hash coolFlagIcon=true}} as |country|>
         {{country.code}}
       </PowerSelectMultiple>
     `);
@@ -437,7 +437,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
         <PowerSelectMultiple
             @options={{countries}}
             @selected={{country}}
-            @selectedItemComponent="selected-item-country"
+            @selectedItemComponent={{component "selected-item-country"}}
             @onChange={{action (mut selected)}}
             @extra={{hash coolFlagIcon=true}} as |country|>
           {{country.code}}


### PR DESCRIPTION
This replaces unsafe component usage with the embroider util that allows EBD to reach Optimized Embroider Safe support level as per https://github.com/embroider-build/embroider/blob/master/ADDON-AUTHOR-GUIDE.md

I also converted the documentation use because while the doc site will not need embroider with the static options enabled any time soon this does remove some deprecation warnings from the now unsafe string based api for passing components around.