### PR TITLE
fix reverting selected promise

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -375,6 +375,11 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
         }
       });
     } else {
+      if (this._lastSelectedPromise) {
+        // no longer using a promise
+        removeObserver(this._lastSelectedPromise, 'content', this, this._selectedObserverCallback);
+        this._lastSelectedPromise = undefined;
+      }
       this._resolvedSelected = undefined;
       // Don't highlight args.selected array on multi-select
       if (!Array.isArray(this.args.selected)) {


### PR DESCRIPTION
I was using ember-changeset and ember-data, whereby the initial @selected value was a promise. Selecting a different non-promise-based value for EPS, and then reverting the changeset which resets the selected value back to the original promise. 
EPS was ignoring this change