### PR TITLE
be more permissive on ember-truth-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ember-concurrency": ">=1.0.0 <3",
     "ember-concurrency-decorators": "^2.0.0",
     "ember-text-measurer": "^0.6.0",
-    "ember-truth-helpers": "^3.0.0"
+    "ember-truth-helpers": "^2.1.0 || ^3.0.0"
   },
   "devDependencies": {
     "@ember-decorators/component": "^6.1.0",


### PR DESCRIPTION
Being more permissive on `ember-truth-helpers` helps people migrate their apps/addons.

For example, even ember-basic-dropdown that this addon depends on, does that: https://github.com/cibernox/ember-basic-dropdown/blob/master/package.json#L112