### PR TITLE
Improve ember-power-select screen reader accessibility

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -2,12 +2,11 @@ import { click, fillIn, settled } from '@ember/test-helpers';
 import { warn } from '@ember/debug';
 
 async function openIfClosedAndGetContentId(trigger) {
-  let contentId = trigger.attributes['aria-owns'] && `${trigger.attributes['aria-owns'].value}`;
+  let contentId = `ember-basic-dropdown-content-${trigger.getAttribute('data-ebd-id').replace('-trigger', '')}`
   let content = contentId ? document.querySelector(`#${contentId}`) : undefined;
   // If the dropdown is closed, open it
   if (!content || content.classList.contains('ember-basic-dropdown-content-placeholder')) {
     await click(trigger);
-    contentId = `${trigger.attributes['aria-owns'].value}`;
   }
   return contentId;
 }

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -45,6 +45,7 @@
       aria-invalid={{@ariaInvalid}}
       aria-label={{@ariaLabel}}
       aria-labelledby={{@ariaLabelledBy}}
+      aria-owns=""
       aria-required={{@required}}
       role={{or @triggerRole "button"}}
       title={{@title}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -46,7 +46,7 @@
       aria-label={{@ariaLabel}}
       aria-labelledby={{@ariaLabelledBy}}
       aria-required={{@required}}
-      role={{or @triggerRole "combobox"}}
+      role={{or @triggerRole "button"}}
       title={{@title}}
       id={{@triggerId}}
       tabindex={{and (not @disabled) (or @tabindex "0")}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -38,12 +38,15 @@
       {{on "focus" this.handleFocus}}
       {{on "blur" this.handleBlur}}
       class="ember-power-select-trigger {{@triggerClass}}{{if publicAPI.isActive " ember-power-select-trigger--active"}}"
+      aria-activedescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
+      aria-controls={{listboxId}}
       aria-describedby={{@ariaDescribedBy}}
+      aria-haspopup="listbox"
       aria-invalid={{@ariaInvalid}}
       aria-label={{@ariaLabel}}
       aria-labelledby={{@ariaLabelledBy}}
       aria-required={{@required}}
-      role={{or @triggerRole "button"}}
+      role={{or @triggerRole "combobox"}}
       title={{@title}}
       id={{@triggerId}}
       tabindex={{and (not @disabled) (or @tabindex "0")}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -38,10 +38,10 @@
       {{on "focus" this.handleFocus}}
       {{on "blur" this.handleBlur}}
       class="ember-power-select-trigger {{@triggerClass}}{{if publicAPI.isActive " ember-power-select-trigger--active"}}"
-      aria-activedescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
-      aria-controls={{listboxId}}
+      aria-activedescendant={{unless @searchEnabled (concat publicAPI.uniqueId "-" this.highlightedIndex)}}
+      aria-controls={{unless @searchEnabled listboxId}}
       aria-describedby={{@ariaDescribedBy}}
-      aria-haspopup="listbox"
+      aria-haspopup={{unless @searchEnabled "listbox"}}
       aria-invalid={{@ariaInvalid}}
       aria-label={{@ariaLabel}}
       aria-labelledby={{@ariaLabelledBy}}
@@ -88,6 +88,7 @@
           @placeholderComponent={{this.placeholderComponent}}
           @extra={{@extra}}
           @listboxId={{listboxId}}
+          @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
           @selectedItemComponent={{@selectedItemComponent}}
           @searchPlaceholder={{@searchPlaceholder}}
           />

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -147,6 +147,18 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   get highlightOnHover(): boolean {
     return this.args.highlightOnHover === undefined ? true : this.args.highlightOnHover
   }
+
+  get highlightedIndex(): number {
+    let results = this.results;
+    let highlighted = this.highlighted;
+
+    if (results) {
+      return indexOfOption(results, highlighted);
+    }
+
+    return 0;
+  }
+
   get placeholderComponent(): string {
     return this.args.placeholderComponent || 'power-select/placeholder';
   }

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -15,6 +15,7 @@ import {
   advanceSelectableOption,
   defaultMatcher,
   defaultTypeAheadMatcher,
+  pathForOption,
   MatcherFn
 } from '../utils/group-utils';
 import { restartableTask } from 'ember-concurrency-decorators';
@@ -148,15 +149,10 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     return this.args.highlightOnHover === undefined ? true : this.args.highlightOnHover
   }
 
-  get highlightedIndex(): number {
+  get highlightedIndex(): string {
     let results = this.results;
     let highlighted = this.highlighted;
-
-    if (results) {
-      return indexOfOption(results, highlighted);
-    }
-
-    return 0;
+    return pathForOption(results, highlighted);
   }
 
   get placeholderComponent(): string {

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -421,7 +421,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (this.args.scrollTo) {
       return this.args.scrollTo(option, select);
     }
-    let optionsList = document.querySelector(`#ember-power-select-options-${select.uniqueId}`) as HTMLElement;
+    let optionsList = document.getElementById(`ember-power-select-options-${select.uniqueId}`) as HTMLElement;
     if (!optionsList) {
       return;
     }

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -421,7 +421,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (this.args.scrollTo) {
       return this.args.scrollTo(option, select);
     }
-    let optionsList = document.querySelector(`[aria-controls="ember-power-select-trigger-${select.uniqueId}"]`) as HTMLElement;
+    let optionsList = document.querySelector(`#ember-power-select-options-${select.uniqueId}`) as HTMLElement;
     if (!optionsList) {
       return;
     }

--- a/addon/components/power-select/before-options.hbs
+++ b/addon/components/power-select/before-options.hbs
@@ -5,7 +5,9 @@
       spellcheck={{false}} role="combobox"
       class="ember-power-select-search-input"
       value={{@select.searchText}}
+      aria-activedescendant={{@ariaActiveDescendant}}
       aria-controls={{@listboxId}}
+      aria-haspopup="listbox"
       placeholder={{@searchPlaceholder}}
       {{on "input" @onInput}}
       {{on "focus" @onFocus}}

--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -1,4 +1,4 @@
-<div role="listbox" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
+<ul role="listbox" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
   {{! template-lint-disable no-unnecessary-concat }}
   {{#if @select.loading}}
     {{#if @loadingMessage}}
@@ -22,7 +22,7 @@
           </Options>
         </Group>
       {{else}}
-        <div class="ember-power-select-option"
+        <li class="ember-power-select-option"
           id="{{@select.uniqueId}}-{{@groupIndex}}{{index}}"
           aria-selected="{{ember-power-select-is-selected opt @select.selected}}"
           aria-disabled={{if opt.disabled "true"}}
@@ -30,8 +30,8 @@
           data-option-index="{{@groupIndex}}{{index}}"
           role={{if (eq opt @select.highlighted) "alert" "option"}}>
           {{yield opt @select}}
-        </div>
+        </li>
       {{/if}}
     {{/each}}
   {{/let}}
-</div>
+</ul>

--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -1,4 +1,4 @@
-<ul role="listbox" aria-controls="ember-power-select-trigger-{{@select.uniqueId}}" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
+<div role="listbox" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
   {{! template-lint-disable no-unnecessary-concat }}
   {{#if @select.loading}}
     {{#if @loadingMessage}}
@@ -22,15 +22,16 @@
           </Options>
         </Group>
       {{else}}
-        <li class="ember-power-select-option"
+        <div class="ember-power-select-option"
+          id="{{@select.uniqueId}}-{{@groupIndex}}{{index}}"
           aria-selected="{{ember-power-select-is-selected opt @select.selected}}"
           aria-disabled={{if opt.disabled "true"}}
           aria-current="{{eq opt @select.highlighted}}"
           data-option-index="{{@groupIndex}}{{index}}"
-          role={{if (eq opt @select.highlighted) "alert" "option"}}>
+          role="option">
           {{yield opt @select}}
-        </li>
+        </div>
       {{/if}}
     {{/each}}
   {{/let}}
-</ul>
+</div>

--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -28,7 +28,7 @@
           aria-disabled={{if opt.disabled "true"}}
           aria-current="{{eq opt @select.highlighted}}"
           data-option-index="{{@groupIndex}}{{index}}"
-          role="option">
+          role={{if (eq opt @select.highlighted) "alert" "option"}}>
           {{yield opt @select}}
         </div>
       {{/if}}

--- a/addon/utils/group-utils.ts
+++ b/addon/utils/group-utils.ts
@@ -47,6 +47,26 @@ export function indexOfOption(collection: any, option: any): number {
   })(collection);
 }
 
+export function pathForOption(collection: any, option: any): string {
+  return (function walk(collection): string {
+    if (!collection) {
+      return '';
+    }
+    for (let i = 0; i < get(collection, 'length'); i++) {
+      let entry = collection.objectAt ? collection.objectAt(i) : collection[i];
+      if (isGroup(entry)) {
+        let result = walk(get(entry, 'options'));
+        if (result.length > 0) {
+          return i + '.' + result;
+        }
+      } else if (entry === option) {
+        return i + '';
+      }
+    }
+    return '';
+  })(collection);
+}
+
 export function optionAtIndex(originalCollection: any, index: number): { disabled: boolean, option: any } {
   let counter = 0;
   return (function walk(collection, ancestorIsDisabled): { disabled: boolean, option: any } | void {

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -215,8 +215,8 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
     assert.dom('.ember-power-select-option[aria-disabled=true]').exists({ count: 3 }, 'Three of them are disabled');
   });
 
-  test('Single-select: The trigger has `role=button` and `aria-owns=<id-of-dropdown>`', async function(assert) {
-    assert.expect(2);
+  test('Single-select: The trigger has `role=button`', async function(assert) {
+    assert.expect(1);
 
     this.numbers = numbers;
     await render(hbs`
@@ -227,11 +227,10 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
 
     await clickTrigger();
     assert.dom('.ember-power-select-trigger').hasAttribute('role', 'button', 'The trigger has role button');
-    assert.dom('.ember-power-select-trigger').hasAttribute('aria-owns', /^ember-basic-dropdown-content-ember\d+$/, 'aria-owns points to the dropdown');
   });
 
-  test('Multiple-select: The trigger has `role=button` and `aria-owns=<id-of-dropdown>`', async function(assert) {
-    assert.expect(2);
+  test('Multiple-select: The trigger has `role=button`', async function(assert) {
+    assert.expect(1);
 
     this.numbers = numbers;
     await render(hbs`
@@ -242,7 +241,6 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
 
     await clickTrigger();
     assert.dom('.ember-power-select-trigger').hasAttribute('role', 'button', 'The trigger has role button');
-    assert.dom('.ember-power-select-trigger').hasAttribute('aria-owns', /^ember-basic-dropdown-content-ember\d+$/, 'aria-owns points to the dropdown');
   });
 
   test('Single-select: The trigger attribute `aria-expanded` is true when the dropdown is opened', async function(assert) {
@@ -452,7 +450,7 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
   });
 
   test('Trigger has proper aria attributes to associate it with the options', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
     this.numbers = numbers;
 
     await render(hbs`
@@ -464,6 +462,7 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
     await clickTrigger();
 
     assert.dom('.ember-power-select-trigger').hasAttribute('aria-haspopup', 'listbox');
+    assert.dom('.ember-power-select-trigger').hasAttribute('aria-owns', '');
     assert.dom('.ember-power-select-trigger').hasAttribute('aria-controls', document.querySelector('.ember-power-select-options').id);
   });
 

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -449,12 +449,18 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
     assert.dom('.ember-power-select-trigger').hasAttribute('role', 'button', 'The `role` was defaults to `button`.');
   });
 
-  test('Trigger has proper aria attributes to associate it with the options', async function(assert) {
+  test('Dropdown with search disabled has proper aria attributes to associate trigger with the options', async function(assert) {
     assert.expect(3);
     this.numbers = numbers;
 
     await render(hbs`
-      <PowerSelect @options={{this.numbers}} @selected={{this.selected}} @onChange={{action (mut this.selected)}} as |number|>
+      <PowerSelect
+        @options={{this.numbers}}
+        @selected={{this.selected}}
+        @searchEnabled={{false}}
+        @onChange={{action (mut this.selected)}}
+        as |number|
+      >
         {{number}}
       </PowerSelect>
     `);
@@ -464,6 +470,31 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
     assert.dom('.ember-power-select-trigger').hasAttribute('aria-haspopup', 'listbox');
     assert.dom('.ember-power-select-trigger').hasAttribute('aria-owns', '');
     assert.dom('.ember-power-select-trigger').hasAttribute('aria-controls', document.querySelector('.ember-power-select-options').id);
+  });
+
+  test('Dropdown with search enabled has proper aria attributes to associate search box with the options', async function(assert) {
+    assert.expect(5);
+    this.numbers = numbers;
+
+    await render(hbs`
+      <PowerSelect
+        @options={{this.numbers}}
+        @selected={{this.selected}}
+        @searchEnabled={{true}}
+        @onChange={{action (mut this.selected)}}
+        as |number|
+      >
+        {{number}}
+      </PowerSelect>
+    `);
+
+    await clickTrigger();
+
+    assert.dom('.ember-power-select-trigger').hasNoAttribute('aria-haspopup');
+    assert.dom('.ember-power-select-trigger').hasNoAttribute('aria-controls');
+    assert.dom('.ember-power-select-search-input').hasAttribute('role', 'combobox');
+    assert.dom('.ember-power-select-search-input').hasAttribute('aria-haspopup', 'listbox');
+    assert.dom('.ember-power-select-search-input').hasAttribute('aria-controls', document.querySelector('.ember-power-select-options').id);
   });
 
   test('Trigger has aria-activedescendant attribute for the highlighted option', async function(assert) {

--- a/tests/integration/components/power-select/mouse-control-test.js
+++ b/tests/integration/components/power-select/mouse-control-test.js
@@ -193,7 +193,7 @@ module('Integration | Component | Ember Power Select (Mouse control)', function(
     `);
 
     await clickTrigger();
-    await triggerEvent('.ember-power-select-options', 'mouseover');
+    await triggerEvent('ul', 'mouseover');
   });
 });
 

--- a/tests/integration/components/power-select/mouse-control-test.js
+++ b/tests/integration/components/power-select/mouse-control-test.js
@@ -193,7 +193,7 @@ module('Integration | Component | Ember Power Select (Mouse control)', function(
     `);
 
     await clickTrigger();
-    await triggerEvent('ul', 'mouseover');
+    await triggerEvent('.ember-power-select-options', 'mouseover');
   });
 });
 

--- a/tests/unit/utils/group-utils-test.js
+++ b/tests/unit/utils/group-utils-test.js
@@ -1,4 +1,4 @@
-import { isGroup, indexOfOption, optionAtIndex, filterOptions, stripDiacritics, countOptions, defaultTypeAheadMatcher } from 'ember-power-select/utils/group-utils';
+import { isGroup, indexOfOption, pathForOption, optionAtIndex, filterOptions, stripDiacritics, countOptions, defaultTypeAheadMatcher } from 'ember-power-select/utils/group-utils';
 import { module, test } from 'qunit';
 
 const groupedOptions = [
@@ -56,6 +56,25 @@ module('Unit | Utility | Group utils', function() {
     assert.equal(indexOfOption(groupedOptions, 'thirteen'), 13);
     assert.equal(indexOfOption(groupedOptions, 'one thousand'), 15);
     assert.equal(indexOfOption(groupedOptions, null), -1);
+  });
+
+  test('#pathForOption works for simple lists with no nesting', function(assert) {
+    assert.equal(pathForOption(null, null), '');
+    assert.equal(pathForOption(basicOptions, null), '');
+    assert.equal(pathForOption(basicOptions, ''), '');
+    assert.equal(pathForOption(basicOptions, 'non-existant option'), '');
+    assert.equal(pathForOption(basicOptions, 'zero'), '0');
+    assert.equal(pathForOption(basicOptions, 'one'), '1');
+    assert.equal(pathForOption(basicOptions, 'five'), '5');
+  });
+
+  test('#pathForOption works for nested lists', function(assert) {
+    assert.equal(pathForOption(groupedOptions, 'zero'), '0.0');
+    assert.equal(pathForOption(groupedOptions, 'four'), '1.0');
+    assert.equal(pathForOption(groupedOptions, 'seven'), '2.0.0');
+    assert.equal(pathForOption(groupedOptions, 'ten'), '2.1.0');
+    assert.equal(pathForOption(groupedOptions, 'one hundred'), '3');
+    assert.equal(pathForOption(groupedOptions, 'one thousand'), '4');
   });
 
   test('#optionAtIndex returns an object `{ disabled, option }`, disabled being true if that option or any ancestor is disabled, and the option will be undefined if the index is out of range', function(assert) {


### PR DESCRIPTION
The current implementation doesn't appear to work well with screen readers. Specifically, screen readers are unable to recognize and read out the options because of missing aria attributes.

This PR fixes a few issues from the previous checklist created by someone else "[a11y] Refine ARIA implementation": https://github.com/cibernox/ember-power-select/issues/806

It closes these two issues from that list:
- Implement aria-activedescendant on the combobox. This property allows focus to stay on the trigger but tells the screen reader which option in the listbox is currently highlighted.
- Remove aria-controls from ul elements inside the listbox. (This relationship was backwards. The trigger controls the options list, not the other way around.)

I also compared ember-power-select to the reference implementation provided by the W3C. In my testing, this reference implementation works very well with screen readers:  https://w3c.github.io/aria-practices/examples/combobox/combobox-select-only.html

This PR by itself doesn't fix all screen reader issues. This is merely a step in the right direction. For one, users will have to pass in `@triggerRole="combobox"`.