### PR TITLE
avoid passing arguments to the component `willDestroy`

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -145,7 +145,8 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
       } catch {}
       this._lastSelectedPromise = undefined;
     }
-    super.willDestroy.apply(this, arguments);
+
+    super.willDestroy();
   }
 
   // Getters


### PR DESCRIPTION
fixes #1601

Unfortunately, I didn't manage to make the build fail even by upgrading TS to the latest. However, the change seems reasonable to me, since `willDestroy` isn't supposed to accept any arguments.

<img width="502" alt="Знімок екрана 2023-10-16 о 15 10 14" src="https://github.com/cibernox/ember-power-select/assets/875361/59ec077d-9a94-4e6c-be3a-26bb298119e2">
