### PR TITLE
fix: compile vendor css files

### DIFF
--- a/vendor/ember-power-select-bootstrap.css
+++ b/vendor/ember-power-select-bootstrap.css
@@ -1,20 +1,27 @@
 .ember-basic-dropdown {
-  position: relative; }
+  position: relative;
+}
 
-.ember-basic-dropdown, .ember-basic-dropdown-content, .ember-basic-dropdown-content * {
-  box-sizing: border-box; }
+.ember-basic-dropdown,
+.ember-basic-dropdown-content,
+.ember-basic-dropdown-content * {
+  box-sizing: border-box;
+}
 
 .ember-basic-dropdown-content {
   position: absolute;
   width: auto;
   z-index: 1000;
-  background-color: #ffffff; }
+  background-color: #ffffff;
+}
 
 .ember-basic-dropdown-content--left {
-  left: 0; }
+  left: 0;
+}
 
 .ember-basic-dropdown-content--right {
-  right: 0; }
+  right: 0;
+}
 
 .ember-basic-dropdown-overlay {
   position: fixed;
@@ -24,13 +31,16 @@
   z-index: 10;
   top: 0;
   left: 0;
-  pointer-events: none; }
+  pointer-events: none;
+}
 
 .ember-basic-dropdown-content-wormhole-origin {
-  display: inline; }
+  display: inline;
+}
 
 .ember-power-select-dropdown * {
-  box-sizing: border-box; }
+  box-sizing: border-box;
+}
 
 .ember-power-select-trigger {
   position: relative;
@@ -47,11 +57,13 @@
   user-select: none;
   -webkit-user-select: none;
   color: inherit;
-  /* Minimum clearfix for modern browsers */ }
-  .ember-power-select-trigger:after {
-    content: "";
-    display: table;
-    clear: both; }
+  /* Minimum clearfix for modern browsers */
+}
+.ember-power-select-trigger:after {
+  content: "";
+  display: table;
+  clear: both;
+}
 
 .ember-power-select-trigger:focus,
 .ember-power-select-trigger--active {
@@ -60,23 +72,27 @@
   border-right: 1px solid #66afe9;
   border-left: 1px solid #66afe9;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
-  outline: 0; }
+  outline: 0;
+}
 
-.ember-basic-dropdown-trigger--below.ember-power-select-trigger[aria-expanded="true"],
-.ember-basic-dropdown-trigger--in-place.ember-power-select-trigger[aria-expanded="true"] {
+.ember-basic-dropdown-trigger--below.ember-power-select-trigger[aria-expanded=true],
+.ember-basic-dropdown-trigger--in-place.ember-power-select-trigger[aria-expanded=true] {
   border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px; }
+  border-bottom-right-radius: 4px;
+}
 
