### PR TITLE
add back ember-try scenarios that were removed with ember-cli-update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
+          - ember-lts-3.16
+          - ember-lts-3.20
           - ember-lts-3.24
           - ember-lts-3.28
           - ember-release

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ ember-data collections and follows idiomatic patterns.
 
 ## Compatibility
 
-* Ember.js v3.24 or above
-* Ember CLI v3.24 or above
+* Ember.js v3.16 or above
+* Ember CLI v3.16 or above
 * Node.js v14 or above
 
 Ember Power Select 1.X works in Ember **2.3.1+**, beta and canary with no deprecations

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,6 +7,24 @@ module.exports = async function () {
   return {
     scenarios: [
       {
+        name: 'ember-lts-3.16',
+
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.16.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-3.20',
+
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.0',
+          },
+        },
+      },
+      {
         name: 'ember-lts-3.24',
 
         npm: {


### PR DESCRIPTION
In https://github.com/cibernox/ember-power-select/pull/1533 the default blueprint update just removes the older ember versions from ember-try. If there is no reason to remove them then we can keep testing them and not drop support until we need to 👍 

Also 3.16 is a good base version to support because it's the first Octane LTS so there are no blockers to fully moving everything to Octane (if they haven't already been 😂 ) 