### PR TITLE
Use ember-data 3.28 in ember 3.28 test & add ember 5 test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           - ember-lts-4.4
           - ember-lts-4.8
           - ember-lts-4.12
+          - ember-5.4
           - ember-release
           - ember-beta
           - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -14,6 +14,7 @@ module.exports = async function () {
             'ember-source': '~3.28.0',
             '@ember/test-helpers': '^2.9.3',
             'ember-qunit': '^6.2.0',
+            'ember-data': '~3.28.0',
           },
         },
       },
@@ -39,6 +40,15 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
+        name: 'ember-5.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.4.0',
+            'ember-data': '~5.3.0',
           },
         },
       },

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,0 +1,3 @@
+﻿import JSONAPIAdapter from '@ember-data/adapter/json-api';
+
+export default class ApplicationAdapter extends JSONAPIAdapter {}

--- a/tests/integration/components/power-select/ember-data-test.js
+++ b/tests/integration/components/power-select/ember-data-test.js
@@ -41,6 +41,8 @@ module(
           'The loading message appears while the promise is pending'
         );
       await promise;
+      await this.users;
+      await settled();
       assert
         .dom('.ember-power-select-option')
         .exists(
@@ -73,6 +75,8 @@ module(
           'The loading message appears while the promise is pending'
         );
       await promise;
+      await this.users;
+      await settled();
       assert
         .dom('.ember-power-select-option')
         .exists(

--- a/tests/integration/components/power-select/ember-data-test.js
+++ b/tests/integration/components/power-select/ember-data-test.js
@@ -99,6 +99,7 @@ module(
     `);
 
       this.set('users', this.store.findAll('user'));
+      await this.users;
       await settled();
       await click('.ember-power-select-multiple-remove-btn');
       assert
@@ -124,6 +125,7 @@ module(
 
       await clickTrigger();
       await typeInSearch('anything');
+      await settled();
       await click('.ember-power-select-option:nth-child(4)');
       assert
         .dom('.ember-power-select-dropdown')


### PR DESCRIPTION
While we support ember v3.28, we should also test this version with ember-data 3.28 (see https://github.com/cibernox/ember-power-select/pull/1603)

Added also a test for ember 5 (since the LTS release is coming soon)