### PR TITLE
guard removing observer

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -135,7 +135,9 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
 
   willDestroy() {
     if (this._lastSelectedPromise && isPromiseProxyLike(this._lastSelectedPromise)) {
-      removeObserver(this._lastSelectedPromise, 'content', this, this._selectedObserverCallback);
+      try {
+        removeObserver(this._lastSelectedPromise, 'content', this, this._selectedObserverCallback);
+      } catch {}
       this._lastSelectedPromise = undefined;
     }
     super.willDestroy.apply(this, arguments);


### PR DESCRIPTION
It seems there's a chance that the observer doesn't exist on willDestroy, if the component starts destroying before the observer gets added in the .then here 

https://github.com/cibernox/ember-power-select/blob/c4d595617d7301c9c62021cd1945ed6b809facac/addon/components/power-select.ts#L352

Not sure how else this could be guarded, because we don't have the check  `Object.hasObserverFor('content')`, we could add a stateless flag though