-.ember-basic-dropdown-trigger--above.ember-power-select-trigger[aria-expanded="true"] {
+.ember-basic-dropdown-trigger--above.ember-power-select-trigger[aria-expanded=true] {
   border-top-left-radius: 4px;
-  border-top-right-radius: 4px; }
+  border-top-right-radius: 4px;
+}
 
 .ember-power-select-placeholder {
   color: #999999;
   display: block;
   overflow-x: hidden;
   white-space: nowrap;
-  text-overflow: ellipsis; }
+  text-overflow: ellipsis;
+}
 
 .ember-power-select-status-icon {
   position: absolute;
@@ -88,45 +104,57 @@
   margin: auto;
   border-style: solid;
   border-width: 7px 4px 0 4px;
-  border-color: #999 transparent transparent transparent; }
-  .ember-basic-dropdown-trigger[aria-expanded="true"] .ember-power-select-status-icon {
-    transform: rotate(180deg); }
+  border-color: #999 transparent transparent transparent;
+}
+.ember-basic-dropdown-trigger[aria-expanded=true] .ember-power-select-status-icon {
+  transform: rotate(180deg);
+}
 
 .ember-power-select-clear-btn {
   position: absolute;
-  cursor: pointer; }
+  cursor: pointer;
+}
+
+.ember-power-select-multiple-options {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+}
 
 .ember-power-select-trigger-multiple-input {
   font-family: inherit;
   font-size: inherit;
   border: none;
-  display: inline-block;
   line-height: inherit;
   -webkit-appearance: none;
   outline: none;
   padding: 0;
-  float: left;
   background-color: transparent;
   text-indent: 2px;
-  /* There's a browser bug where this selectos cannot be chained with commas */ }
-  .ember-power-select-trigger-multiple-input:disabled {
-    background-color: #eeeeee; }
-  .ember-power-select-trigger-multiple-input::placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-webkit-input-placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-moz-placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-ms-input-placeholder {
-    opacity: 1;
-    color: #999999; }
-
-.ember-power-select-multiple-options {
-  padding: 0;
-  margin: 0; }
+  /* There's a browser bug where this selectos cannot be chained with commas */
+}
+.ember-power-select-trigger-multiple-input:disabled {
+  background-color: #eeeeee;
+}
+.ember-power-select-trigger-multiple-input::placeholder {
+  opacity: 1;
+  color: #999999;
+}
+.ember-power-select-trigger-multiple-input::-webkit-input-placeholder {
+  opacity: 1;
+  color: #999999;
+}
+.ember-power-select-trigger-multiple-input::-moz-placeholder {
+  opacity: 1;
+  color: #999999;
+}
+.ember-power-select-trigger-multiple-input::-ms-input-placeholder {
+  opacity: 1;
+  color: #999999;
+}
 
 .ember-power-select-multiple-option {
   border: 1px solid gray;
@@ -134,18 +162,20 @@
   color: #333333;
   background-color: #e4e4e4;
   padding: 0 4px;
-  display: inline-block;
   line-height: 1.45;
-  float: left;
-  margin: 2px 0 2px 3px; }
+  margin: 2px 0 2px 3px;
+}
 
 .ember-power-select-multiple-remove-btn {
-  cursor: pointer; }
-  .ember-power-select-multiple-remove-btn:not(:hover) {
-    opacity: 0.5; }
+  cursor: pointer;
+}
+.ember-power-select-multiple-remove-btn:not(:hover) {
+  opacity: 0.5;
+}
 
 .ember-power-select-search {
-  padding: 4px; }
+  padding: 4px;
+}
 
 .ember-power-select-search-input {
   border: 1px solid #ccc;
@@ -153,11 +183,13 @@
   width: 100%;
   font-size: inherit;
   line-height: inherit;
-  padding: 0 5px; }
-  .ember-power-select-search-input:focus {
-    border: 1px solid #66afe9;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
-    outline: 0; }
+  padding: 0 5px;
+}
+.ember-power-select-search-input:focus {
+  border: 1px solid #66afe9;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  outline: 0;
+}
 
 .ember-power-select-dropdown {
   border-left: 1px solid #ccc;
@@ -166,112 +198,136 @@
   border-radius: 4px;
   box-shadow: rgba(0, 0, 0, 0.172549) 0px 6px 12px 0px;
   overflow: hidden;
-  color: inherit; }
+  color: inherit;
+}
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--above {
   transform: translateY(calc(-1 * 3px));
   border-top: 1px solid #ccc;
   border-bottom: 1px solid #ccc;
   border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px; }
+  border-bottom-right-radius: 4px;
+}
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--below, .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
   transform: translateY(3px);
   border-top: 1px solid #ccc;
   border-bottom: 1px solid #ccc;
   border-top-left-radius: 4px;
-  border-top-right-radius: 4px; }
+  border-top-right-radius: 4px;
+}
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
-  width: 100%; }
+  width: 100%;
+}
 
 .ember-power-select-options {
   list-style: none;
   margin: 0;
   padding: 0;
   user-select: none;
-  -webkit-user-select: none; }
-  .ember-power-select-options[role="listbox"] {
-    overflow-y: auto;
-    /* in firefox in windows this can cause a word-break issue. Try `overflow-y: scroll` if that happens */
-    -webkit-overflow-scrolling: touch;
-    max-height: 14em; }
+  -webkit-user-select: none;
+}
+.ember-power-select-options[role=listbox] {
+  overflow-y: auto; /* in firefox in windows this can cause a word-break issue. Try `overflow-y: scroll` if that happens */
+  -webkit-overflow-scrolling: touch;
+  max-height: 14em;
+}
 
 .ember-power-select-option {
   cursor: pointer;
-  padding: 0 8px; }
+  padding: 0 8px;
+}
 
-.ember-power-select-group[aria-disabled="true"] {
+.ember-power-select-group[aria-disabled=true] {
   color: #999999;
-  cursor: not-allowed; }
+  cursor: not-allowed;
+}
 
-.ember-power-select-group[aria-disabled="true"] .ember-power-select-option,
-.ember-power-select-option[aria-disabled="true"] {
+.ember-power-select-group[aria-disabled=true] .ember-power-select-option,
+.ember-power-select-option[aria-disabled=true] {
   color: #999999;
   pointer-events: none;
-  cursor: not-allowed; }
+  cursor: not-allowed;
+}
 
