### PR TITLE
Avoid chained accessors in `.get()`

### DIFF
--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -48,9 +48,9 @@ export default Component.extend({
       let optionIndex = optionItem.getAttribute('data-option-index');
       action(this._optionFromIndex(optionIndex), e);
     };
-    this.element.addEventListener('mouseup', (e) => findOptionAndPerform(this.get('select.actions.choose'), e));
+    this.element.addEventListener('mouseup', (e) => findOptionAndPerform(this.get('select').actions.choose, e));
     if (this.get('highlightOnHover')) {
-      this.element.addEventListener('mouseover', (e) => findOptionAndPerform(this.get('select.actions.highlight'), e));
+      this.element.addEventListener('mouseover', (e) => findOptionAndPerform(this.get('select').actions.highlight, e));
     }
     if (this.get('isTouchDevice')) {
       this._addTouchEvents();


### PR DESCRIPTION
Ember 3.x deprecated the older style of `.get()` and some chained accessor paths have proven problematic for us.