### PR TITLE
Fix import from ember-basic-dropdown

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -21,7 +21,7 @@ import {
 import { restartableTask } from 'ember-concurrency-decorators';
 // @ts-ignore
 import { timeout } from 'ember-concurrency';
-import { Dropdown, DropdownActions } from 'ember-basic-dropdown/addon/components/basic-dropdown';
+import { Dropdown, DropdownActions } from 'ember-basic-dropdown/components/basic-dropdown';
 
 interface SelectActions extends DropdownActions {
   search: (term: string) => void


### PR DESCRIPTION
One should not import from the addon directory. In glint 1.0, this will cause problems if not addressed.