-.ember-power-select-option[aria-selected="true"] {
-  background-color: #f5f5f5; }
-
-.ember-power-select-option[aria-current="true"] {
+.ember-power-select-option[aria-selected=true] {
   background-color: #f5f5f5;
-  color: inherit; }
+}
+
+.ember-power-select-option[aria-current=true] {
+  background-color: #f5f5f5;
+  color: inherit;
+}
 
 .ember-power-select-group-name {
   cursor: default;
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .ember-power-select-trigger[aria-disabled=true] {
-  background-color: #eeeeee; }
+  background-color: #eeeeee;
+}
 
 .ember-power-select-trigger {
-  padding: 0 16px 0 0; }
+  padding: 0 16px 0 0;
+}
 
 .ember-power-select-selected-item, .ember-power-select-placeholder {
-  margin-left: 8px; }
+  margin-left: 8px;
+}
 
 .ember-power-select-status-icon {
-  right: 5px; }
+  right: 5px;
+}
 
 .ember-power-select-clear-btn {
-  right: 25px; }
+  right: 25px;
+}
 
 .ember-power-select-group .ember-power-select-group .ember-power-select-group-name {
-  padding-left: 24px; }
-
+  padding-left: 24px;
+}
 .ember-power-select-group .ember-power-select-group .ember-power-select-option {
-  padding-left: 40px; }
-
+  padding-left: 40px;
+}
 .ember-power-select-group .ember-power-select-option {
-  padding-left: 24px; }
-
+  padding-left: 24px;
+}
 .ember-power-select-group .ember-power-select-group-name {
-  padding-left: 8px; }
+  padding-left: 8px;
+}
 
 .ember-power-select-trigger[dir=rtl] {
-  padding: 0 0 0 16px; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-selected-item, .ember-power-select-trigger[dir=rtl] .ember-power-select-placeholder {
-    margin-right: 8px; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-multiple-option {
-    float: right; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-trigger-multiple-input {
-    float: right; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-status-icon {
-    left: 5px;
-    right: initial; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-clear-btn {
-    left: 25px;
-    right: initial; }
+  padding: 0 0 0 16px;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-selected-item, .ember-power-select-trigger[dir=rtl] .ember-power-select-placeholder {
+  margin-right: 8px;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-multiple-option {
+  float: right;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-trigger-multiple-input {
+  float: right;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-status-icon {
+  left: 5px;
+  right: initial;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-clear-btn {
+  left: 25px;
+  right: initial;
+}
 
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group .ember-power-select-group-name {
-  padding-right: 24px; }
-
+  padding-right: 24px;
+}
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group .ember-power-select-option {
-  padding-right: 40px; }
-
+  padding-right: 40px;
+}
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-option {
-  padding-right: 24px; }
-
+  padding-right: 24px;
+}
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group-name {
-  padding-right: 8px; }
+  padding-right: 8px;
+}

--- a/vendor/ember-power-select-material.css
+++ b/vendor/ember-power-select-material.css
@@ -1,55 +1,72 @@
 @keyframes drop-fade-below {
   0% {
     opacity: 0;
-    transform: translateY(-20px); }
+    transform: translateY(-20px);
+  }
   100% {
     opacity: 1;
-    transform: translateY(3px); } }
-
+    transform: translateY(3px);
+  }
+}
 @keyframes drop-fade-above {
   0% {
     opacity: 0;
-    transform: translateY(20px); }
+    transform: translateY(20px);
+  }
   100% {
     opacity: 1;
-    transform: translateY(-3px); } }
-
+    transform: translateY(-3px);
+  }
+}
 .ember-basic-dropdown-content--below.ember-basic-dropdown--transitioning-in {
-  animation: drop-fade-below .15s; }
+  animation: drop-fade-below 0.15s;
+}
 
 .ember-basic-dropdown-content--below.ember-basic-dropdown--transitioning-out {
-  animation: drop-fade-below .15s reverse; }
+  animation: drop-fade-below 0.15s reverse;
+}
 
 .ember-basic-dropdown-content--above.ember-basic-dropdown--transitioning-in {
-  animation: drop-fade-above .15s; }
+  animation: drop-fade-above 0.15s;
+}
 
 .ember-basic-dropdown-content--above.ember-basic-dropdown--transitioning-out {
-  animation: drop-fade-above .15s reverse; }
+  animation: drop-fade-above 0.15s reverse;
+}
 
 .ember-power-select-placeholder {
   transition: transform 0.2s, color 0.2s;
-  transform-origin: 0 0; }
-  .ember-power-select-trigger--active .ember-power-select-placeholder {
-    transform: scale(0.7) translateY(-10px);
-    color: #106cc8; }
+  transform-origin: 0 0;
+}
+.ember-power-select-trigger--active .ember-power-select-placeholder {
+  transform: scale(0.7) translateY(-10px);
+  color: rgb(16, 108, 200);
+}
 
 .ember-basic-dropdown {
-  position: relative; }
+  position: relative;
+}
 
