### PR TITLE
🐞 Fix error when providing `@initiallyOpened={{true}}` and `@selected`

### DIFF
--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -29,6 +29,7 @@
       {{did-update this._updateOptions @options}}
       {{did-insert this._updateSelected @selected}}
       {{did-update this._updateSelected @selected}}
+      {{did-insert this._registerAPI publicAPI}}
       {{did-update this._registerAPI publicAPI}}
       {{did-update this._performSearch this.searchText}}
       {{on "keydown" this.handleTriggerKeydown}}

--- a/tests/integration/components/power-select/opened-property-test.js
+++ b/tests/integration/components/power-select/opened-property-test.js
@@ -19,4 +19,17 @@ module('Integration | Component | Ember Power Select (The opened property)', fun
 
     assert.dom('.ember-power-select-dropdown').exists('Dropdown is opened');
   });
+
+  test('[BUGFIX] the select can be rendered already opened by passing `@initiallyOpened={{true}}` AND `@selected`', async function(assert) {
+    assert.expect(1);
+
+    this.numbers = numbers;
+    await render(hbs`
+      <PowerSelect @options={{numbers}} @onChange={{action (mut foo)}} @initiallyOpened={{true}} @selected="seven" as |option|>
+        {{option}}
+      </PowerSelect>
+    `);
+
+    assert.dom('.ember-power-select-dropdown').exists('Dropdown is opened');
+  });
 });


### PR DESCRIPTION
#1288 Seems to have introduced a bug whereby providing `@initiallyOpened` AND `@selected` causes an error as described in #1426 .

This PR adds a failing test for the bug and also the bug fix.

Closes #1426 