### PR TITLE
Add full embroider compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           - ember-beta
           # - ember-canary
           - node-tests
-          - embroider
+          - embroider-safe
           # - ember-classic
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           - ember-beta
           # - ember-canary
           - node-tests
-          # - embroider
+          - embroider
           # - ember-classic
     steps:
       - uses: actions/checkout@v2

--- a/addon/components/power-select-multiple.hbs
+++ b/addon/components/power-select-multiple.hbs
@@ -5,9 +5,9 @@
   @ariaInvalid={{@ariaInvalid}}
   @ariaLabel={{@ariaLabel}}
   @ariaLabelledBy={{@ariaLabelledBy}}
-  @afterOptionsComponent={{@afterOptionsComponent}}
+  @afterOptionsComponent={{ensure-safe-component @afterOptionsComponent}}
   @allowClear={{@allowClear}}
-  @beforeOptionsComponent={{or @beforeOptionsComponent null}}
+  @beforeOptionsComponent={{if @beforeOptionsComponent (ensure-safe-component @beforeOptionsComponent) null}}
   @buildSelection={{or @buildSelection this.defaultBuildSelection}}
   @calculatePosition={{@calculatePosition}}
   @closeOnSelect={{@closeOnSelect}}
@@ -16,14 +16,14 @@
   @disabled={{@disabled}}
   @dropdownClass={{@dropdownClass}}
   @extra={{@extra}}
-  @groupComponent={{@groupComponent}}
+  @groupComponent={{ensure-safe-component @groupComponent}}
   @horizontalPosition={{@horizontalPosition}}
   @initiallyOpened={{@initiallyOpened}}
   @loadingMessage={{@loadingMessage}}
   @matcher={{@matcher}}
   @matchTriggerWidth={{@matchTriggerWidth}}
   @noMatchesMessage={{@noMatchesMessage}}
-  @noMatchesMessageComponent={{@noMatchesMessageComponent}}
+  @noMatchesMessageComponent={{ensure-safe-component @noMatchesMessageComponent}}
   @onBlur={{@onBlur}}
   @onChange={{@onChange}}
   @onClose={{@onClose}}
@@ -32,9 +32,9 @@
   @onKeydown={{this.handleKeydown}}
   @onOpen={{this.handleOpen}}
   @options={{@options}}
-  @optionsComponent={{@optionsComponent}}
+  @optionsComponent={{ensure-safe-component @optionsComponent}}
   @placeholder={{@placeholder}}
-  @placeholderComponent={{@placeholderComponent}}
+  @placeholderComponent={{ensure-safe-component @placeholderComponent}}
   @preventScroll={{@preventScroll}}
   @registerAPI={{@registerAPI}}
   @renderInPlace={{@renderInPlace}}
@@ -46,16 +46,21 @@
   @searchMessage={{@searchMessage}}
   @searchPlaceholder={{@searchPlaceholder}}
   @selected={{@selected}}
-  @selectedItemComponent={{@selectedItemComponent}}
+  @selectedItemComponent={{ensure-safe-component @selectedItemComponent}}
   @eventType={{@eventType}}
   @title={{@title}}
   @triggerClass="ember-power-select-multiple-trigger {{@triggerClass}}"
-  @triggerComponent={{component (or @triggerComponent "power-select-multiple/trigger") tabindex=@tabindex}}
+  @triggerComponent={{
+    if
+    @triggerComponent
+    (component (ensure-safe-component @triggerComponent) tabindex=@tabindex)
+    (component "power-select-multiple/trigger" tabindex=@tabindex)
+  }}
   @triggerId={{@triggerId}}
   @verticalPosition={{@verticalPosition}}
   @tabindex={{this.computedTabIndex}}
-  @ebdTriggerComponent={{@ebdTriggerComponent}}
-  @ebdContentComponent={{@ebdContentComponent}}
+  @ebdTriggerComponent={{ensure-safe-component @ebdTriggerComponent}}
+  @ebdContentComponent={{ensure-safe-component @ebdContentComponent}}
   ...attributes as |option select|>
   {{yield option select}}
 </PowerSelect>