-.ember-basic-dropdown, .ember-basic-dropdown-content, .ember-basic-dropdown-content * {
-  box-sizing: border-box; }
+.ember-basic-dropdown,
+.ember-basic-dropdown-content,
+.ember-basic-dropdown-content * {
+  box-sizing: border-box;
+}
 
 .ember-basic-dropdown-content {
   position: absolute;
   width: auto;
   z-index: 1000;
-  background-color: #ffffff; }
+  background-color: #ffffff;
+}
 
 .ember-basic-dropdown-content--left {
-  left: 0; }
+  left: 0;
+}
 
 .ember-basic-dropdown-content--right {
-  right: 0; }
+  right: 0;
+}
 
 .ember-basic-dropdown-overlay {
   position: fixed;
@@ -59,13 +76,16 @@
   z-index: 10;
   top: 0;
   left: 0;
-  pointer-events: none; }
+  pointer-events: none;
+}
 
 .ember-basic-dropdown-content-wormhole-origin {
-  display: inline; }
+  display: inline;
+}
 
 .ember-power-select-dropdown * {
-  box-sizing: border-box; }
+  box-sizing: border-box;
+}
 
 .ember-power-select-trigger {
   position: relative;
@@ -82,36 +102,42 @@
   user-select: none;
   -webkit-user-select: none;
   color: inherit;
-  /* Minimum clearfix for modern browsers */ }
-  .ember-power-select-trigger:after {
-    content: "";
-    display: table;
-    clear: both; }
+  /* Minimum clearfix for modern browsers */
+}
+.ember-power-select-trigger:after {
+  content: "";
+  display: table;
+  clear: both;
+}
 
 .ember-power-select-trigger:focus,
 .ember-power-select-trigger--active {
   border-top: none;
-  border-bottom: 2px solid #106cc8;
+  border-bottom: 2px solid rgb(16, 108, 200);
   border-right: none;
   border-left: none;
   box-shadow: none;
-  outline: none; }
+  outline: none;
+}
 
-.ember-basic-dropdown-trigger--below.ember-power-select-trigger[aria-expanded="true"],
-.ember-basic-dropdown-trigger--in-place.ember-power-select-trigger[aria-expanded="true"] {
+.ember-basic-dropdown-trigger--below.ember-power-select-trigger[aria-expanded=true],
+.ember-basic-dropdown-trigger--in-place.ember-power-select-trigger[aria-expanded=true] {
   border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0; }
+  border-bottom-right-radius: 0;
+}
 
-.ember-basic-dropdown-trigger--above.ember-power-select-trigger[aria-expanded="true"] {
+.ember-basic-dropdown-trigger--above.ember-power-select-trigger[aria-expanded=true] {
   border-top-left-radius: 0;
-  border-top-right-radius: 0; }
+  border-top-right-radius: 0;
+}
 
 .ember-power-select-placeholder {
   color: #999999;
   display: block;
   overflow-x: hidden;
   white-space: nowrap;
-  text-overflow: ellipsis; }
+  text-overflow: ellipsis;
+}
 
 .ember-power-select-status-icon {
   position: absolute;
@@ -123,45 +149,57 @@
   margin: auto;
   border-style: solid;
   border-width: 7px 4px 0 4px;
-  border-color: #9e9e9e transparent transparent transparent; }
-  .ember-basic-dropdown-trigger[aria-expanded="true"] .ember-power-select-status-icon {
-    transform: rotate(180deg); }
+  border-color: #9e9e9e transparent transparent transparent;
+}
+.ember-basic-dropdown-trigger[aria-expanded=true] .ember-power-select-status-icon {
+  transform: rotate(180deg);
+}
 
 .ember-power-select-clear-btn {
   position: absolute;
-  cursor: pointer; }
+  cursor: pointer;
+}
+
+.ember-power-select-multiple-options {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+}
 
 .ember-power-select-trigger-multiple-input {
   font-family: inherit;
   font-size: inherit;
   border: none;
-  display: inline-block;
   line-height: inherit;
   -webkit-appearance: none;
   outline: none;
   padding: 0;
-  float: left;
   background-color: transparent;
   text-indent: 2px;
-  /* There's a browser bug where this selectos cannot be chained with commas */ }
-  .ember-power-select-trigger-multiple-input:disabled {
-    background-color: #eeeeee; }
-  .ember-power-select-trigger-multiple-input::placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-webkit-input-placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-moz-placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-ms-input-placeholder {
-    opacity: 1;
-    color: #999999; }
-
-.ember-power-select-multiple-options {
-  padding: 0;
-  margin: 0; }
+  /* There's a browser bug where this selectos cannot be chained with commas */
+}
+.ember-power-select-trigger-multiple-input:disabled {
+  background-color: #eeeeee;
+}
+.ember-power-select-trigger-multiple-input::placeholder {
+  opacity: 1;
+  color: #999999;
+}
+.ember-power-select-trigger-multiple-input::-webkit-input-placeholder {
+  opacity: 1;
+  color: #999999;
+}
+.ember-power-select-trigger-multiple-input::-moz-placeholder {
+  opacity: 1;
+  color: #999999;
+}
+.ember-power-select-trigger-multiple-input::-ms-input-placeholder {
+  opacity: 1;
+  color: #999999;
+}
 
 .ember-power-select-multiple-option {
   border: none;
@@ -169,18 +207,20 @@
   color: #333333;
   background-color: #e4e4e4;
   padding: 0 10px;
-  display: inline-block;
   line-height: 2;
-  float: left;
-  margin: 2px 0 2px 3px; }
+  margin: 2px 0 2px 3px;
+}
 
 .ember-power-select-multiple-remove-btn {
-  cursor: pointer; }
-  .ember-power-select-multiple-remove-btn:not(:hover) {
-    opacity: 0.5; }
+  cursor: pointer;
+}
+.ember-power-select-multiple-remove-btn:not(:hover) {
+  opacity: 0.5;
+}
 
 .ember-power-select-search {
-  padding: 4px; }
+  padding: 4px;
+}
 
 .ember-power-select-search-input {
   border: none;
@@ -188,11 +228,13 @@
   width: 100%;
   font-size: inherit;
   line-height: inherit;
-  padding: 0 5px; }
-  .ember-power-select-search-input:focus {
-    border: none;
-    box-shadow: none;
-    outline: none; }
+  padding: 0 5px;
+}
+.ember-power-select-search-input:focus {
+  border: none;
+  box-shadow: none;
+  outline: none;
+}
 
 .ember-power-select-dropdown {
   border-left: none;
@@ -201,110 +243,134 @@
   border-radius: none;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
   overflow: hidden;
-  color: inherit; }
+  color: inherit;
+}
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--above {
   border-top: none;
   border-bottom: none;
   border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0; }
