### PR TITLE
Set `args.selected` as optional

### DIFF
--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -67,7 +67,7 @@ export interface PowerSelectArgs {
   noMatchesMessageComponent?: string | ComponentLike<any>;
   matchTriggerWidth?: boolean;
   options: any[] | PromiseProxy<any[]>;
-  selected: any | PromiseProxy<any>;
+  selected?: any | PromiseProxy<any>;
   destination?: string;
   closeOnSelect?: boolean;
   renderInPlace?: boolean;


### PR DESCRIPTION
See #1649. All cases of undefined seems to be handled well