### PR TITLE
fix deprecate import for newer ember-cli

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/debug';
+import { deprecate } from 'ember-deprecations';
 import { registerAsyncHelper } from '@ember/test';
 import { click, fillIn, triggerKeyEvent, triggerEvent } from '@ember/test-helpers';
 import {


### PR DESCRIPTION
I get an error running ember-power-select under ember-cli 3.27.0.
```js
Build Error (broccoli-persistent-filter:Babel > [Babel: ember-power-select]) in ember-power-select/test-support/helpers.js                                                                
                                                                                                                                                                                          
/home/tony/src/datafruits/ember-power-select/test-support/helpers.js: @ember/debug does not have a deprecate export                                                                       
> 1 | import { deprecate } from '@ember/debug';                                              
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                           
  2 | import { registerAsyncHelper } from '@ember/test';                                                                                                                                  
  3 | import { click, fillIn, triggerKeyEvent, triggerEvent } from '@ember/test-helpers';                                                                                                 
  4 | import {                                                                               
```                        