+  border-bottom-right-radius: 0;
+}
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--below, .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
   border-top: none;
   border-bottom: none;
   border-top-left-radius: 0;
-  border-top-right-radius: 0; }
+  border-top-right-radius: 0;
+}
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
-  width: 100%; }
+  width: 100%;
+}
 
 .ember-power-select-options {
   list-style: none;
   margin: 0;
   padding: 0;
   user-select: none;
-  -webkit-user-select: none; }
-  .ember-power-select-options[role="listbox"] {
-    overflow-y: auto;
-    /* in firefox in windows this can cause a word-break issue. Try `overflow-y: scroll` if that happens */
-    -webkit-overflow-scrolling: touch;
-    max-height: 17.5em; }
+  -webkit-user-select: none;
+}
+.ember-power-select-options[role=listbox] {
+  overflow-y: auto; /* in firefox in windows this can cause a word-break issue. Try `overflow-y: scroll` if that happens */
+  -webkit-overflow-scrolling: touch;
+  max-height: 17.5em;
+}
 
 .ember-power-select-option {
   cursor: pointer;
-  padding: 0 8px; }
+  padding: 0 8px;
+}
 
-.ember-power-select-group[aria-disabled="true"] {
+.ember-power-select-group[aria-disabled=true] {
   color: #999999;
-  cursor: not-allowed; }
+  cursor: not-allowed;
+}
 
-.ember-power-select-group[aria-disabled="true"] .ember-power-select-option,
-.ember-power-select-option[aria-disabled="true"] {
+.ember-power-select-group[aria-disabled=true] .ember-power-select-option,
+.ember-power-select-option[aria-disabled=true] {
   color: #999999;
   pointer-events: none;
-  cursor: not-allowed; }
+  cursor: not-allowed;
+}
 
