### PR TITLE
Add aria accessibility properties to PowerSelectMultiple

### DIFF
--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -1,8 +1,8 @@
+{{! template-lint-disable "no-invalid-interactive" }}
 <ul
   id="ember-power-select-multiple-options-{{@select.uniqueId}}"
   aria-activedescendant={{if (and @select.isOpen (not @searchEnabled)) @ariaActiveDescendant}}
   class="ember-power-select-multiple-options"
-  role="button"
   {{did-update this.openChanged @select.isOpen}}
   {{on "touchstart" this.chooseOption}}
   {{on "mousedown" this.chooseOption}}
@@ -11,7 +11,6 @@
     <li class="ember-power-select-multiple-option {{if opt.disabled "ember-power-select-multiple-option--disabled"}}">
       {{#unless @select.disabled}}
         <span
-          {{! template-lint-disable "no-nested-interactive" }}
           role="button"
           aria-label="remove element"
           class="ember-power-select-multiple-remove-btn"
@@ -32,12 +31,12 @@
   {{/each}}
   {{#if @searchEnabled}}
     <input
-      {{! template-lint-disable "no-nested-interactive" }}
       type="search"
       role="combobox"
       class="ember-power-select-trigger-multiple-input"
       aria-activedescendant={{if @select.isOpen @ariaActiveDescendant}}
       aria-haspopup="listbox"
+      aria-expanded={{if @select.isOpen "true" "false"}}
       autocomplete="off"
       autocorrect="off"
       autocapitalize="off"

--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -1,5 +1,7 @@
 <ul
   id="ember-power-select-multiple-options-{{@select.uniqueId}}"
+  aria-activedescendant={{if (and @select.isOpen (not @searchEnabled)) @ariaActiveDescendant}}
+  aria-haspopup={{unless @searchEnabled "listbox"}}
   class="ember-power-select-multiple-options"
   role="button"
   {{did-update this.openChanged @select.isOpen}}
@@ -33,7 +35,10 @@
     <input
       {{! template-lint-disable "no-nested-interactive" }}
       type="search"
+      role="combobox"
       class="ember-power-select-trigger-multiple-input"
+      aria-activedescendant={{if @select.isOpen @ariaActiveDescendant}}
+      aria-haspopup="listbox"
       autocomplete="off"
       autocorrect="off"
       autocapitalize="off"

--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -1,7 +1,6 @@
 <ul
   id="ember-power-select-multiple-options-{{@select.uniqueId}}"
   aria-activedescendant={{if (and @select.isOpen (not @searchEnabled)) @ariaActiveDescendant}}
-  aria-haspopup={{unless @searchEnabled "listbox"}}
   class="ember-power-select-multiple-options"
   role="button"
   {{did-update this.openChanged @select.isOpen}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -70,6 +70,7 @@
           @onKeydown={{this.handleKeydown}}
           @placeholder={{@placeholder}}
           @placeholderComponent={{this.placeholderComponent}}
+          @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
           as |opt term|>
           {{yield opt term}}
         </Trigger>

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -554,7 +554,7 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
   });
 
   test('PowerSelectMultiple with search enabled has proper aria attributes', async function(assert) {
-    assert.expect(10);
+    assert.expect(11);
     this.numbers = numbers;
 
     await render(hbs`
@@ -578,6 +578,7 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
     assert.dom('.ember-power-select-trigger-multiple-input').hasAttribute('role', 'combobox', 'Multi select search box has role combobox');
     assert.dom('.ember-power-select-trigger-multiple-input').hasAttribute('aria-controls', /^ember-power-select-options-ember\d+$/, 'Multi select search box has aria-controls value');
     assert.dom('.ember-power-select-trigger-multiple-input').hasAttribute('aria-haspopup', 'listbox', 'Multi select search box has aria-haspopup value');
+    assert.dom('.ember-power-select-trigger-multiple-input').hasAttribute('aria-expanded', 'true', 'Multi select search box has aria-expanded value');
 
     // by default, the first option is highlighted and marked as aria-activedescendant
     assert.dom('.ember-power-select-option').hasAttribute('aria-current', 'true', 'The first element is highlighted');

--- a/tests/integration/components/power-select/a11y-test.js
+++ b/tests/integration/components/power-select/a11y-test.js
@@ -520,4 +520,72 @@ module('Integration | Component | Ember Power Select (Accessibility)', function(
     assert.dom('.ember-power-select-option:nth-child(4)').hasAttribute('aria-current', 'true', 'The 4th element is highlighted');
     assert.dom('.ember-power-select-trigger').hasAttribute('aria-activedescendant', document.querySelector('.ember-power-select-option:nth-child(4)').id, 'The 4th element is the aria-activedescendant');
   });
+
+  test('PowerSelectMultiple with search disabled has proper aria attributes', async function(assert) {
+    assert.expect(7);
+    this.numbers = numbers;
+
+    await render(hbs`
+      <PowerSelectMultiple
+        @options={{this.numbers}}
+        @selected={{this.selected}}
+        @searchEnabled={{false}}
+        @onChange={{action (mut this.selected)}}
+        as |number|
+      >
+        {{number}}
+      </PowerSelectMultiple>
+    `);
+
+    assert.dom('.ember-power-select-trigger').hasAttribute('aria-controls', /^ember-power-select-options-ember\d+$/, 'The trigger has aria-controls value');
+    assert.dom('.ember-power-select-trigger').hasNoAttribute('aria-activedescendant', 'aria-activedescendant is not present when the dropdown is closed');
+    assert.dom('.ember-power-select-trigger').hasAttribute('aria-haspopup', 'listbox', 'aria-haspopup is present on the trigger');
+
+    await clickTrigger();
+
+    // by default, the first option is highlighted and marked as aria-activedescendant
+    assert.dom('.ember-power-select-option').hasAttribute('aria-current', 'true', 'The first element is highlighted');
+    assert.dom('.ember-power-select-trigger').hasAttribute('aria-activedescendant', document.querySelector('.ember-power-select-option:nth-child(1)').id, 'The first element is the aria-activedescendant');
+
+    await triggerEvent('.ember-power-select-option:nth-child(4)', 'mouseover');
+
+    assert.dom('.ember-power-select-option:nth-child(4)').hasAttribute('aria-current', 'true', 'The 4th element is highlighted');
+    assert.dom('.ember-power-select-trigger').hasAttribute('aria-activedescendant', document.querySelector('.ember-power-select-option:nth-child(4)').id, 'The 4th element is the aria-activedescendant');
+  });
+
+  test('PowerSelectMultiple with search enabled has proper aria attributes', async function(assert) {
+    assert.expect(10);
+    this.numbers = numbers;
+
+    await render(hbs`
+      <PowerSelectMultiple
+        @options={{this.numbers}}
+        @selected={{this.selected}}
+        @searchEnabled={{true}}
+        @onChange={{action (mut this.selected)}}
+        as |number|
+      >
+        {{number}}
+      </PowerSelectMultiple>
+    `);
+
+    assert.dom('.ember-power-select-trigger').hasNoAttribute('aria-controls', 'The trigger has no aria-controls value');
+    assert.dom('.ember-power-select-trigger').hasNoAttribute('aria-activedescendant', 'aria-activedescendant is not present on the trigger');
+    assert.dom('.ember-power-select-trigger').hasNoAttribute('aria-haspopup', 'aria-haspopup is not present on the trigger');
+
+    await clickTrigger();
+
+    assert.dom('.ember-power-select-trigger-multiple-input').hasAttribute('role', 'combobox', 'Multi select search box has role combobox');
+    assert.dom('.ember-power-select-trigger-multiple-input').hasAttribute('aria-controls', /^ember-power-select-options-ember\d+$/, 'Multi select search box has aria-controls value');
+    assert.dom('.ember-power-select-trigger-multiple-input').hasAttribute('aria-haspopup', 'listbox', 'Multi select search box has aria-haspopup value');
+
+    // by default, the first option is highlighted and marked as aria-activedescendant
+    assert.dom('.ember-power-select-option').hasAttribute('aria-current', 'true', 'The first element is highlighted');
+    assert.dom('.ember-power-select-trigger-multiple-input').hasAttribute('aria-activedescendant', document.querySelector('.ember-power-select-option:nth-child(1)').id, 'The first element is the aria-activedescendant');
+
+    await triggerEvent('.ember-power-select-option:nth-child(4)', 'mouseover');
+
+    assert.dom('.ember-power-select-option:nth-child(4)').hasAttribute('aria-current', 'true', 'The 4th element is highlighted');
+    assert.dom('.ember-power-select-trigger-multiple-input').hasAttribute('aria-activedescendant', document.querySelector('.ember-power-select-option:nth-child(4)').id, 'The 4th element is the aria-activedescendant');
+  });
 });


### PR DESCRIPTION
Because `<PowerSelectMultiple>` uses `<PowerSelect>` I naively assumed that I didn't need to do anything with `<PowerSelectMultiple>` when I did the accessibility improvements in https://github.com/cibernox/ember-power-select/pull/1481. Of course that's not the case.

I followed the W3C WAI-ARIA 1.2 recommendation for comboboxes:
https://www.w3.org/TR/wai-aria-1.2/#combobox