### PR TITLE
Update type imports -- /addon/ isn't a valid path

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -20,7 +20,7 @@ import {
 } from '../utils/group-utils';
 // @ts-ignore
 import { restartableTask, timeout } from 'ember-concurrency';
-import { Dropdown, DropdownActions } from 'ember-basic-dropdown/addon/components/basic-dropdown';
+import type { Dropdown, DropdownActions } from 'ember-basic-dropdown/components/basic-dropdown';
 
 interface SelectActions extends DropdownActions {
   search: (term: string) => void


### PR DESCRIPTION
for consumers that end up importing this file, the type declarations don't include `/addon`

`/addon` ends up working during development time, because the original source is in TS -- but it ends up not being the same as the emitted declarations.