### PR TITLE
fix: Update invalid type imports

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -20,7 +20,7 @@ import {
 } from '../utils/group-utils';
 // @ts-ignore
 import { restartableTask, timeout } from 'ember-concurrency';
-import { Dropdown, DropdownActions } from 'ember-basic-dropdown/addon/components/basic-dropdown';
+import type { Dropdown, DropdownActions } from 'ember-basic-dropdown/components/basic-dropdown';
 
 interface SelectActions extends DropdownActions {
   search: (term: string) => void

--- a/components/power-select.d.ts
+++ b/components/power-select.d.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { MatcherFn } from '../utils/group-utils';
-import { Dropdown, DropdownActions } from 'ember-basic-dropdown/addon/components/basic-dropdown';
+import type { Dropdown, DropdownActions } from 'ember-basic-dropdown/components/basic-dropdown';
 interface SelectActions extends DropdownActions {
     search: (term: string) => void;
     highlight: (option: any) => void;


### PR DESCRIPTION
Copied from https://github.com/cibernox/ember-power-select/pull/1577

> For consumers that end up importing this file, the type declarations don't include `/addon`
> 
> `/addon` ends up working during development time, because the original source is in TS -- but it ends up not being the same as the emitted declarations.

This was also previously fixed in https://github.com/cibernox/ember-power-select/pull/1560 but it seems maybe that was accidentally removed in https://github.com/cibernox/ember-power-select/commit/617cceecc560cd5bb63b575b0ccc66ea4b814e33 ?