--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -19,7 +19,7 @@
         </span>
       {{/if}}
       {{#if @selectedItemComponent}}
-        {{component @selectedItemComponent extra=@extra option=opt select=@select}}
+        {{component (ensure-safe-component @selectedItemComponent) extra=@extra option=opt select=@select}}
       {{else}}
         {{yield opt @select}}
       {{/if}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -10,8 +10,8 @@
   @verticalPosition={{@verticalPosition}}
   @disabled={{@disabled}}
   @calculatePosition={{@calculatePosition}}
-  @triggerComponent={{@ebdTriggerComponent}}
-  @contentComponent={{@ebdContentComponent}}
+  @triggerComponent={{ensure-safe-component @ebdTriggerComponent}}
+  @contentComponent={{ensure-safe-component @ebdContentComponent}}
   as |dropdown|>
   {{#let (assign dropdown (hash
     selected=this.selected
@@ -52,13 +52,19 @@
       id={{@triggerId}}
       tabindex={{and (not @disabled) (or @tabindex "0")}}
       ...attributes
-      >
-      {{#let (component (or @triggerComponent "power-select/trigger")) as |Trigger|}}
+    >
+      {{#let 
+        (if 
+          @triggerComponent 
+          (component (ensure-safe-component @triggerComponent)) 
+          (component 'power-select/trigger')
+        ) 
+      as |Trigger|}}
         <Trigger
           @allowClear={{@allowClear}}
           @buildSelection={{@buildSelection}}
           @loadingMessage={{or @loadingMessage "Loading options..."}}
-          @selectedItemComponent={{@selectedItemComponent}}
+          @selectedItemComponent={{ensure-safe-component @selectedItemComponent}}
           @select={{publicAPI}}
           @searchEnabled={{@searchEnabled}}
           @searchField={{@searchField}}
@@ -69,7 +75,11 @@
           @onInput={{this.handleInput}}
           @onKeydown={{this.handleKeydown}}
           @placeholder={{@placeholder}}
-          @placeholderComponent={{this.placeholderComponent}}
+          @placeholderComponent={{if 
+            @placeholderComponent 
+            (ensure-safe-component @placeholderComponent) 
+            (component 'power-select/placeholder')
+          }}
           @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
           as |opt term|>
           {{yield opt term}}
@@ -77,33 +87,64 @@
       {{/let}}
     </dropdown.Trigger>
     <dropdown.Content class="ember-power-select-dropdown{{if publicAPI.isActive " ember-power-select-dropdown--active"}} {{@dropdownClass}}">
-      {{#let (component (if (eq @beforeOptionsComponent undefined) "power-select/before-options" @beforeOptionsComponent)) as |BeforeOptions|}}
-        <BeforeOptions
-          @select={{publicAPI}}
-          @searchEnabled={{@searchEnabled}}
-          @onInput={{this.handleInput}}
-          @onKeydown={{this.handleKeydown}}
-          @onFocus={{this.handleFocus}}
-          @onBlur={{this.handleBlur}}
-          @placeholder={{@placeholder}}
-          @placeholderComponent={{this.placeholderComponent}}
-          @extra={{@extra}}
-          @listboxId={{listboxId}}
-          @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
-          @selectedItemComponent={{@selectedItemComponent}}
-          @searchPlaceholder={{@searchPlaceholder}}
+      {{#if (not-eq @beforeOptionsComponent null)}}
+        {{#let 
+          (if 
+            @beforeOptionsComponent 
+            (component (ensure-safe-component @beforeOptionsComponent))
+            (component 'power-select/before-options')
+          ) 
+        as |BeforeOptions|}}
+          <BeforeOptions
+            @select={{publicAPI}}
+            @searchEnabled={{@searchEnabled}}
+            @onInput={{this.handleInput}}
+            @onKeydown={{this.handleKeydown}}
+            @onFocus={{this.handleFocus}}
+            @onBlur={{this.handleBlur}}
+            @placeholder={{@placeholder}}
+            @placeholderComponent={{or @placeholderComponent (component 'power-select/placeholder')}}
+            @extra={{@extra}}
+            @listboxId={{listboxId}}
+            @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
+            @selectedItemComponent={{ensure-safe-component @selectedItemComponent}}
+            @searchPlaceholder={{@searchPlaceholder}}
           />
-      {{/let}}
+        {{/let}}
+      {{/if}}
       {{#if this.mustShowSearchMessage}}
-        {{#let (component (or @searchMessageComponent "power-select/search-message")) as |SearchMessage|}}
+        {{#let 
+          (if 
+            @searchMessageComponent 
+            (component (ensure-safe-component @searchMessageComponent))
+            (component 'power-select/search-message')
+          ) 
+        as |SearchMessage|}}
           <SearchMessage @searchMessage={{this.searchMessage}} @select={{publicAPI}}/>
         {{/let}}
       {{else if this.mustShowNoMessages}}
-        {{#let (component (or @noMatchesMessageComponent "power-select/no-matches-message")) as |NoMatchesMessage|}}
+        {{#let 
+          (if 
+            @noMatchesMessageComponent
+            (component (ensure-safe-component @noMatchesMessageComponent))
+            (component 'power-select/no-matches-message')
+          ) 
+         as |NoMatchesMessage|}}
           <NoMatchesMessage @noMatchesMessage={{this.noMatchesMessage}} @select={{publicAPI}} />
         {{/let}}
       {{else}}
-        {{#let (component (or @optionsComponent "power-select/options")) as |Options|}}
+        {{#let 
+          (if 
+            @optionsComponent
+            (component (ensure-safe-component @optionsComponent))
+            (component 'power-select/options')
+          ) 
+          (if 
+            @groupComponent
+            (component (ensure-safe-component @groupComponent))
+            (component 'power-select/power-select-group')
+          ) 
+        as |Options Group|}}
           <Options
             @loadingMessage={{or @loadingMessage "Loading options..."}}
             @select={{publicAPI}}
@@ -112,19 +153,22 @@
             @optionsComponent={{Options}}
             @extra={{@extra}}
             @highlightOnHover={{this.highlightOnHover}}
-            @groupComponent={{or @groupComponent "power-select/power-select-group"}}
+            @groupComponent={{Group}}
             id={{listboxId}}
             class="ember-power-select-options" as |option select|>
             {{yield option select}}
           </Options>
         {{/let}}
       {{/if}}
-      {{#let (component @afterOptionsComponent) as |AfterOptions|}}
-        <AfterOptions
-          @extra={{@extra}}
-          @select={{publicAPI}}
-        />
-      {{/let}}
+      
+      {{#if @afterOptionsComponent}}
+        {{#let (component (ensure-safe-component @afterOptionsComponent)) as |AfterOptions|}}
+          <AfterOptions
+            @extra={{@extra}}
+            @select={{publicAPI}}
+          />
+        {{/let}}
+      {{/if}}
     </dropdown.Content>
   {{/let}}
 </BasicDropdown>

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -59,7 +59,9 @@ export interface PowerSelectArgs {
   highlightOnHover?: boolean
   placeholderComponent?: string
   searchMessage?: string
+  searchMessageComponent?: string;
   noMatchesMessage?: string
+  noMatchesMessageComponent?: string;
   matchTriggerWidth?: boolean
   options: any[] | PromiseProxy<any[]>
   selected: any | PromiseProxy<any>
@@ -69,6 +71,9 @@ export interface PowerSelectArgs {
   searchEnabled?: boolean
   tabindex?: number | string
   triggerComponent?: string
+  beforeOptionsComponent?: string
+  optionsComponent?: string;
+  groupComponent?: string;
   matcher?: MatcherFn
   initiallyOpened?: boolean
   typeAheadOptionMatcher?: MatcherFn
@@ -153,10 +158,6 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     let results = this.results;
     let highlighted = this.highlighted;
     return pathForOption(results, highlighted);
-  }
-
-  get placeholderComponent(): string {
-    return this.args.placeholderComponent || 'power-select/placeholder';
   }
 
   get searchMessage(): string {

--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -5,7 +5,10 @@
       <li class="ember-power-select-option ember-power-select-option--loading-message" role="option">{{@loadingMessage}}</li>
     {{/if}}
   {{/if}}
-  {{#let (component @groupComponent) (component @optionsComponent) as |Group Options|}}
+  {{#let 
+    (component (ensure-safe-component @groupComponent)) 
+    (component (ensure-safe-component @optionsComponent)) 
+  as |Group Options|}}
     {{#each @options as |opt index|}}
       {{#if (ember-power-select-is-group opt)}}
         <Group @group={{opt}} @select={{@select}} @extra={{@extra}}>

--- a/addon/components/power-select/trigger.hbs
+++ b/addon/components/power-select/trigger.hbs
@@ -1,6 +1,6 @@
 {{#if @select.selected}}
   {{#if @selectedItemComponent}}
-    {{component @selectedItemComponent extra=(readonly @extra) option=(readonly @select.selected) select=(readonly @select)}}
+    {{component (ensure-safe-component @selectedItemComponent) extra=(readonly @extra) option=(readonly @select.selected) select=(readonly @select)}}
   {{else}}
     <span class="ember-power-select-selected-item">{{yield @select.selected @select}}</span>
   {{/if}}
@@ -8,6 +8,6 @@
     <span class="ember-power-select-clear-btn" role="button" {{on "mousedown" this.clear}} {{on "touchstart" this.clear}}>&times;</span>
   {{/if}}
 {{else}}
-  {{component @placeholderComponent placeholder=@placeholder}}
+  {{component (ensure-safe-component @placeholderComponent) placeholder=@placeholder}}
 {{/if}}
 <span class="ember-power-select-status-icon"></span>

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe } = require('@embroider/test-setup');
 
 module.exports = async function() {
   return {
@@ -59,6 +60,7 @@ module.exports = async function() {
           devDependencies: {}
         }
       },
+      embroiderSafe()
     ]
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@ember-decorators/component": "^6.1.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.5.0",
+        "@embroider/test-setup": "^0.47.2",
         "@types/ember": "^3.16.0",
         "@types/ember__test-helpers": "^2.0.0",
         "@types/ember-data": "^3.16.1",
@@ -3206,6 +3207,19 @@
       "dependencies": {
         "path-root": "^0.1.1",
         "resolve": "^1.10.0"
+      }
+    },
+    "node_modules/@embroider/test-setup": {
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-0.47.2.tgz",
+      "integrity": "sha512-zTiNaicOeBJWQ+uAJOEg4Z4plmvF2Ckze+tMZ0sycp2o09UV72WC8s9L3pssWOGgHMV6Kl+eCfFQelWwUOqz1Q==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/@embroider/util": {
@@ -32378,6 +32392,16 @@
             "resolve": "^1.10.0"
           }
         }
+      }
+    },
+    "@embroider/test-setup": {
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-0.47.2.tgz",
+      "integrity": "sha512-zTiNaicOeBJWQ+uAJOEg4Z4plmvF2Ckze+tMZ0sycp2o09UV72WC8s9L3pssWOGgHMV6Kl+eCfFQelWwUOqz1Q==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
       }
     },
     "@embroider/util": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
+        "@embroider/util": "^0.47.2",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
         "ember-assign-helper": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@ember-decorators/component": "^6.1.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.5.0",
+    "@embroider/test-setup": "^0.47.2",
     "@types/ember": "^3.16.0",
     "@types/ember__test-helpers": "^2.0.0",
     "@types/ember-data": "^3.16.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "vendor"
   ],
   "dependencies": {
+    "@embroider/util": "^0.47.2",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "ember-assign-helper": "^0.4.0",

--- a/tests/dummy/app/templates/components/navigable-select.hbs.bak
+++ b/tests/dummy/app/templates/components/navigable-select.hbs.bak
@@ -1,4 +1,11 @@
-<PowerSelect @options={{this.currentOptions}} @selected={{this.selected}} @closeOnSelect={{false}} @onChange={{this.onchange}} @optionsComponent="animated-options" @search={{this.search}} as |levelOrOption|>
+<PowerSelect
+  @options={{this.currentOptions}}
+  @selected={{this.selected}}
+  @closeOnSelect={{false}}
+  @onChange={{this.onchange}}
+  @optionsComponent={{component "animated-options"}}
+  @search={{this.search}} as |levelOrOption|
+>
   {{#if levelOrOption.parentLevel}}
     <strong>&lt; Back</strong>
   {{else if levelOrOption.levelName}}

--- a/tests/dummy/app/templates/components/selected-item-country.hbs
+++ b/tests/dummy/app/templates/components/selected-item-country.hbs
@@ -1,0 +1,8 @@
+ <div class="country-detailed-info">
+    <img src={{@option.flagUrl}} class="country-flag" alt="Flag of {{@option.name}}">
+    <div class="country-data-text">
+      <strong>{{@option.name}}</strong>
+      <br>
+      <small>Population in 2014: <i>{{@option.population}}</i></small>
+    </div>
+  </div>

--- a/tests/dummy/app/templates/helpers-testing.hbs
+++ b/tests/dummy/app/templates/helpers-testing.hbs
@@ -57,7 +57,7 @@
     @onChange={{fn (mut this.selected3)}}
     @search={{this.searchAsync}}
     @beforeOptionsComponent={{null}}
-    @triggerComponent="custom-trigger-with-search" as |num|>
+    @triggerComponent={{component "custom-trigger-with-search"}} as |num|>
     {{num}}
   </PowerSelect>
 </div>

--- a/tests/dummy/app/templates/public-pages.hbs
+++ b/tests/dummy/app/templates/public-pages.hbs
@@ -15,7 +15,7 @@
           @options={{this.mainSelectOptions}}
           @selected={{this.mainSelected}}
           @disabled={{this.disabled}}
-          @triggerComponent="main-header-select-trigger"
+          @triggerComponent={{component "main-header-select-trigger"}}
           @onChange={{this.changeOptions}}
           @dropdownClass="main-header-select-dropdown" as |opt|>
           {{opt}}

--- a/tests/dummy/app/templates/public-pages/docs/the-trigger.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/the-trigger.hbs
@@ -27,7 +27,7 @@
 
 <p>
   Since we have run out of block to pass the the component we need to use other components if we want to
-  go any further. Pass <code>selectedItemComponent="component-name"</code> to the component.
+  go any further. Pass <code>selectedItemComponent=\{\{component "component-name"\}\}</code> to the component.
 </p>
 
 <p>

--- a/tests/dummy/app/templates/snippets/navigable-select-2.hbs.bak
+++ b/tests/dummy/app/templates/snippets/navigable-select-2.hbs.bak
@@ -4,7 +4,7 @@
   @selected={{this.selected}}
   @closeOnSelect={{false}}
   @onChange={{this.onChange}}
-  @optionsComponent="animated-options"
+  @optionsComponent={{component "animated-options"}}
   @search={{this.search}} as |levelOrOption|>
   {{#if levelOrOption.parentLevel}}
     <strong>Back</strong>

--- a/tests/dummy/app/templates/snippets/the-trigger-2.hbs
+++ b/tests/dummy/app/templates/snippets/the-trigger-2.hbs
@@ -2,7 +2,7 @@
   @searchEnabled={{true}}
   @options={{this.countries}}
   @selected={{this.country}}
-  @selectedItemComponent="selected-item-country"
+  @selectedItemComponent={{component "selected-item-country"}}
   @searchField="name"
   @onChange={{fn (mut this.country)}}
   as |country|>

--- a/tests/dummy/app/templates/snippets/the-trigger-4.hbs
+++ b/tests/dummy/app/templates/snippets/the-trigger-4.hbs
@@ -1,7 +1,7 @@
 <PowerSelect
   @options={{this.names}}
   @selected={{this.aName}}
-  @placeholderComponent="weird-placeholder"
+  @placeholderComponent={{component "weird-placeholder"}}
   @onChange={{fn (mut this.aName)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/tests/integration/components/power-select/customization-with-components-test.js
+++ b/tests/integration/components/power-select/customization-with-components-test.js
@@ -11,12 +11,16 @@ import { isPresent } from '@ember/utils';
 module('Integration | Component | Ember Power Select (Customization using components)', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('selected option can be customized using triggerComponent', async function(assert) {
+  test('selected option can be customized using triggerComponent as string', async function(assert) {
     assert.expect(3);
 
     this.owner.register('component:selected-country', class extends Component {
       layout = hbs`
-        <img src={{@select.selected.flagUrl}} class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" alt="Flag of {{@select.selected.name}}">
+        <img 
+          src={{@select.selected.flagUrl}} 
+          class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" 
+          alt="Flag of {{@select.selected.name}}"
+        >
         {{@select.selected.name}}
       `
     });
@@ -25,7 +29,42 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelect @options={{this.countries}} @selected={{this.country}} @triggerComponent="selected-country" @onChange={{action (mut this.foo)}} as |country|>
+      <PowerSelect 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @triggerComponent="selected-country"
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    assert.dom('.ember-power-select-status-icon').doesNotExist('The provided trigger component is not rendered');
+    assert.dom('.ember-power-select-trigger .icon-flag').exists('The custom flag appears.');
+    assert.dom('.ember-power-select-trigger').hasText('Spain', 'With the country name as the text.');
+  });
+
+  test('selected option can be customized using triggerComponent', async function(assert) {
+    assert.expect(3);
+
+    this.owner.register('component:selected-country', class extends Component {
+      layout = hbs`
+        <img 
+          src={{@select.selected.flagUrl}} 
+          class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" 
+          alt="Flag of {{@select.selected.name}}">
+        {{@select.selected.name}}
+      `
+    });
+
+    this.countries = countries;
+    this.country = countries[1]; // Spain
+
+    await render(hbs`
+      <PowerSelect 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @triggerComponent={{component "selected-country"}} 
+        @onChange={{action (mut this.foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);
@@ -46,19 +85,23 @@ module('Integration | Component | Ember Power Select (Customization using compon
         @options={{this.countries}}
         @loadingMessage="hmmmm paella"
         @selected={{this.country}}
-        @triggerComponent="custom-trigger-component"
+        @triggerComponent={{component "custom-trigger-component"}}
         @onChange={{action (mut this.foo)}} as |country|>
-        {{option}}
+        {{country}}
       </PowerSelect>
     `);
     assert.dom('.custom-trigger-component').hasText('hmmmm paella', 'The loading message is passed to the trigger component');
   });
 
-  test('selected item option can be customized using `@selectedItemComponent`', async function(assert) {
+  test('selected item option can be customized using `@selectedItemComponent` as string', async function(assert) {
     assert.expect(3);
-    this.owner.register('component:selected-item-country', Component.extend({
+    this.owner.register('component:selected-country', Component.extend({
       layout: hbs`
-        <img src={{@select.selected.flagUrl}} class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" alt="Flag of {{@select.selected.name}}">
+        <img 
+          src={{@select.selected.flagUrl}} 
+          class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" 
+          alt="Flag of {{@select.selected.name}}"
+        >
         {{@select.selected.name}}
       `
     }));
@@ -66,7 +109,11 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelect @options={{this.countries}} @selected={{this.country}} @selectedItemComponent="selected-item-country" @onChange={{action (mut this.foo)}} as |country|>
+      <PowerSelect 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @selectedItemComponent="selected-country" 
+        @onChange={{action (mut this.foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);
@@ -74,6 +121,72 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.dom('.ember-power-select-status-icon').exists('The provided trigger component is rendered');
     assert.dom('.ember-power-select-trigger .icon-flag').exists('The custom flag appears.');
     assert.dom('.ember-power-select-trigger').hasText('Spain', 'With the country name as the text.');
+  });
+
+  test('selected item option can be customized using `@selectedItemComponent`', async function(assert) {
+    assert.expect(3);
+    this.owner.register('component:selected-country', Component.extend({
+      layout: hbs`
+        <img 
+          src={{@select.selected.flagUrl}} 
+          class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" 
+          alt="Flag of {{@select.selected.name}}"
+        >
+        {{@select.selected.name}}
+      `
+    }));
+    this.countries = countries;
+    this.country = countries[1]; // Spain
+
+    await render(hbs`
+      <PowerSelect 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @selectedItemComponent={{component "selected-country"}} 
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    assert.dom('.ember-power-select-status-icon').exists('The provided trigger component is rendered');
+    assert.dom('.ember-power-select-trigger .icon-flag').exists('The custom flag appears.');
+    assert.dom('.ember-power-select-trigger').hasText('Spain', 'With the country name as the text.');
+  });
+
+  test('the list of options can be customized using `@optionsComponent` as string', async function(assert) {
+    assert.expect(2);
+    this.owner.register('component:list-of-countries', Component.extend({
+      layout: hbs`
+        <p>Countries:</p>
+        <ul>
+          {{#if @extra.field}}
+            {{#each @options as |option index|}}
+              <li>{{index}}. {{get option @extra.field}}</li>
+            {{/each}}
+          {{else}}
+            {{#each @options as |option index|}}
+              <li>{{index}}. {{option.name}}</li>
+            {{/each}}
+          {{/if}}
+        </ul>
+      `
+    }));
+    this.countries = countries;
+    this.country = countries[1]; // Spain
+
+    await render(hbs`
+      <PowerSelect 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @optionsComponent="list-of-countries" 
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+    assert.dom('.ember-power-select-options').includesText('Countries:', 'The given component is rendered');
+    assert.dom('.ember-power-select-options').includesText('3. Russia', 'The component has access to the options');
   });
 
   test('the list of options can be customized using `@optionsComponent`', async function(assert) {
@@ -98,7 +211,11 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelect @options={{this.countries}} @selected={{this.country}} @optionsComponent="list-of-countries" @onChange={{action (mut this.foo)}} as |country|>
+      <PowerSelect 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @optionsComponent={{component "list-of-countries"}} 
+        @onChange={{action (mut this.foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);
@@ -130,7 +247,12 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelect @options={{this.countries}} @selected={{this.country}} @optionsComponent="list-of-countries" @onChange={{action (mut this.foo)}} @extra={{hash field="code"}} as |country|>
+      <PowerSelect 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @optionsComponent={{component "list-of-countries"}} 
+        @onChange={{action (mut this.foo)}} 
+        @extra={{hash field="code"}} as |country|>
         {{country.code}}
       </PowerSelect>
     `);
@@ -140,12 +262,12 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.dom('.ember-power-select-options').includesText('3. RU', 'The component uses the field in the extra has to render the options');
   });
 
-  test('the content before the list can be customized passing `@beforeOptionsComponent`', async function(assert) {
+  test('the content before the list can be customized passing `@beforeOptionsComponent` as string', async function(assert) {
     assert.expect(4);
     this.owner.register('component:custom-before-options', Component.extend({
       layout: hbs`
         <p id="custom-before-options-p-tag">{{@placeholder}}</p>
-        {{component @placeholderComponent placeholder=@placeholder}}
+        {{component (ensure-safe-component @placeholderComponent) placeholder=@placeholder}}
       `
     }));
     this.countries = countries;
@@ -156,6 +278,35 @@ module('Integration | Component | Ember Power Select (Customization using compon
         @options={{this.countries}}
         @selected={{this.country}}
         @beforeOptionsComponent="custom-before-options"
+        @placeholder="inception"
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+    assert.dom('.ember-power-select-dropdown #custom-before-options-p-tag').exists('The custom component is rendered instead of the usual search bar');
+    assert.dom('.ember-power-select-dropdown #custom-before-options-p-tag').hasText('inception', 'The placeholder attribute is passed through.');
+    assert.dom('.ember-power-select-dropdown .ember-power-select-placeholder').exists('The placeholder component is passed through.');
+    assert.dom('.ember-power-select-search-input').doesNotExist('The search input is not visible');
+  });
+
+  test('the content before the list can be customized passing `@beforeOptionsComponent`', async function(assert) {
+    assert.expect(4);
+    this.owner.register('component:custom-before-options', Component.extend({
+      layout: hbs`
+        <p id="custom-before-options-p-tag">{{@placeholder}}</p>
+        {{component (ensure-safe-component @placeholderComponent) placeholder=@placeholder}}
+      `
+    }));
+    this.countries = countries;
+    this.country = countries[1]; // Spain
+
+    await render(hbs`
+      <PowerSelect
+        @selected={{this.country}}
+        @beforeOptionsComponent={{component "custom-before-options"}}
+        @options={{this.countries}}
         @placeholder="inception"
         @placeholderComponent={{component "power-select/placeholder"}}
         @onChange={{action (mut this.foo)}} as |country|>
@@ -170,7 +321,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.dom('.ember-power-select-search-input').doesNotExist('The search input is not visible');
   });
 
-  test('the content after the list can be customized passing `@afterOptionsComponent`', async function(assert) {
+  test('the content after the list can be customized passing `@afterOptionsComponent` as string', async function(assert) {
     assert.expect(2);
     this.owner.register('component:custom-after-options', Component.extend({
       layout: hbs`<p id="custom-after-options-p-tag">Customized after options!</p>`
@@ -194,13 +345,37 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.dom('.ember-power-select-search-input').exists('The search input is still visible');
   });
 
+  test('the content after the list can be customized passing `@afterOptionsComponent`', async function(assert) {
+    assert.expect(2);
+    this.owner.register('component:custom-after-options', Component.extend({
+      layout: hbs`<p id="custom-after-options-p-tag">Customized after options!</p>`
+    }));
+    this.countries = countries;
+    this.country = countries[1]; // Spain
+
+    await render(hbs`
+      <PowerSelect
+        @options={{this.countries}}
+        @selected={{this.country}}
+        @afterOptionsComponent={{component "custom-after-options"}}
+        @onChange={{action (mut this.foo)}}
+        @searchEnabled={{true}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+    assert.dom('.ember-power-select-dropdown #custom-after-options-p-tag').exists('The custom component is rendered instead of the usual search bar');
+    assert.dom('.ember-power-select-search-input').exists('The search input is still visible');
+  });
+
   test('the `@beforeOptionsComponent` and `@afterOptionsComponent` receive the `@extra` hash', async function(assert) {
     assert.expect(1);
-    this.owner.register('component:custom-before-options2', Component.extend({
-      layout: hbs`<button class="custom-before-options2-button" onclick={{@extra.passedAction}}>Do something</button>`
+    this.owner.register('component:custom-before-options', Component.extend({
+      layout: hbs`<button class="custom-before-options2-button" type="button" onclick={{@extra.passedAction}}>Do something</button>`
     }));
-    this.owner.register('component:custom-after-options2', Component.extend({
-      layout: hbs`<button class="custom-after-options2-button" onclick={{@extra.passedAction}}>Do something</button>`
+    this.owner.register('component:custom-after-options', Component.extend({
+      layout: hbs`<button class="custom-after-options2-button" type="button" onclick={{@extra.passedAction}}>Do something</button>`
     }));
     let counter = 0;
     this.countries = countries;
@@ -214,8 +389,8 @@ module('Integration | Component | Ember Power Select (Customization using compon
         @options={{this.countries}}
         @selected={{this.country}}
         @onChange={{action (mut this.selected)}}
-        @afterOptionsComponent="custom-after-options2"
-        @beforeOptionsComponent="custom-before-options2"
+        @afterOptionsComponent={{component "custom-after-options"}}
+        @beforeOptionsComponent={{component "custom-before-options"}}
         @extra={{hash passedAction=(action this.someAction)}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -250,7 +425,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
         @options={{this.countries}}
         @selected={{this.country}}
         @onChange={{action (mut this.selected)}}
-        @triggerComponent="custom-trigger-that-handles-focus"
+        @triggerComponent={{component "custom-trigger-that-handles-focus"}}
         @onFocus={{this.didFocusInside}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -259,7 +434,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
     await focus('#focusable-input');
   });
 
-  test('the search message can be customized passing `@searchMessageComponent`', async function(assert) {
+  test('the search message can be customized passing `@searchMessageComponent` as string', async function(assert) {
     assert.expect(1);
     this.owner.register('component:custom-search-message', Component.extend({
       layout: hbs`<p id="custom-search-message-p-tag">Customized seach message!</p>`
@@ -275,7 +450,26 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.dom('.ember-power-select-dropdown #custom-search-message-p-tag').exists('The custom component is rendered instead of the usual message');
   });
 
-  test('the no matches element can be customized passing `@noMatchesMessageComponent`', async function(assert) {
+  test('the search message can be customized passing `@searchMessageComponent`', async function(assert) {
+    assert.expect(1);
+    this.owner.register('component:custom-search-message', Component.extend({
+      layout: hbs`<p id="custom-search-message-p-tag">Customized seach message!</p>`
+    }));
+    this.searchFn = function() {};
+    await render(hbs`
+      <PowerSelect 
+        @search={{this.searchFn}} 
+        @searchMessageComponent={{component "custom-search-message"}} 
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+    assert.dom('.ember-power-select-dropdown #custom-search-message-p-tag').exists('The custom component is rendered instead of the usual message');
+  });
+
+  test('the no matches element can be customized passing `@noMatchesMessageComponent` as string', async function(assert) {
     assert.expect(2);
 
     this.owner.register('component:custom-no-matches-message', Component.extend({
@@ -296,7 +490,32 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.dom('#custom-no-matches-message-p-tag').hasText('Nope');
   });
 
-  test('placeholder can be customized using `@placeholderComponent`', async function(assert) {
+  test('the no matches element can be customized passing `@noMatchesMessageComponent`', async function(assert) {
+    assert.expect(2);
+
+    this.owner.register('component:custom-no-matches-message', Component.extend({
+      layout: hbs`<p id="custom-no-matches-message-p-tag">{{@noMatchesMessage}}</p>`
+    }));
+
+    this.options = [];
+
+    await render(hbs`
+      <PowerSelect 
+        @options={{this.options}} 
+        @noMatchesMessageComponent={{component "custom-no-matches-message"}} 
+        @noMatchesMessage="Nope" 
+        @onChange={{action (mut this.foo)}} as |option|>
+        {{option}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+
+    assert.dom('.ember-power-select-dropdown #custom-no-matches-message-p-tag').exists('The custom component is rendered instead of the usual message');
+    assert.dom('#custom-no-matches-message-p-tag').hasText('Nope');
+  });
+
+  test('placeholder can be customized using `@placeholderComponent` as string', async function(assert) {
     assert.expect(2);
     this.owner.register('component:custom-placeholder', Component.extend({
       layout: hbs`
@@ -321,7 +540,32 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.dom('.ember-power-select-placeholder').hasText('This is a very bold placeholder', 'The placeholder content is equal.');
   });
 
-  test('`@groupComponent` can be overridden', async function(assert) {
+  test('placeholder can be customized using `@placeholderComponent`', async function(assert) {
+    assert.expect(2);
+    this.owner.register('component:custom-placeholder', Component.extend({
+      layout: hbs`
+        <div class="ember-power-select-placeholder">
+          This is a very <span style="font-weight:bold">bold</span> placeholder
+        </div>
+      `
+    }));
+    this.countries = countries;
+
+    await render(hbs`
+      <PowerSelect
+        @options={{this.countries}}
+        @placeholder="test"
+        @placeholderComponent={{component "custom-placeholder"}}
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    assert.dom('.ember-power-select-placeholder').exists('The placeholder appears.');
+    assert.dom('.ember-power-select-placeholder').hasText('This is a very bold placeholder', 'The placeholder content is equal.');
+  });
+
+  test('`@groupComponent` can be overridden as string', async function(assert) {
     this.groupedNumbers = groupedNumbers;
     let numberOfGroups = 5; // number of groups in groupedNumber;
 
@@ -338,6 +582,28 @@ module('Integration | Component | Ember Power Select (Customization using compon
     await clickTrigger();
     assert.dom('.ember-power-select-options .custom-component').exists({ count: numberOfGroups });
   });
+
+  test('`@groupComponent` can be overridden', async function(assert) {
+    this.groupedNumbers = groupedNumbers;
+    let numberOfGroups = 5; // number of groups in groupedNumber;
+
+    this.owner.register('component:custom-group-component', Component.extend({
+      layout: hbs`<div class="custom-component">{{yield}}</div>`
+    }));
+
+    await render(hbs`
+      <PowerSelect 
+        @options={{this.groupedNumbers}} 
+        @groupComponent={{component "custom-group-component"}} 
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+    assert.dom('.ember-power-select-options .custom-component').exists({ count: numberOfGroups });
+  });
+
 
   test('`@groupComponent` has extension points', async function(assert) {
     this.groupedNumbers = groupedNumbers;
@@ -358,7 +624,11 @@ module('Integration | Component | Ember Power Select (Customization using compon
     }));
 
     await render(hbs`
-      <PowerSelect @options={{this.groupedNumbers}} @groupComponent="custom-group-component" @extra={{this.extra}} @onChange={{action (mut this.foo)}} as |country|>
+      <PowerSelect 
+        @options={{this.groupedNumbers}} 
+        @groupComponent={{component "custom-group-component"}} 
+        @extra={{this.extra}} 
+        @onChange={{action (mut this.foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
     `);
@@ -388,7 +658,12 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelectMultiple @options={{this.countries}} @selected={{this.country}} @optionsComponent="list-of-countries" @onChange={{action (mut this.foo)}} @extra={{hash field="code"}} as |country|>
+      <PowerSelectMultiple 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @optionsComponent={{component "list-of-countries"}} 
+        @onChange={{action (mut this.foo)}} 
+        @extra={{hash field="code"}} as |country|>
         {{country.code}}
       </PowerSelectMultiple>
     `);
@@ -403,7 +678,11 @@ module('Integration | Component | Ember Power Select (Customization using compon
     assert.expect(1);
     this.owner.register('component:selected-country', Component.extend({
       layout: hbs`
-        <img src={{@select.selected.flagUrl}} class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" alt="Flag of {{@select.selected.name}}">
+        <img 
+          src={{@select.selected.flagUrl}} 
+          class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" 
+          alt="Flag of {{@select.selected.name}}"
+        >
         {{@select.selected.name}}
       `
     }));
@@ -411,7 +690,12 @@ module('Integration | Component | Ember Power Select (Customization using compon
     this.country = countries[1]; // Spain
 
     await render(hbs`
-      <PowerSelectMultiple @options={{this.countries}} @selected={{this.country}} @triggerComponent="selected-country" @onChange={{action (mut this.foo)}} @extra={{hash coolFlagIcon=true}} as |country|>
+      <PowerSelectMultiple 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @triggerComponent={{component "selected-country"}} 
+        @onChange={{action (mut this.foo)}} 
+        @extra={{hash coolFlagIcon=true}} as |country|>
         {{country.code}}
       </PowerSelectMultiple>
     `);
@@ -423,9 +707,13 @@ module('Integration | Component | Ember Power Select (Customization using compon
 
   test('the power-select-multiple `@selectedItemComponent` receives the `extra` hash', async function(assert) {
     assert.expect(1);
-    this.owner.register('component:selected-item-country', Component.extend({
+    this.owner.register('component:selected-country', Component.extend({
       layout: hbs`
-        <img src={{@select.selected.flagUrl}} class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" alt="Flag of {{@select.selected.name}}">
+        <img 
+          src={{@select.selected.flagUrl}} 
+          class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" 
+          alt="Flag of {{@select.selected.name}}"
+        >
         {{@select.selected.name}}
       `
     }));
@@ -437,7 +725,7 @@ module('Integration | Component | Ember Power Select (Customization using compon
         <PowerSelectMultiple
             @options={{this.countries}}
             @selected={{this.country}}
-            @selectedItemComponent="selected-item-country"
+            @selectedItemComponent={{component "selected-country"}}
             @onChange={{action (mut this.selected)}}
             @extra={{hash coolFlagIcon=true}} as |country|>
           {{country.code}}
@@ -445,6 +733,6 @@ module('Integration | Component | Ember Power Select (Customization using compon
       </div>
     `);
 
-    assert.dom('.ember-power-select-trigger .cool-flag-icon').exists({ count: 1 }, 'The custom selectedItemComponent renders with the extra.coolFlagIcon customization option triggering some state change.');
+    assert.dom('.ember-power-select-trigger .cool-flag-icon').exists({ count: 1 }, 'The custom selectedItemComponent renders with the extra.coolFlagIcon.');
   });
 });

--- a/tests/integration/components/power-select/customization-with-extending-components-test.js
+++ b/tests/integration/components/power-select/customization-with-extending-components-test.js
@@ -1,0 +1,291 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { countries } from "../constants";
+import { groupedNumbers } from "../constants";
+import { clickTrigger } from "ember-power-select/test-support/helpers";
+import Component from "@ember/component";
+
+module(
+  "Integration | Component | Ember Power Select (Customization with overwriting components)",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("overwriting `power-select/trigger` works", async function (assert) {
+      assert.expect(3);
+
+      this.owner.register(
+        "component:power-select/trigger",
+        class extends Component {
+          layout = hbs`
+        <img 
+          src={{@select.selected.flagUrl}} 
+          class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" 
+          alt="Flag of {{@select.selected.name}}"
+        >
+        {{@select.selected.name}}
+      `;
+        }
+      );
+
+      this.countries = countries;
+      this.country = countries[1]; // Spain
+
+      await render(hbs`
+      <PowerSelect 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+      assert
+        .dom(".ember-power-select-status-icon")
+        .doesNotExist("The provided trigger component is not rendered");
+      assert
+        .dom(".ember-power-select-trigger .icon-flag")
+        .exists("The custom flag appears.");
+      assert
+        .dom(".ember-power-select-trigger")
+        .hasText("Spain", "With the country name as the text.");
+    });
+
+    test("overwriting `power-select/options` works", async function (assert) {
+      assert.expect(2);
+      this.owner.register(
+        "component:power-select/options",
+        Component.extend({
+          layout: hbs`
+        <p>Countries:</p>
+        <ul>
+          {{#if @extra.field}}
+            {{#each @options as |option index|}}
+              <li>{{index}}. {{get option @extra.field}}</li>
+            {{/each}}
+          {{else}}
+            {{#each @options as |option index|}}
+              <li>{{index}}. {{option.name}}</li>
+            {{/each}}
+          {{/if}}
+        </ul>
+      `,
+        })
+      );
+      this.countries = countries;
+      this.country = countries[1]; // Spain
+
+      await render(hbs`
+      <PowerSelect 
+        @options={{this.countries}} 
+        @selected={{this.country}} 
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+      await clickTrigger();
+      assert
+        .dom(".ember-power-select-options")
+        .includesText("Countries:", "The given component is rendered");
+      assert
+        .dom(".ember-power-select-options")
+        .includesText("3. Russia", "The component has access to the options");
+    });
+
+    test("overwriting `power-select/before-options` works", async function (assert) {
+      assert.expect(4);
+      this.owner.register(
+        "component:power-select/before-options",
+        Component.extend({
+          layout: hbs`
+        <p id="custom-before-options-p-tag">{{@placeholder}}</p>
+        {{component @placeholderComponent placeholder=@placeholder}}
+      `,
+        })
+      );
+      this.countries = countries;
+      this.country = countries[1]; // Spain
+
+      await render(hbs`
+      <PowerSelect
+        @options={{this.countries}}
+        @selected={{this.country}}
+        @placeholder="inception"
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+      await clickTrigger();
+      assert
+        .dom(".ember-power-select-dropdown #custom-before-options-p-tag")
+        .exists(
+          "The custom component is rendered instead of the usual search bar"
+        );
+      assert
+        .dom(".ember-power-select-dropdown #custom-before-options-p-tag")
+        .hasText("inception", "The placeholder attribute is passed through.");
+      assert
+        .dom(".ember-power-select-dropdown .ember-power-select-placeholder")
+        .exists("The placeholder component is passed through.");
+      assert
+        .dom(".ember-power-select-search-input")
+        .doesNotExist("The search input is not visible");
+    });
+
+    test("overwriting `power-select/search-message` works", async function (assert) {
+      assert.expect(1);
+      this.owner.register(
+        "component:power-select/search-message",
+        Component.extend({
+          layout: hbs`<p id="custom-search-message-p-tag">Customized seach message!</p>`,
+        })
+      );
+      this.searchFn = function () {};
+      await render(hbs`
+      <PowerSelect 
+        @search={{this.searchFn}} 
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+      await clickTrigger();
+      assert
+        .dom(".ember-power-select-dropdown #custom-search-message-p-tag")
+        .exists(
+          "The custom component is rendered instead of the usual message"
+        );
+    });
+
+    test("overwriting `power-select/no-matches-message` works", async function (assert) {
+      assert.expect(2);
+
+      this.owner.register(
+        "component:power-select/no-matches-message",
+        Component.extend({
+          layout: hbs`<p id="custom-no-matches-message-p-tag">{{@noMatchesMessage}}</p>`,
+        })
+      );
+
+      this.options = [];
+
+      await render(hbs`
+      <PowerSelect 
+        @options={{this.options}} 
+        @noMatchesMessage="Nope" 
+        @onChange={{action (mut this.foo)}} as |option|>
+        {{option}}
+      </PowerSelect>
+    `);
+
+      await clickTrigger();
+
+      assert
+        .dom(".ember-power-select-dropdown #custom-no-matches-message-p-tag")
+        .exists(
+          "The custom component is rendered instead of the usual message"
+        );
+      assert.dom("#custom-no-matches-message-p-tag").hasText("Nope");
+    });
+
+    test("overwriting `power-select/placeholder` works", async function (assert) {
+      assert.expect(2);
+      this.owner.register(
+        "component:power-select/placeholder",
+        Component.extend({
+          layout: hbs`
+        <div class="ember-power-select-placeholder">
+          This is a very <span style="font-weight:bold">bold</span> placeholder
+        </div>
+      `,
+        })
+      );
+      this.countries = countries;
+
+      await render(hbs`
+      <PowerSelect
+        @options={{this.countries}}
+        @placeholder="test"
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+      assert
+        .dom(".ember-power-select-placeholder")
+        .exists("The placeholder appears.");
+      assert
+        .dom(".ember-power-select-placeholder")
+        .hasText(
+          "This is a very bold placeholder",
+          "The placeholder content is equal."
+        );
+    });
+
+    test("overwriting `power-select/power-select-group` works", async function (assert) {
+      this.groupedNumbers = groupedNumbers;
+      let numberOfGroups = 5; // number of groups in groupedNumber;
+
+      this.owner.register(
+        "component:power-select/power-select-group",
+        Component.extend({
+          layout: hbs`<div class="custom-component">{{yield}}</div>`,
+        })
+      );
+
+      await render(hbs`
+      <PowerSelect 
+        @options={{this.groupedNumbers}} 
+        @onChange={{action (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+      await clickTrigger();
+      assert
+        .dom(".ember-power-select-options .custom-component")
+        .exists({ count: numberOfGroups });
+    });
+
+    test("overwriting `power-select-multiple/trigger` works", async function (assert) {
+      assert.expect(1);
+      this.owner.register(
+        "component:power-select-multiple/trigger",
+        Component.extend({
+          layout: hbs`
+        <img 
+          src={{@select.selected.flagUrl}} 
+          class="icon-flag {{if @extra.coolFlagIcon "cool-flag-icon"}}" 
+          alt="Flag of {{@select.selected.name}}"
+        >
+        {{@select.selected.name}}
+      `,
+        })
+      );
+      this.countries = countries;
+      this.country = countries[1]; // Spain
+
+      await render(hbs`
+      <PowerSelectMultiple 
+        @options={{this.countries}}
+        @selected={{this.country}} 
+        @onChange={{action (mut this.foo)}} 
+        @extra={{hash coolFlagIcon=true}} as |country|>
+        {{country.code}}
+      </PowerSelectMultiple>
+    `);
+
+      await clickTrigger();
+
+      assert
+        .dom(".ember-power-select-trigger .cool-flag-icon")
+        .exists(
+          { count: 1 },
+          "The custom triggerComponent renders with the extra.coolFlagIcon customization option triggering some state change."
+        );
+    });
+  }
+);


### PR DESCRIPTION
This PR hopefully makes this addon fully embroider compatible.

Note that this relies on https://github.com/embroider-build/embroider/pull/922 (or something along these lines) to be merged - see https://github.com/embroider-build/embroider/issues/921 (in order for embroider compatibility to really work).

This is based on https://github.com/cibernox/ember-power-select/pull/1419 in many ways, but there have been a bunch of changes in the meanwhile, so it was somewhat easier to reproduce the changes than to deal with merge conflicts etc.

I also added some tests to ensure we keep supporting overwriting the default components (which would break with certain implementations, e.g. if we imported the default components in JS-land).