### PR TITLE
aria-activedescendant property should not be present when dropdown is closed

### DIFF
--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -38,7 +38,7 @@
       {{on "focus" this.handleFocus}}
       {{on "blur" this.handleBlur}}
       class="ember-power-select-trigger {{@triggerClass}}{{if publicAPI.isActive " ember-power-select-trigger--active"}}"
-      aria-activedescendant={{unless @searchEnabled (concat publicAPI.uniqueId "-" this.highlightedIndex)}}
+      aria-activedescendant={{if dropdown.isOpen (unless @searchEnabled (concat publicAPI.uniqueId "-" this.highlightedIndex))}}
       aria-controls={{unless @searchEnabled listboxId}}
       aria-describedby={{@ariaDescribedBy}}
       aria-haspopup={{unless @searchEnabled "listbox"}}

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -498,7 +498,7 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
   });
 
   test('Trigger has aria-activedescendant attribute for the highlighted option', async function(assert) {
-    assert.expect(4);
+    assert.expect(5);
     this.numbers = numbers;
 
     await render(hbs`
@@ -506,6 +506,8 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
         {{number}}
       </PowerSelect>
     `);
+
+    assert.dom('.ember-power-select-trigger').hasNoAttribute('aria-activedescendant', 'aria-activedescendant is not present when the dropdown is closed');
 
     await clickTrigger();
 


### PR DESCRIPTION
The `aria-activedescendant` property should always refer to a valid element. When the dropdown is closed, none of the options are in the DOM, so `aria-activedescendant` should be blank.