### PR TITLE
Fix typo in isMultipleWithSearch property name

### DIFF
--- a/addon/components/power-select-multiple/trigger.hbs
+++ b/addon/components/power-select-multiple/trigger.hbs
@@ -76,7 +76,7 @@
           (ensure-safe-component @placeholderComponent)
           select=@select
           placeholder=@placeholder
-          isMutlipleWithSearch=true
+          isMultipleWithSearch=true
           inputComponent=InputComponent
           displayPlaceholder=(and
             (not @select.searchText) (not @select.selected)

--- a/addon/components/power-select/placeholder.hbs
+++ b/addon/components/power-select/placeholder.hbs
@@ -1,4 +1,4 @@
-{{#if @isMutlipleWithSearch}}
+{{#if @isMultipleWithSearch}}
   <@inputComponent @isDefaultPlaceholder={{true}} />
 {{else if @placeholder}}
   <span


### PR DESCRIPTION
I just noticed there's a typo in this property name.