### PR TITLE
types: Separate Args and Signature

### DIFF
--- a/ember-power-select/src/components/power-select-multiple.ts
+++ b/ember-power-select/src/components/power-select-multiple.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { isEqual } from '@ember/utils';
-import type { PowerSelectArgs, Select } from './power-select';
+import type { PowerSelectSignature, Select } from './power-select';
 
-interface PowerSelectMultipleArgs extends PowerSelectArgs {
+interface PowerSelectMultipleSignature extends PowerSelectSignature {
   // any extra property for multiple selects?
 }
 
-export default class PowerSelectMultipleComponent extends Component<PowerSelectMultipleArgs> {
+export default class PowerSelectMultipleComponent extends Component<PowerSelectMultipleSignature> {
   get computedTabIndex() {
     if (this.args.triggerComponent === undefined && this.args.searchEnabled) {
       return '-1';

--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -59,7 +59,6 @@ interface Performable {
 }
 // Some args are not listed here because they are only accessed from the template. Should I list them?
 export interface PowerSelectArgs {
-  Element: HTMLElement;
   highlightOnHover?: boolean;
   placeholderComponent?: string | ComponentLike<any>;
   searchMessage?: string;
@@ -120,6 +119,11 @@ export interface PowerSelectArgs {
   onBlur?: (select: Select, event: FocusEvent) => void;
   scrollTo?: (option: any, select: Select) => void;
   registerAPI?: (select: Select) => void;
+}
+
+export interface PowerSelectSignature {
+  Element: HTMLElement;
+  Args: PowerSelectArgs;
   Blocks: {
     default: [option: any, select: Select];
   };
@@ -143,7 +147,7 @@ const isCancellablePromise = <T>(
   return typeof thing.cancel === 'function';
 };
 
-export default class PowerSelectComponent extends Component<PowerSelectArgs> {
+export default class PowerSelectComponent extends Component<PowerSelectSignature> {
   // Untracked properties
   _publicAPIActions = {
     search: this._search,


### PR DESCRIPTION
If`Element` and `Blocks` is included in the main component interface, `Args` needs its own property.


I had the following glint 2345 error when consuming the PowerSelect component, as it expected Element and Blocks to be passed in as required arguments:

```
NamedArgs<PowerSelectArgs> (…) is missing the following properties from type 'PowerSelectArgs': Element, destination, Blocks glint(2345)
```