### PR TITLE
add back customizing ember basic dropdown trigger and content components

### DIFF
--- a/addon/components/power-select-multiple.hbs
+++ b/addon/components/power-select-multiple.hbs
@@ -54,7 +54,7 @@
   @verticalPosition={{@verticalPosition}}
   @tabindex={{this.computedTabIndex}}
   @ebdTriggerComponent={{@ebdTriggerComponent}}
-  @ebdTriggerComponent={{@ebdContentComponent}}
+  @ebdContentComponent={{@ebdContentComponent}}
   ...attributes as |option select|>
   {{yield option select}}
 </PowerSelect>

--- a/addon/components/power-select-multiple.hbs
+++ b/addon/components/power-select-multiple.hbs
@@ -53,6 +53,8 @@
   @triggerId={{@triggerId}}
   @verticalPosition={{@verticalPosition}}
   @tabindex={{this.computedTabIndex}}
+  @ebdTriggerComponent={{@ebdTriggerComponent}}
+  @ebdTriggerComponent={{@ebdContentComponent}}
   ...attributes as |option select|>
   {{yield option select}}
 </PowerSelect>

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -10,6 +10,8 @@
   @verticalPosition={{@verticalPosition}}
   @disabled={{@disabled}}
   @calculatePosition={{@calculatePosition}}
+  @triggerComponent={{@ebdTriggerComponent}}
+  @contentComponent={{@ebdContentComponent}}
   ...attributes as |dropdown|>
   {{#let (assign dropdown (hash
     selected=this.selected


### PR DESCRIPTION
Sometimes reaching the core is needed, this was previously supported not sure when it got deprecated or regressed, i think when jumping from 3.0.6 to 4.x.x

`ember-paper` depends on it:

https://github.com/miguelcobain/ember-paper/blob/1c23f2ef65ffd3f496aab1ac1cc1ed88b3a5729f/addon/components/paper-select/template.hbs#L18

Previously:

https://github.com/cibernox/ember-power-select/blob/672ad84e7a96c4fdc8f1aff42b4c77be669e8156/addon/templates/components/power-select.hbs#L14
