### PR TITLE
Set `args.options` as optional

### DIFF
--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -66,7 +66,7 @@ export interface PowerSelectArgs {
   noMatchesMessage?: string;
   noMatchesMessageComponent?: string | ComponentLike<any>;
   matchTriggerWidth?: boolean;
-  options: any[] | PromiseProxy<any[]>;
+  options?: any[] | PromiseProxy<any[]>;
   selected: any | PromiseProxy<any>;
   destination?: string;
   closeOnSelect?: boolean;


### PR DESCRIPTION
To me, all cases of undefined args.options seems to handled well, so undefined options should not give a glint type error.