### PR TITLE
Define `destination` as optional

### DIFF
--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -69,7 +69,7 @@ export interface PowerSelectArgs {
   matchTriggerWidth?: boolean;
   options: any[] | PromiseProxy<any[]>;
   selected: any | PromiseProxy<any>;
-  destination: string;
+  destination?: string;
   closeOnSelect?: boolean;
   renderInPlace?: boolean;
   preventScroll?: boolean;


### PR DESCRIPTION
As I understand it, `destination` is not required if `renderInPlace` is true