-.ember-power-select-option[aria-selected="true"] {
-  background-color: #e1e1e1; }
+.ember-power-select-option[aria-selected=true] {
+  background-color: #e1e1e1;
+}
 
-.ember-power-select-option[aria-current="true"] {
+.ember-power-select-option[aria-current=true] {
   background-color: #eee;
-  color: inherit; }
+  color: inherit;
+}
 
 .ember-power-select-group-name {
   cursor: default;
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .ember-power-select-trigger[aria-disabled=true] {
-  background-color: #eeeeee; }
+  background-color: #eeeeee;
+}
 
 .ember-power-select-trigger {
-  padding: 0 16px 0 0; }
+  padding: 0 16px 0 0;
+}
 
 .ember-power-select-selected-item, .ember-power-select-placeholder {
-  margin-left: 8px; }
+  margin-left: 8px;
+}
 
 .ember-power-select-status-icon {
-  right: 5px; }
+  right: 5px;
+}
 
 .ember-power-select-clear-btn {
-  right: 25px; }
+  right: 25px;
+}
 
 .ember-power-select-group .ember-power-select-group .ember-power-select-group-name {
-  padding-left: 24px; }
-
+  padding-left: 24px;
+}
 .ember-power-select-group .ember-power-select-group .ember-power-select-option {
-  padding-left: 40px; }
-
+  padding-left: 40px;
+}
 .ember-power-select-group .ember-power-select-option {
-  padding-left: 24px; }
-
+  padding-left: 24px;
+}
 .ember-power-select-group .ember-power-select-group-name {
-  padding-left: 8px; }
+  padding-left: 8px;
+}
 
 .ember-power-select-trigger[dir=rtl] {
-  padding: 0 0 0 16px; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-selected-item, .ember-power-select-trigger[dir=rtl] .ember-power-select-placeholder {
-    margin-right: 8px; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-multiple-option {
-    float: right; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-trigger-multiple-input {
-    float: right; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-status-icon {
-    left: 5px;
-    right: initial; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-clear-btn {
-    left: 25px;
-    right: initial; }
+  padding: 0 0 0 16px;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-selected-item, .ember-power-select-trigger[dir=rtl] .ember-power-select-placeholder {
+  margin-right: 8px;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-multiple-option {
+  float: right;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-trigger-multiple-input {
+  float: right;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-status-icon {
+  left: 5px;
+  right: initial;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-clear-btn {
+  left: 25px;
+  right: initial;
+}
 
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group .ember-power-select-group-name {
-  padding-right: 24px; }
-
+  padding-right: 24px;
+}
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group .ember-power-select-option {
-  padding-right: 40px; }
-
+  padding-right: 40px;
+}
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-option {
-  padding-right: 24px; }
-
+  padding-right: 24px;
+}
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group-name {
-  padding-right: 8px; }
+  padding-right: 8px;
+}

--- a/vendor/ember-power-select.css
+++ b/vendor/ember-power-select.css
@@ -1,20 +1,27 @@
 .ember-basic-dropdown {
-  position: relative; }
+  position: relative;
+}
 
-.ember-basic-dropdown, .ember-basic-dropdown-content, .ember-basic-dropdown-content * {
-  box-sizing: border-box; }
+.ember-basic-dropdown,
+.ember-basic-dropdown-content,
+.ember-basic-dropdown-content * {
+  box-sizing: border-box;
+}
 
 .ember-basic-dropdown-content {
   position: absolute;
   width: auto;
   z-index: 1000;
-  background-color: #ffffff; }
+  background-color: #ffffff;
+}
 
 .ember-basic-dropdown-content--left {
-  left: 0; }
+  left: 0;
+}
 
 .ember-basic-dropdown-content--right {
-  right: 0; }
+  right: 0;
+}
 
 .ember-basic-dropdown-overlay {
   position: fixed;
@@ -24,13 +31,16 @@
   z-index: 10;
   top: 0;
   left: 0;
-  pointer-events: none; }
+  pointer-events: none;
+}
 
 .ember-basic-dropdown-content-wormhole-origin {
-  display: inline; }
+  display: inline;
+}
 
 .ember-power-select-dropdown * {
-  box-sizing: border-box; }
+  box-sizing: border-box;
+}
 
 .ember-power-select-trigger {
   position: relative;
@@ -47,11 +57,13 @@
   user-select: none;
   -webkit-user-select: none;
   color: inherit;
-  /* Minimum clearfix for modern browsers */ }
-  .ember-power-select-trigger:after {
-    content: "";
-    display: table;
-    clear: both; }
+  /* Minimum clearfix for modern browsers */
+}
+.ember-power-select-trigger:after {
+  content: "";
+  display: table;
+  clear: both;
+}
 
 .ember-power-select-trigger:focus,
 .ember-power-select-trigger--active {
@@ -59,23 +71,27 @@
   border-bottom: 1px solid #aaaaaa;
   border-right: 1px solid #aaaaaa;
   border-left: 1px solid #aaaaaa;
-  box-shadow: none; }
+  box-shadow: none;
+}
 
-.ember-basic-dropdown-trigger--below.ember-power-select-trigger[aria-expanded="true"],
-.ember-basic-dropdown-trigger--in-place.ember-power-select-trigger[aria-expanded="true"] {
+.ember-basic-dropdown-trigger--below.ember-power-select-trigger[aria-expanded=true],
+.ember-basic-dropdown-trigger--in-place.ember-power-select-trigger[aria-expanded=true] {
   border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0; }
+  border-bottom-right-radius: 0;
+}
 
