### PR TITLE
Embroider: add scenarios to ember-try

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function() {
   return {
@@ -59,6 +60,8 @@ module.exports = async function() {
           devDependencies: {}
         }
       },
+      embroiderSafe(),
+      embroiderOptimized(),
     ]
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -27,5 +27,6 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree();
+  const { maybeEmbroider } = require('@embroider/test-setup');
+  return maybeEmbroider(app);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1953,6 +1953,16 @@
         }
       }
     },
+    "@embroider/test-setup": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-0.37.0.tgz",
+      "integrity": "sha512-4jme5zEonjGvKeyVRygyXmooMuwmaa3nBiIxwbkRA6KWh0BLyZSqPwlQl93s7IT7S5PO5U9TqNiqI4yp2k5T7Q==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.20",
+        "resolve": "^1.17.0"
+      }
+    },
     "@embroider/util": {
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/@embroider/util/-/util-0.36.0.tgz",

--- a/package.json
+++ b/package.json
@@ -62,10 +62,11 @@
   "devDependencies": {
     "@ember-decorators/component": "^6.1.0",
     "@ember/optional-features": "^2.0.0",
+    "@embroider/test-setup": "^0.37.0",
     "@types/ember": "^3.16.0",
-    "@types/ember__test-helpers": "^1.7.0",
     "@types/ember-data": "^3.16.1",
     "@types/ember-qunit": "^3.4.9",
+    "@types/ember__test-helpers": "^1.7.0",
     "@types/qunit": "^2.9.1",
     "@types/rsvp": "^4.0.3",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
As per the Embroider [Addon Author Guide](https://github.com/embroider-build/embroider/blob/master/ADDON-AUTHOR-GUIDE.md#addon-author-guide).

Can use this as a starting point to work on compatibility with `staticComponents ` which is a requirement of `splitAtRoutes`. 

## Current state

The `embroider-safe` scenario passes which is great.

Dummy app doesn't build under `embroider-optimized` due to unhandled dynamic component invocation.

```
Build Error (PackagerRunner) in templates/snippets/the-trigger-2.hbs

Module Error (from /Users/giles/code/cloned/ember-power-select/node_modules/thread-loader/dist/cjs.js):
Missing component: selected-item-country in templates/snippets/the-trigger-2.hbs
```