### PR TITLE
Remove overrides in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,9 +125,6 @@
   "ember-addon": {
     "configPath": "tests/dummy/config"
   },
-  "overrides": {
-    "ember-source": "$ember-source"
-  },
   "release-it": {
     "plugins": {
       "@release-it-plugins/lerna-changelog": {


### PR DESCRIPTION
A time ago we have added `overrides` in `package.json` because there were some problems with packages....

Now we can remove this line, because it should work also without that line