-.ember-basic-dropdown-trigger--above.ember-power-select-trigger[aria-expanded="true"] {
+.ember-basic-dropdown-trigger--above.ember-power-select-trigger[aria-expanded=true] {
   border-top-left-radius: 0;
-  border-top-right-radius: 0; }
+  border-top-right-radius: 0;
+}
 
 .ember-power-select-placeholder {
   color: #999999;
   display: block;
   overflow-x: hidden;
   white-space: nowrap;
-  text-overflow: ellipsis; }
+  text-overflow: ellipsis;
+}
 
 .ember-power-select-status-icon {
   position: absolute;
@@ -87,45 +103,57 @@
   margin: auto;
   border-style: solid;
   border-width: 7px 4px 0 4px;
-  border-color: #aaaaaa transparent transparent transparent; }
-  .ember-basic-dropdown-trigger[aria-expanded="true"] .ember-power-select-status-icon {
-    transform: rotate(180deg); }
+  border-color: #aaaaaa transparent transparent transparent;
+}
+.ember-basic-dropdown-trigger[aria-expanded=true] .ember-power-select-status-icon {
+  transform: rotate(180deg);
+}
 
 .ember-power-select-clear-btn {
   position: absolute;
-  cursor: pointer; }
+  cursor: pointer;
+}
+
+.ember-power-select-multiple-options {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+}
 
 .ember-power-select-trigger-multiple-input {
   font-family: inherit;
   font-size: inherit;
   border: none;
-  display: inline-block;
   line-height: inherit;
   -webkit-appearance: none;
   outline: none;
   padding: 0;
-  float: left;
   background-color: transparent;
   text-indent: 2px;
-  /* There's a browser bug where this selectos cannot be chained with commas */ }
-  .ember-power-select-trigger-multiple-input:disabled {
-    background-color: #eeeeee; }
-  .ember-power-select-trigger-multiple-input::placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-webkit-input-placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-moz-placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-ms-input-placeholder {
-    opacity: 1;
-    color: #999999; }
-
-.ember-power-select-multiple-options {
-  padding: 0;
-  margin: 0; }
+  /* There's a browser bug where this selectos cannot be chained with commas */
+}
+.ember-power-select-trigger-multiple-input:disabled {
+  background-color: #eeeeee;
+}
+.ember-power-select-trigger-multiple-input::placeholder {
+  opacity: 1;
+  color: #999999;
+}
+.ember-power-select-trigger-multiple-input::-webkit-input-placeholder {
+  opacity: 1;
+  color: #999999;
+}
+.ember-power-select-trigger-multiple-input::-moz-placeholder {
+  opacity: 1;
+  color: #999999;
+}
+.ember-power-select-trigger-multiple-input::-ms-input-placeholder {
+  opacity: 1;
+  color: #999999;
+}
 
 .ember-power-select-multiple-option {
   border: 1px solid gray;
@@ -133,18 +161,20 @@
   color: #333333;
   background-color: #e4e4e4;
   padding: 0 4px;
-  display: inline-block;
   line-height: 1.45;
-  float: left;
-  margin: 2px 0 2px 3px; }
+  margin: 2px 0 2px 3px;
+}
 
 .ember-power-select-multiple-remove-btn {
-  cursor: pointer; }
-  .ember-power-select-multiple-remove-btn:not(:hover) {
-    opacity: 0.5; }
+  cursor: pointer;
+}
+.ember-power-select-multiple-remove-btn:not(:hover) {
+  opacity: 0.5;
+}
 
 .ember-power-select-search {
-  padding: 4px; }
+  padding: 4px;
+}
 
 .ember-power-select-search-input {
   border: 1px solid #aaaaaa;
@@ -152,10 +182,12 @@
   width: 100%;
   font-size: inherit;
   line-height: inherit;
-  padding: 0 5px; }
-  .ember-power-select-search-input:focus {
-    border: 1px solid #aaaaaa;
-    box-shadow: none; }
+  padding: 0 5px;
+}
+.ember-power-select-search-input:focus {
+  border: 1px solid #aaaaaa;
+  box-shadow: none;
+}
 
 .ember-power-select-dropdown {
   border-left: 1px solid #aaaaaa;
@@ -164,110 +196,134 @@
   border-radius: 4px;
   box-shadow: none;
   overflow: hidden;
-  color: inherit; }
+  color: inherit;
+}
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--above {
   border-top: 1px solid #aaaaaa;
   border-bottom: none;
   border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0; }
+  border-bottom-right-radius: 0;
+}
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--below, .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
   border-top: none;
   border-bottom: 1px solid #aaaaaa;
   border-top-left-radius: 0;
