### PR TITLE
fix: display code snippets in documentation

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    snippetPaths: ['tests/dummy/app/templates/snippets/'],
   });
 
   /*


### PR DESCRIPTION
# Preview
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/36460224/190921980-119e70e1-36c3-48ab-b7d4-b4b9341d19ee.png">
