### PR TITLE
restrict isSliceable to avoid slicing strings

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -90,7 +90,7 @@ export interface PowerSelectArgs {
 }
 
 const isSliceable = <T>(coll: any): coll is Sliceable<T> => {
-  return typeof coll.slice === 'function';
+  return typeof coll.slice === 'function' && typeof coll.sort === 'function';
 }
 
 const isPromiseLike = <T>(thing: any): thing is Promise<T> => {


### PR DESCRIPTION
I think the intention here is to `slice` arrays, rather than strings. Arrays can be sorted, but it's not an operation that makes sense for strings.

This caused a regression for a internal object that inherited from `String`. I would perhaps classify it as surprising behaviour.