-  border-top-right-radius: 0; }
+  border-top-right-radius: 0;
+}
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
-  width: 100%; }
+  width: 100%;
+}
 
 .ember-power-select-options {
   list-style: none;
   margin: 0;
   padding: 0;
   user-select: none;
-  -webkit-user-select: none; }
-  .ember-power-select-options[role="listbox"] {
-    overflow-y: auto;
-    /* in firefox in windows this can cause a word-break issue. Try `overflow-y: scroll` if that happens */
-    -webkit-overflow-scrolling: touch;
-    max-height: 12.25em; }
+  -webkit-user-select: none;
+}
+.ember-power-select-options[role=listbox] {
+  overflow-y: auto; /* in firefox in windows this can cause a word-break issue. Try `overflow-y: scroll` if that happens */
+  -webkit-overflow-scrolling: touch;
+  max-height: 12.25em;
+}
 
 .ember-power-select-option {
   cursor: pointer;
-  padding: 0 8px; }
+  padding: 0 8px;
+}
 
-.ember-power-select-group[aria-disabled="true"] {
+.ember-power-select-group[aria-disabled=true] {
   color: #999999;
-  cursor: not-allowed; }
+  cursor: not-allowed;
+}
 
-.ember-power-select-group[aria-disabled="true"] .ember-power-select-option,
-.ember-power-select-option[aria-disabled="true"] {
+.ember-power-select-group[aria-disabled=true] .ember-power-select-option,
+.ember-power-select-option[aria-disabled=true] {
   color: #999999;
   pointer-events: none;
-  cursor: not-allowed; }
+  cursor: not-allowed;
+}
 
-.ember-power-select-option[aria-selected="true"] {
-  background-color: #dddddd; }
+.ember-power-select-option[aria-selected=true] {
+  background-color: #dddddd;
+}
 
-.ember-power-select-option[aria-current="true"] {
+.ember-power-select-option[aria-current=true] {
   background-color: #5897fb;
-  color: #ffffff; }
+  color: #ffffff;
+}
 
 .ember-power-select-group-name {
   cursor: default;
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .ember-power-select-trigger[aria-disabled=true] {
-  background-color: #eeeeee; }
+  background-color: #eeeeee;
+}
 
 .ember-power-select-trigger {
-  padding: 0 16px 0 0; }
+  padding: 0 16px 0 0;
+}
 
 .ember-power-select-selected-item, .ember-power-select-placeholder {
-  margin-left: 8px; }
+  margin-left: 8px;
+}
 
 .ember-power-select-status-icon {
-  right: 5px; }
+  right: 5px;
+}
 
 .ember-power-select-clear-btn {
-  right: 25px; }
+  right: 25px;
+}
 
 .ember-power-select-group .ember-power-select-group .ember-power-select-group-name {
-  padding-left: 24px; }
-
+  padding-left: 24px;
+}
 .ember-power-select-group .ember-power-select-group .ember-power-select-option {
-  padding-left: 40px; }
-
+  padding-left: 40px;
+}
 .ember-power-select-group .ember-power-select-option {
-  padding-left: 24px; }
-
+  padding-left: 24px;
+}
 .ember-power-select-group .ember-power-select-group-name {
-  padding-left: 8px; }
+  padding-left: 8px;
+}
 
 .ember-power-select-trigger[dir=rtl] {
-  padding: 0 0 0 16px; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-selected-item, .ember-power-select-trigger[dir=rtl] .ember-power-select-placeholder {
-    margin-right: 8px; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-multiple-option {
-    float: right; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-trigger-multiple-input {
-    float: right; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-status-icon {
-    left: 5px;
-    right: initial; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-clear-btn {
-    left: 25px;
-    right: initial; }
+  padding: 0 0 0 16px;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-selected-item, .ember-power-select-trigger[dir=rtl] .ember-power-select-placeholder {
+  margin-right: 8px;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-multiple-option {
+  float: right;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-trigger-multiple-input {
+  float: right;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-status-icon {
+  left: 5px;
+  right: initial;
+}
+.ember-power-select-trigger[dir=rtl] .ember-power-select-clear-btn {
+  left: 25px;
+  right: initial;
+}
 
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group .ember-power-select-group-name {
-  padding-right: 24px; }
-
+  padding-right: 24px;
+}
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group .ember-power-select-option {
-  padding-right: 40px; }
-
+  padding-right: 40px;
+}
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-option {
-  padding-right: 24px; }
-
+  padding-right: 24px;
+}
 .ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group-name {
-  padding-right: 8px; }
+  padding-right: 8px;
+}


### PR DESCRIPTION
Fixes #1586 

Used the `compile-css.js` script which is already present. Seems to have also done some formatting changes on existing code, which is not bad but should maybe not have been included in this commit. I'll leave it for now.

Side note: this is a step which should probably be automated in the release process so it's not forgotten. The formatting changes could also be done by prettier, I see it's included as dependency but there seem to be no scripts which use this.