### PR TITLE
drop the skip of 'no-invalid-interactive' template-lint rule with fix offenses

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -5,7 +5,6 @@ module.exports = {
   extends: 'octane',
   rules: {
     'block-indentation': false,
-    'no-invalid-interactive': false,
     'attribute-indentation': false,
     'no-partial': false,
     'no-inline-styles': false,

--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -1,6 +1,7 @@
 <ul
   id="ember-power-select-multiple-options-{{@select.uniqueId}}"
   class="ember-power-select-multiple-options"
+  role="button"
   {{did-update this.openChanged @select.isOpen}}
   {{on "touchstart" this.chooseOption}}
   {{on "mousedown" this.chooseOption}}
@@ -8,7 +9,9 @@
   {{#each @select.selected as |opt idx|}}
     <li class="ember-power-select-multiple-option {{if opt.disabled "ember-power-select-multiple-option--disabled"}}">
       {{#unless @select.disabled}}
-        <span role="button"
+        <span
+          {{! template-lint-disable "no-nested-interactive" }}
+          role="button"
           aria-label="remove element"
           class="ember-power-select-multiple-remove-btn"
           data-selected-index={{idx}}>
@@ -28,6 +31,7 @@
   {{/each}}
   {{#if @searchEnabled}}
     <input
+      {{! template-lint-disable "no-nested-interactive" }}
       type="search"
       class="ember-power-select-trigger-multiple-input"
       autocomplete="off"

--- a/addon/components/power-select/trigger.hbs
+++ b/addon/components/power-select/trigger.hbs
@@ -5,7 +5,7 @@
     <span class="ember-power-select-selected-item">{{yield @select.selected @select}}</span>
   {{/if}}
   {{#if (and @allowClear (not @select.disabled))}}
-    <span class="ember-power-select-clear-btn" {{on "mousedown" this.clear}} {{on "touchstart" this.clear}}>&times;</span>
+    <span class="ember-power-select-clear-btn" role="button" {{on "mousedown" this.clear}} {{on "touchstart" this.clear}}>&times;</span>
   {{/if}}
 {{else}}
   {{component @placeholderComponent placeholder=@placeholder}}

--- a/tests/dummy/app/templates/snippets/navigable-select-3.hbs
+++ b/tests/dummy/app/templates/snippets/navigable-select-3.hbs
@@ -4,6 +4,7 @@
       aria-selected={{ember-power-select-is-selected opt @selected}}
       aria-disabled={{opt.disabled}}
       aria-current={{eq opt @highlighted}}
+      role="button"
       {{on "click" (fn @select opt @dropdown)}}
       {{on "mouseover" (fn @highlight opt)}}>
       {{yield opt}}


### PR DESCRIPTION
Related to https://github.com/cibernox/ember-power-select/commit/6a33c3dc7183fc937b7b1b8597c0dbdd645faba2