### PR TITLE
Cleans up scrollTo's element finding

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -430,7 +430,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (index === -1) {
       return;
     }
-    let optionElement = (optionsList.querySelectorAll('[data-option-index]') as NodeListOf<HTMLElement>).item(index);
+    let optionElement = optionsList.querySelector(`[data-option-index='${index}']`) as HTMLElement;
     if (!optionElement) {
       return;
     }


### PR DESCRIPTION
This commit simplifies the search for the option to scroll to, by querying directly for the element with the right index instead of fetching all elements and then selecting from the generated array.

This feels slightly cleaner to my eyes, and has the added benefit of ensuring it's not broken by something like [vertical-collection](https://github.com/html-next/vertical-collection), which only renders a sliding window of options for performance reasons. The combination was causing keyboard-navigation to fail unexpectedly, since `.item(19)` was no longer guaranteed to be the item with `data-option-index='19'`, nor was the array guaranteed to be long enough to have that element.