### PR TITLE
Add missing dependency `@ember/render-modifiers`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "7.1.2",
       "license": "MIT",
       "dependencies": {
+        "@ember/render-modifiers": "^2.1.0",
         "@ember/string": "^3.1.1",
         "@embroider/util": "^1.11.0",
         "@glimmer/component": "^1.1.2",
@@ -2473,6 +2474,28 @@
       },
       "engines": {
         "node": "10.* || 12.* || >= 14"
+      }
+    },
+    "node_modules/@ember/render-modifiers": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-2.1.0.tgz",
+      "integrity": "sha512-LruhfoDv2itpk0fA0IC76Sxjcnq/7BC6txpQo40hOko8Dn6OxwQfxkPIbZGV0Cz7df+iX+VJrcYzNIvlc3w2EQ==",
+      "dependencies": {
+        "@embroider/macros": "^1.0.0",
+        "ember-cli-babel": "^7.26.11",
+        "ember-modifier-manager-polyfill": "^1.2.0"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.2",
+        "ember-source": "^3.8 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ember/string": {
@@ -13319,7 +13342,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
       "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
-      "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.10.0",
         "ember-cli-version-checker": "^2.1.2",
@@ -13333,7 +13355,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
       "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
       "dependencies": {
         "resolve": "^1.3.3",
         "semver": "^5.3.0"
@@ -13346,7 +13367,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -13380,29 +13400,6 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/ember-prism/node_modules/@ember/render-modifiers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-2.1.0.tgz",
-      "integrity": "sha512-LruhfoDv2itpk0fA0IC76Sxjcnq/7BC6txpQo40hOko8Dn6OxwQfxkPIbZGV0Cz7df+iX+VJrcYzNIvlc3w2EQ==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/macros": "^1.0.0",
-        "ember-cli-babel": "^7.26.11",
-        "ember-modifier-manager-polyfill": "^1.2.0"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      },
-      "peerDependencies": {
-        "@glint/template": "^1.0.2",
-        "ember-source": "^3.8 || ^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@glint/template": {
-          "optional": true
-        }
       }
     },
     "node_modules/ember-qunit": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "postpublish": "ember ts:clean"
   },
   "dependencies": {
+    "@ember/render-modifiers": "^2.1.0",
     "@embroider/util": "^1.11.0",
     "@ember/string": "^3.1.1",
     "@glimmer/component": "^1.1.2",


### PR DESCRIPTION
The addon is using `did-insert`/ `did-update` modifiers, but `@ember/render-modifiers` was never added in `dependencies`.

The addons has worked since now only, because other packages like `ember-basic-dropdown` were bringing this dependency (in basic-dropdown v7.3.0 we have dropped the dependency `@ember/render-modifiers`)