### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,50 +12,26 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 3 * * 0' # every Sunday at 3am
+    - cron: "0 3 * * 0" # every Sunday at 3am
 
 env:
   CI: true
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tests:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     name: Base Tests
-    timeout-minutes: 60
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node:
-        - "12"
-        - "14"
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        persist-credentials: false
-    - name: Reconfigure git to use HTTP authentication
-      run: >
-        git config --global url."https://github.com/".insteadOf
-        ssh://git@github.com/
-    - uses: volta-cli/action@v1
-      with:
-        node-version: ${{ matrix.node }}
-
-    - run: npm ci
-
-    - name: Test with ${{ matrix.node }}
-      run: npm run test
-
-  floating-dependencies:
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
-    name: Floating Dependencies
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node:
-        - "12"
-        - "14"
-
+          - "12"
+          - "14"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -68,18 +44,45 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install
+      - run: npm ci
 
-      - name: Test with Node ${{ matrix.node }}
-        run: npm run test
+      - name: Ember Test with ${{ matrix.node }}
+        run: npm run test:ember
 
-  try-scenarios:
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
-    name: "Compatibility"
-    timeout-minutes: 60
+      - name: Node Tests with Node ${{ matrix.node }}
+        run: npm run nodetest
+
+  floating-dependencies:
+    name: Floating Dependencies
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     needs: tests
 
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
+      - uses: volta-cli/action@v1
+        with:
+          node-version: 14
+
+      - run: npm install --lock-file=false
+
+      - name: Ember Tests
+        run: npm run test:ember
+
+      - name: Node Tests
+        run: npm run nodetest
+
+  try-scenarios:
+    name: "Compatibility"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    needs: tests
     strategy:
       fail-fast: true
       matrix:
@@ -88,10 +91,9 @@ jobs:
           - ember-lts-3.20
           - ember-release
           - ember-beta
-          # - ember-canary
-          - node-tests
+          - ember-canary
           - embroider-safe
-          # - ember-classic
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -107,7 +109,6 @@ jobs:
         run: npm install
       - name: test
         run: node_modules/.bin/ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup
-
 
   publish:
     name: Release


### PR DESCRIPTION
Currently, all CI steps run `npm test`, which in turn will run `npm test:ember-compatibility`, which will run the tests for all ember-try scenarios.

This PR streamlines this to:

* `tests` which runs the regular ember tests
* `floating-dependencies` which has been slightly adjusted to run `npm install --lock-file=false` to ensure it is truly floating
* `try-scenarios` which actually runs the ember-try scenarios in a matrix

I also updated it to only run the node matrix for the base tests, not the floating dependencies (let me know if that is there on purpose, happy to re-add it then!) Both floating-dependencies & try-scenarios are now run only after tests completed. Finally, the concurrency setting ensures that a CI run is cancelled if a new state is pushed to the same branch while CI is running.

The visualization shows the change nicely:

Before:
![Screenshot from 2022-01-26 13-55-14](https://user-images.githubusercontent.com/2411343/151171657-54e3835f-4e53-4a69-a88d-854a235b104d.png)

After:
![Screenshot from 2022-01-26 13-55-01](https://user-images.githubusercontent.com/2411343/151171672-0c65c2a8-4336-428a-8e1a-e6d76dd24915.png)