### PR TITLE
Use role=option for all options in list

### DIFF
--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -28,7 +28,7 @@
           aria-disabled={{if opt.disabled "true"}}
           aria-current="{{eq opt @select.highlighted}}"
           data-option-index="{{@groupIndex}}{{index}}"
-          role={{if (eq opt @select.highlighted) "alert" "option"}}>
+          role="option">
           {{yield opt @select}}
         </li>
       {{/if}}

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -40,7 +40,7 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
     [].slice.call(nestedOptionList).forEach((e) => assert.dom(e).hasAttribute('role', 'group'));
   });
 
-  test('Single-select: All options have `role=option` except highlighted options which have `role=alert`', async function(assert) {
+  test('Single-select: All options have `role=option`', async function(assert) {
     assert.expect(15);
 
     this.groupedNumbers = groupedNumbers;
@@ -52,16 +52,10 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
 
     await clickTrigger();
 
-    [].slice.call(document.querySelectorAll('li.ember-power-select-option[aria-current="true"]')).forEach((e) => {
-      assert.dom(e).hasAttribute('role', 'alert');
-    });
-
-    [].slice.call(document.querySelectorAll('li.ember-power-select-option[aria-current="false"]')).forEach((e) => {
-      assert.dom(e).hasAttribute('role', 'option');
-    });
+    [].slice.call(document.querySelectorAll('.ember-power-select-option')).forEach((e) => assert.dom(e).hasAttribute('role', 'option'));
   });
 
-  test('Multiple-select: All options have `role=option` except highlighted options which have `role=alert`', async function(assert) {
+  test('Multiple-select: All options have `role=option`', async function(assert) {
     assert.expect(15);
 
     this.groupedNumbers = groupedNumbers;
@@ -73,13 +67,7 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
 
     await clickTrigger();
 
-    [].slice.call(document.querySelectorAll('li.ember-power-select-option[aria-current="true"]')).forEach((e) => {
-      assert.dom(e).hasAttribute('role', 'alert');
-    });
-
-    [].slice.call(document.querySelectorAll('li.ember-power-select-option[aria-current="false"]')).forEach((e) => {
-      assert.dom(e).hasAttribute('role', 'option');
-    });
+    [].slice.call(document.querySelectorAll('.ember-power-select-option')).forEach((e) => assert.dom(e).hasAttribute('role', 'option'));
   });
 
   test('Single-select: The selected option has `aria-selected=true` and the rest `aria-selected=false`', async function(assert) {
@@ -149,42 +137,6 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
     await triggerKeyEvent('.ember-power-select-search-input', 'keydown', 40);
     assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('aria-current', 'false', 'the first option has now aria-current=false');
     assert.dom(findContains('.ember-power-select-option', 'two')).hasAttribute('aria-current', 'true', 'the second option has now aria-current=false');
-  });
-
-  test('Single-select: The highlighted option has `role=alert` and the rest have `role=option`', async function(assert) {
-    assert.expect(4);
-
-    this.numbers = numbers;
-    await render(hbs`
-      <PowerSelect @options={{this.numbers}} @selected={{this.selected}} @onChange={{action (mut this.selected)}} @searchEnabled={{true}} as |option|>
-        {{option}}
-      </PowerSelect>
-    `);
-
-    await clickTrigger();
-    assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('role', 'alert', 'the highlighted option has role=alert');
-    assert.dom('.ember-power-select-option[role="option"]').exists({ count: numbers.length - 1 }, 'All other options have role=option');
-    await triggerKeyEvent('.ember-power-select-search-input', 'keydown', 40);
-    assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('role', 'option', 'the first option now has role=option');
-    assert.dom(findContains('.ember-power-select-option', 'two')).hasAttribute('role', 'alert', 'the second option now has role=alert');
-  });
-
-  test('Multiple-select: The highlighted option has `role=alert` and the rest `role=option`', async function(assert) {
-    assert.expect(4);
-
-    this.numbers = numbers;
-    await render(hbs`
-      <PowerSelect @options={{this.numbers}} @selected={{this.selected}} @onChange={{action (mut this.selected)}} @searchEnabled={{true}} as |option|>
-        {{option}}
-      </PowerSelect>
-    `);
-
-    await clickTrigger();
-    assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('role', 'alert', 'the highlighted option has role=alert');
-    assert.dom('.ember-power-select-option[role="option"]').exists({ count: numbers.length - 1 }, 'All other options have role=option');
-    await triggerKeyEvent('.ember-power-select-search-input', 'keydown', 40);
-    assert.dom(findContains('.ember-power-select-option', 'one')).hasAttribute('role', 'option', 'the first option now has role=option');
-    assert.dom(findContains('.ember-power-select-option', 'two')).hasAttribute('role', 'alert', 'the second option now has role=alert');
   });
 
   test('Single-select: Options with a disabled field have `aria-disabled=true`', async function(assert) {


### PR DESCRIPTION
I didn't include this in my previous PR (https://github.com/cibernox/ember-power-select/pull/1481) because I considered it a breaking change but since there is a plan to cut a new major release of EPS, I may as well try to sneak this in.

I haven't seen any documentation that using `role="alert"` is appropriate here (if such documentation exists, please send it to me!). The W3C reference implementation uses `role="option"` for all options (https://w3c.github.io/aria-practices/examples/combobox/combobox-select-only.html). In fact, our product had an accessibility audit completed by an external company and they said we had to switch it from `role="alert"`. As well, with the addition of `aria-activedescendant`, screen readers should be able to read out options without this.

We were able to patch this in our product by passing in a custom options component, but if I can sneak in this change, we can stop doing that.