### PR TITLE
isSliceable is not working for ember data 3.x hasmany relationships

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -21,6 +21,7 @@ import {
 // @ts-ignore
 import { restartableTask, timeout } from 'ember-concurrency';
 import type { Dropdown, DropdownActions } from 'ember-basic-dropdown/components/basic-dropdown';
+import { isArray } from '@ember/array';
 
 interface SelectActions extends DropdownActions {
   search: (term: string) => void
@@ -90,7 +91,7 @@ export interface PowerSelectArgs {
 }
 
 const isSliceable = <T>(coll: any): coll is Sliceable<T> => {
-  return typeof coll.slice === 'function' && typeof coll.sort === 'function';
+  return isArray(coll);
 }
 
 const isPromiseLike = <T>(thing: any): thing is Promise<T> => {


### PR DESCRIPTION
This commit https://github.com/cibernox/ember-power-select/commit/83720b4d27abb4f04a4527769056e8e8fd23df79  introduced a bug for ED 3.27.X users (or earlier versions I guess, idk). HasMany relationships don't implement `.sort`, I think the idea is just to find out if the thing we are dealing with is an Arrayish, I would favor isArray util... which takes into account other ember array-like things

