### PR TITLE
Improve a11y & make easier to fullfill all requirements out of the box

### DIFF
--- a/docs/app/components/snippets/action-handling-1.hbs
+++ b/docs/app/components/snippets/action-handling-1.hbs
@@ -1,3 +1,3 @@
-<PowerSelect @selected={{this.destination}} @options={{this.cities}} @onChange={{this.chooseDestination}} as |name|>
+<PowerSelect @selected={{this.destination}} @options={{this.cities}} @onChange={{this.chooseDestination}} @labelText="Country" as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/action-handling-2.hbs
+++ b/docs/app/components/snippets/action-handling-2.hbs
@@ -1,3 +1,3 @@
-<PowerSelect @selected={{this.destination}} @options={{this.cities}} @onChange={{fn (mut this.destination)}} as |name|>
+<PowerSelect @selected={{this.destination}} @options={{this.cities}} @onChange={{fn (mut this.destination)}} @labelText="Country" as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/action-handling-3.hbs
+++ b/docs/app/components/snippets/action-handling-3.hbs
@@ -2,6 +2,7 @@
   @selected={{this.selectedCities}}
   @options={{this.cities}}
   @onChange={{fn (mut this.selectedCities)}}
+  @labelText="Country"
   @onKeydown={{this.handleKeydown}} as |name|>
   {{name}}
 </PowerSelectMultiple>

--- a/docs/app/components/snippets/action-handling-4.hbs
+++ b/docs/app/components/snippets/action-handling-4.hbs
@@ -2,6 +2,7 @@
   @selected={{this.selectedCities}}
   @options={{this.cities}}
   @onChange={{fn (mut this.selectedCities)}}
+  @labelText="Country"
   @onInput={{this.checkLength}} as |name|>
   {{name}}
 </PowerSelectMultiple>

--- a/docs/app/components/snippets/action-handling-5.hbs
+++ b/docs/app/components/snippets/action-handling-5.hbs
@@ -6,6 +6,7 @@
   @options={{this.cities}}
   @onChange={{fn (mut this.selected)}}
   @onFocus={{this.handleFocus}}
+  @labelText="Country"
   @onBlur={{this.handleBlur}} as |name|>
   {{name}}
 </PowerSelectMultiple>

--- a/docs/app/components/snippets/action-handling-6.hbs
+++ b/docs/app/components/snippets/action-handling-6.hbs
@@ -6,6 +6,7 @@
     @options={{this.numbers}}
     @onChange={{fn (mut this.number)}}
     @onOpen={{this.startSelfDestroyCountdown}}
+    @labelText="Country"
     @placeholder="Once opened this component will destroy itself in 8 seconds" as |number|>
     {{number}}
   </PowerSelect>

--- a/docs/app/components/snippets/action-handling-7.hbs
+++ b/docs/app/components/snippets/action-handling-7.hbs
@@ -5,6 +5,7 @@
   @dropdownClass={{this.selectClass}}
   @onChange={{fn (mut this.mandatoryNumber)}}
   @onClose={{this.verifyPresence}}
+  @labelText="Country"
   @placeholder={{"I really NEED this info"}} as |number|>
   {{number}}
 </PowerSelect>

--- a/docs/app/components/snippets/create-custom-options-1.hbs
+++ b/docs/app/components/snippets/create-custom-options-1.hbs
@@ -3,6 +3,7 @@
   @selected={{this.selected}}
   @onChange={{fn (mut this.selected)}}
   @searchEnabled={{true}}
+  @labelText="Country"
   @onKeydown={{this.createOnEnter}} as |number|>
   {{number}}
 </PowerSelectMultiple>

--- a/docs/app/components/snippets/custom-search-action-1.hbs
+++ b/docs/app/components/snippets/custom-search-action-1.hbs
@@ -2,6 +2,7 @@
   @searchEnabled={{true}}
   @search={{this.searchRepo}}
   @selected={{this.selected}}
+  @labelText="Repository"
   @onChange={{fn (mut this.selected)}} as |repo|>
   {{repo.full_name}}
 </PowerSelect>

--- a/docs/app/components/snippets/custom-search-action-2.hbs
+++ b/docs/app/components/snippets/custom-search-action-2.hbs
@@ -2,6 +2,7 @@
   @search={{perform this.searchTask}}
   @searchEnabled={{true}}
   @selected={{this.selected}}
+  @labelText="Repository"
   @onChange={{fn (mut this.selected)}} as |repo|>
   {{repo.full_name}}
 </PowerSelect>

--- a/docs/app/components/snippets/debounce-searches-1.hbs
+++ b/docs/app/components/snippets/debounce-searches-1.hbs
@@ -2,6 +2,7 @@
   @search={{this.searchRepo}}
   @selected={{this.selected}}
   @onChange={{fn (mut this.selected)}}
+  @labelText="Repository"
   @searchEnabled={{true}} as |repo|>
   {{repo.full_name}}
 </PowerSelect>

--- a/docs/app/components/snippets/debounce-searches-2.hbs
+++ b/docs/app/components/snippets/debounce-searches-2.hbs
@@ -2,6 +2,7 @@
   @searchEnabled={{true}}
   @search={{perform this.searchRepo}}
   @selected={{this.selected}}
+  @labelText="Repository"
   @onChange={{fn (mut this.selected)}} as |repo|>
   {{repo.full_name}}
 </PowerSelect>

--- a/docs/app/components/snippets/groups-1.hbs
+++ b/docs/app/components/snippets/groups-1.hbs
@@ -2,6 +2,7 @@
   @searchEnabled={{true}}
   @options={{this.groupedNumbers}}
   @selected={{this.number}}
+  @labelText="Number"
   @onChange={{fn (mut this.number)}} as |num|>
   {{num}}
 </PowerSelect>

--- a/docs/app/components/snippets/how-to-use-it-1.hbs
+++ b/docs/app/components/snippets/how-to-use-it-1.hbs
@@ -1,3 +1,3 @@
-<PowerSelect @options={{this.names}} @onChange={{this.foo}} as |name|>
+<PowerSelect @options={{this.names}} @onChange={{this.foo}} @labelText="Names" as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/how-to-use-it-2.hbs
+++ b/docs/app/components/snippets/how-to-use-it-2.hbs
@@ -1,6 +1,7 @@
 <PowerSelect
   @options={{this.countries}}
   @selected={{this.destination}}
+  @labelText="Country"
   @onChange={{this.foo}} as |country|>
   <img src={{country.flagUrl}} class="icon-flag" alt="Flag of {{country.name}}">
   <strong>{{country.name}}</strong>

--- a/docs/app/components/snippets/how-to-use-it-3.hbs
+++ b/docs/app/components/snippets/how-to-use-it-3.hbs
@@ -1,4 +1,4 @@
-<PowerSelect @options={{this.countries}} @selected={{this.destination}} @onChange={{this.foo}} as |country|>
+<PowerSelect @options={{this.countries}} @selected={{this.destination}} @labelText="Country" @onChange={{this.foo}} as |country|>
   <img src={{country.flagUrl}} class="icon-flag" alt="Flag of {{country.name}}">
   <strong>{{country.name}}</strong>
 </PowerSelect>

--- a/docs/app/components/snippets/multiple-selection-1.hbs
+++ b/docs/app/components/snippets/multiple-selection-1.hbs
@@ -2,6 +2,7 @@
   @searchEnabled={{true}}
   @options={{this.names}}
   @selected={{this.name}}
+  @labelText="Name"
   @placeholder="Select some names..."
   @onChange={{fn (mut this.name)}} as |name|>
   {{name}}

--- a/docs/app/components/snippets/the-list-1.hbs
+++ b/docs/app/components/snippets/the-list-1.hbs
@@ -2,6 +2,7 @@
   @options={{this.names}}
   @destination="customized-destination"
   @selected={{this.name123}}
+  @labelText="Name"
   @onChange={{fn (mut this.name123)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-list-10.hbs
+++ b/docs/app/components/snippets/the-list-10.hbs
@@ -2,6 +2,7 @@
   @options={{this.names}}
   @renderInPlace={{true}}
   @selected={{this.name345}}
+  @labelText="Name"
   @onChange={{fn (mut this.name345)}} as |name|>
   {{name}}
   <a href="#" {{on "mouseup" this.stopPropagation}} {{on "click" (fn this.removeName name)}}>&times;</a>

--- a/docs/app/components/snippets/the-list-2.hbs
+++ b/docs/app/components/snippets/the-list-2.hbs
@@ -2,6 +2,7 @@
   @options={{this.names}}
   @renderInPlace={{true}}
   @selected={{this.name}}
+  @labelText="Name"
   @onChange={{fn (mut this.name)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-list-3.hbs
+++ b/docs/app/components/snippets/the-list-3.hbs
@@ -2,6 +2,7 @@
   @options={{this.names}}
   @verticalPosition="above"
   @selected={{this.name}}
+  @labelText="Name"
   @onChange={{fn (mut this.name)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-list-4.hbs
+++ b/docs/app/components/snippets/the-list-4.hbs
@@ -1,6 +1,7 @@
 <PowerSelect
   @options={{this.emptyList}}
   @selected={{this.selected}}
+  @labelText="Name"
   @onChange={{fn (mut this.selected)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-list-5.hbs
+++ b/docs/app/components/snippets/the-list-5.hbs
@@ -2,6 +2,7 @@
   @options={{this.emptyList}}
   @noMatchesMessage="404 bro"
   @selected={{this.selected}}
+  @labelText="Matches message"
   @onChange={{fn (mut this.selected)}}
   as |name|>
   {{name}}

--- a/docs/app/components/snippets/the-list-7.hbs
+++ b/docs/app/components/snippets/the-list-7.hbs
@@ -1,18 +1,19 @@
 <button type="button" {{on "click" this.refreshCollection}}>Refresh collection</button>
 <br>
-Default loading message
 <PowerSelect
   @options={{this.promise}}
   @selected={{this.selected}}
+  @labelText="Default loading message"
   @onChange={{fn (mut this.selected)}} as |name|>
   {{name}}
 </PowerSelect>
 <br>
-Custom loading message (press the <code>Refresh Collection</code> button and open this select)
 <PowerSelect
   @options={{this.promise}}
   @loadingMessage="Waiting for the server...."
   @selected={{this.selected}}
+  @labelText="Custom loading message"
   @onChange={{fn (mut this.selected)}} as |name|>
   {{name}}
 </PowerSelect>
+(press the <code>Refresh Collection</code> button and open this select)

--- a/docs/app/components/snippets/the-list-8.hbs
+++ b/docs/app/components/snippets/the-list-8.hbs
@@ -3,6 +3,7 @@
   @options={{this.countries}}
   @selected={{this.country}}
   @searchField="name"
+  @labelText="Country"
   @onChange={{fn (mut this.country)}}
   as |country|>
   {{country.name}}

--- a/docs/app/components/snippets/the-list-9.hbs
+++ b/docs/app/components/snippets/the-list-9.hbs
@@ -1,6 +1,7 @@
 <PowerSelect
   @options={{this.groupedNumbers}}
   @selected={{this.number}}
+  @labelText="Number"
   @onChange={{fn (mut this.number)}}
   as |num|>
   {{num}}

--- a/docs/app/components/snippets/the-search-1.hbs
+++ b/docs/app/components/snippets/the-search-1.hbs
@@ -2,6 +2,7 @@
   @searchEnabled={{true}}
   @options={{this.diacritics}}
   @selected={{this.selectedDiacritic}}
+  @labelText="Name"
   @onChange={{fn (mut this.selectedDiacritic)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-search-2.hbs
+++ b/docs/app/components/snippets/the-search-2.hbs
@@ -4,6 +4,7 @@
 <PowerSelect
   @options={{this.diacritics}}
   @selected={{this.fellow}}
+  @labelText="Name"
   @onChange={{fn (mut this.fellow)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-search-3.hbs
+++ b/docs/app/components/snippets/the-search-3.hbs
@@ -3,6 +3,7 @@
   @options={{this.countries}}
   @searchField="name"
   @selected={{this.selected}}
+  @labelText="Country"
   @onChange={{fn (mut this.selected)}} as |country|>
   {{country.name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-search-4.hbs
+++ b/docs/app/components/snippets/the-search-4.hbs
@@ -4,6 +4,7 @@
   @searchField="name"
   @selected={{this.selected}}
   @onChange={{fn (mut this.selected)}}
+  @labelText="Country"
   @beforeOptionsComponent={{component "power-select/before-options" autofocus=false}} as |country|>
   {{country.name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-search-5.hbs
+++ b/docs/app/components/snippets/the-search-5.hbs
@@ -3,6 +3,7 @@
   @options={{this.people}}
   @matcher={{this.myMatcher}}
   @selected={{this.selectedPerson}}
+  @labelText="Person"
   @onChange={{fn (mut this.selectedPerson)}} as |person|>
   {{person.name}} {{person.surname}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-search-6.hbs
+++ b/docs/app/components/snippets/the-search-6.hbs
@@ -2,6 +2,7 @@
   @searchEnabled={{true}}
   @options={{this.names}}
   @selected={{this.selectedPersonName}}
+  @labelText="Name"
   @onChange={{fn (mut this.selectedPersonName)}} as |name select|>
   {{highlight-substr name select.lastSearchedText}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-search-7.hbs
+++ b/docs/app/components/snippets/the-search-7.hbs
@@ -3,6 +3,7 @@
   @options={{this.diacritics}}
   @searchPlaceholder="Type to name..."
   @selected={{this.person}}
+  @labelText="Name"
   @onChange={{fn (mut this.person)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-trigger-1.hbs
+++ b/docs/app/components/snippets/the-trigger-1.hbs
@@ -2,6 +2,7 @@
   @options={{this.names}}
   @disabled={{true}}
   @selected={{this.name}}
+  @labelText="Name"
   @onChange={{fn (mut this.name)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-trigger-2.hbs
+++ b/docs/app/components/snippets/the-trigger-2.hbs
@@ -4,6 +4,7 @@
   @selected={{this.country}}
   @selectedItemComponent={{component "selected-item-country"}}
   @searchField="name"
+  @labelText="Country"
   @onChange={{fn (mut this.country)}}
   as |country|>
   <div class="country-detailed-info">

--- a/docs/app/components/snippets/the-trigger-3.hbs
+++ b/docs/app/components/snippets/the-trigger-3.hbs
@@ -4,6 +4,7 @@
   @placeholder="Please, select one destination"
   @selected={{this.selected}}
   @searchField="name"
+  @labelText="Destination"
   @onChange={{fn (mut this.selected)}} as |country|>
   {{country.name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-trigger-4.hbs
+++ b/docs/app/components/snippets/the-trigger-4.hbs
@@ -2,6 +2,7 @@
   @options={{this.names}}
   @selected={{this.aName}}
   @placeholderComponent={{component "weird-placeholder"}}
+  @labelText="Name"
   @onChange={{fn (mut this.aName)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/components/snippets/the-trigger-5.hbs
+++ b/docs/app/components/snippets/the-trigger-5.hbs
@@ -2,6 +2,7 @@
   @options={{this.names}}
   @selected={{this.name}}
   @allowClear={{true}}
+  @labelText="Name"
   @onChange={{fn (mut this.name)}} as |name|>
   {{name}}
 </PowerSelect>

--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Ember Power Select</title>

--- a/docs/app/styles/_base.scss
+++ b/docs/app/styles/_base.scss
@@ -42,7 +42,7 @@ h2 {
   margin-top: 1rem;
   font-size: 1.5rem;
 }
-h3 {
+h3, .t3 {
   margin-top: 1.5rem;
   font-size: 1.25rem;
 }

--- a/docs/app/styles/_variables.scss
+++ b/docs/app/styles/_variables.scss
@@ -43,7 +43,12 @@ $brand-color-brighter: #FD6868;
 $link-color: $brand-color;
 
 $light-gray: #ddd;
-$gray: #888;
+$gray: #5f5f5f;
+$link-gray: #200101;
 
 // Paddings
 $wrapper-padding: 0.5rem;
+
+// Override colors for accessibility and set opacity
+$ember-power-select-placeholder-color: #333 !default;
+$ember-power-select-disabled-option-color: #333 !default;

--- a/docs/app/styles/components/docs.scss
+++ b/docs/app/styles/components/docs.scss
@@ -62,3 +62,7 @@
     border-bottom: 1px solid red;
   }
 }
+
+.ember-power-select-placeholder {
+  opacity: 0.8 !important;
+}

--- a/docs/app/styles/components/docs.scss
+++ b/docs/app/styles/components/docs.scss
@@ -30,8 +30,10 @@
 .doc-page-nav-link-prev {
   float: left;
 }
-.section-selector {
-  margin-bottom: 1rem;
+.doc-submenu {
+  .section-selector {
+    margin-bottom: 1rem;
+  }
   @media only screen and (min-width: $medium-breakpoint) {
     display: none;
   }

--- a/docs/app/styles/components/index.scss
+++ b/docs/app/styles/components/index.scss
@@ -46,7 +46,7 @@
   margin: 25px auto;
 }
 .selling-point-code {
-  color: #CCC;
+  color: #858585;
   padding: 0;
   font-size: 25px;
   font-family: monospace;

--- a/docs/app/styles/components/main-footer.scss
+++ b/docs/app/styles/components/main-footer.scss
@@ -5,6 +5,10 @@
   border-top: 1px solid #bbb;
   padding-left: 1rem;
   padding-right: 1rem;
+
+  a {
+    color: $link-gray;
+  }
 }
 .main-footer-content {
   @extend %wrapper;

--- a/docs/app/styles/components/side-nav.scss
+++ b/docs/app/styles/components/side-nav.scss
@@ -1,4 +1,4 @@
-$side-nav-color: #777;
+$side-nav-color: #343434;
 .side-nav {
   width: 200px;
   color: $side-nav-color;
@@ -10,8 +10,8 @@ $side-nav-color: #777;
 }
 .side-nav-header {
   font-size: 18px;
-  font-weight: 300;
-  color: #777;
+  font-weight: 400;
+  color: #343434;
   margin-bottom: 10px;
   border-bottom: 1px solid rgba(153, 153, 153, 0.2);
   &:not(:first-child) {
@@ -20,7 +20,7 @@ $side-nav-color: #777;
 }
 .side-nav-link {
   display: block;
-  color: #999;
+  color: #686868;
   padding-left: 16px;
   .beta-label {
     color: white;

--- a/docs/app/styles/docs/code-example.scss
+++ b/docs/app/styles/docs/code-example.scss
@@ -11,7 +11,7 @@
   background-color: white;
   text-transform: capitalize;
   &:not(.active) {
-    color: #999;
+    color: #707070;
     cursor: pointer;
   }
   &.active {

--- a/docs/app/templates/playground.hbs
+++ b/docs/app/templates/playground.hbs
@@ -5,17 +5,19 @@
   @selected={{this.selected}}
   @onChange={{fn (mut this.selected)}}
   @search={{this.searchUsers}}
+  @labelText="User"
   @searchEnabled={{true}}
   as |user|>
   {{user.name}}
 </PowerSelect>
 
-<h3>Multiple select inside a form</h3>
+<h2 class="t3">Multiple select inside a form</h2>
 <form action="/nonexistent">
   <PowerSelectMultiple
     @options={{this.cities}}
     @selected={{this.chosenCities}}
     @onChange={{fn (mut this.chosenCities)}}
+    @labelText="Country"
     @searchEnabled={{true}} as |city|>
     {{city}}
   </PowerSelectMultiple>

--- a/docs/app/templates/public-pages.hbs
+++ b/docs/app/templates/public-pages.hbs
@@ -7,7 +7,7 @@
       <a href="https://github.com/cibernox/ember-power-select" class="main-header-nav-link">Github</a>
     </div>
     <div class="main-header-logo">
-      <LinkTo @route="public-pages.index" class="home-link">
+      <LinkTo @route="public-pages.index" class="home-link" id="home-link">
         <img src="/ember_logo.png" alt="ember">
       </LinkTo>
       <div class="main-header-select">
@@ -17,6 +17,7 @@
           @disabled={{this.disabled}}
           @triggerComponent={{component "main-header-select-trigger"}}
           @onChange={{this.changeOptions}}
+          @ariaLabelledBy="home-link"
           @dropdownClass="main-header-select-dropdown" as |opt|>
           {{opt}}
         </PowerSelect>
@@ -27,9 +28,6 @@
 <div class="main-content">
   {{outlet}}
 </div>
-<aside class="link-to-other-version">
-  This is the documentation for version 3.X of the addon. If you are looking for version 2.X you can find the docs <a href="https://2-x.ember-power-select.com">here</a>
-</aside>
 <footer class="main-footer">
   <div class="main-footer-content">
     Deployed with love by <a href="http://github.com/cibernox">Miguel Camba</a>

--- a/docs/app/templates/public-pages/cookbook.hbs
+++ b/docs/app/templates/public-pages/cookbook.hbs
@@ -11,9 +11,11 @@
     <LinkTo @route="public-pages.cookbook.navigable-select" class="side-nav-link">Navigable select</LinkTo> --}}
   </nav>
   <section class="doc-page">
-    <PowerSelect @selected={{this.currentSection}} @options={{this.groupedSections}} @onChange={{this.visit}} @searchField="text" @triggerClass="section-selector" as |option|>
-      {{option.text}}
-    </PowerSelect>
+    <div class="doc-submenu">
+      <PowerSelect @selected={{this.currentSection}} @options={{this.groupedSections}} @onChange={{this.visit}} @labelText="Submenu" @searchField="text" @triggerClass="section-selector" as |option|>
+        {{option.text}}
+      </PowerSelect>
+    </div>
     {{outlet}}
   </section>
 </section>

--- a/docs/app/templates/public-pages/cookbook/debounce-searches.hbs
+++ b/docs/app/templates/public-pages/cookbook/debounce-searches.hbs
@@ -24,7 +24,7 @@
   It makes you code a little more but in exchange you always have the ultimate decision.
 </p>
 
-<h3>Debouncing searches with ember-concurrency</h3>
+<h2 class="t3">Debouncing searches with ember-concurrency</h2>
 
 <p>
   Ember Power Select uses <a href="https://ember-concurrency.com/docs/introduction/">ember-concurrency</a>

--- a/docs/app/templates/public-pages/cookbook/material-theme.hbs
+++ b/docs/app/templates/public-pages/cookbook/material-theme.hbs
@@ -10,7 +10,7 @@
   <CodeSnippet @name="material-theme-1.scss" />
 </div>
 
-<h3>Regular selects without search</h3>
+<h2 class="t3">Regular selects without search</h2>
 <div style="display: flex;">
   <div style="flex: 1; padding: 5px;">
     <PowerSelect
@@ -42,7 +42,7 @@
   </div>
 </div>
 
-<h3>Regular selects with search</h3>
+<h2 class="t3">Regular selects with search</h2>
 <PowerSelect
   @triggerClass="material-theme-trigger"
   @dropdownClass="material-theme-dropdown"
@@ -57,7 +57,7 @@
   {{country.name}}
 </PowerSelect>
 
-<h3>Multiple selects with search</h3>
+<h2 class="t3">Multiple selects with search</h2>
 <PowerSelectMultiple
   @triggerClass="material-theme-trigger"
   @dropdownClass="material-theme-dropdown"
@@ -71,7 +71,7 @@
 >
   {{country.name}}
 </PowerSelectMultiple>
-<h3>Groups</h3>
+<h2 class="t3">Groups</h2>
 <PowerSelect
   @triggerClass="material-theme-trigger"
   @dropdownClass="material-theme-dropdown"
@@ -84,7 +84,7 @@
   {{num}}
 </PowerSelect>
 
-<h3>Select with clear btn</h3>
+<h2 class="t3">Select with clear btn</h2>
 <PowerSelect
   @triggerClass="material-theme-trigger"
   @dropdownClass="material-theme-dropdown"

--- a/docs/app/templates/public-pages/docs.hbs
+++ b/docs/app/templates/public-pages/docs.hbs
@@ -27,9 +27,11 @@
     <LinkTo @route="public-pages.docs.api-reference" class="side-nav-link">API reference</LinkTo>
   </nav>
   <section class="doc-page">
-    <PowerSelect @selected={{this.currentSection}} @options={{this.groupedSections}} @onChange={{this.visit}} @searchField="text" @triggerClass="section-selector" as |option|>
-      {{option.text}}
-    </PowerSelect>
+    <div class="doc-submenu">
+      <PowerSelect @selected={{this.currentSection}} @options={{this.groupedSections}} @onChange={{this.visit}} @searchField="text" @labelText="Submenu" @triggerClass="section-selector" as |option|>
+        {{option.text}}
+      </PowerSelect>
+    </div>
     {{outlet}}
   </section>
 </section>

--- a/docs/app/templates/public-pages/docs/action-handling.hbs
+++ b/docs/app/templates/public-pages/docs/action-handling.hbs
@@ -17,7 +17,7 @@
   can do with each of them.
 </p>
 
-<h3><code>onChange</code> Action</h3>
+<h2 class="t3"><code>onChange</code> Action</h2>
 
 <p>
   This action will fire whenever an option of the component is selected or unselected.
@@ -49,7 +49,7 @@
   very tricky to implement.
 </p>
 
-<h3><code>onKeydown</code> Action</h3>
+<h2 class="t3"><code>onKeydown</code> Action</h2>
 
 <p>
   The second option you can provide to the component to customize it's behavior is <code>onKeydown</code>.
@@ -75,7 +75,7 @@
   {{component (ensure-safe-component this.actionHandling3)}}
 </CodeExample>
 
-<h3><code>onInput</code> Action</h3>
+<h2 class="t3"><code>onInput</code> Action</h2>
 
 <p>
   Selects might have searchboxes. When you type on them you usually want to search, which is the default behaviour,
@@ -97,7 +97,7 @@
   {{component (ensure-safe-component this.actionHandling4)}}
 </CodeExample>
 
-<h3><code>onFocus/onBlur</code> Actions</h3>
+<h2 class="t3"><code>onFocus/onBlur</code> Actions</h2>
 
 <p>
   The next actions you can use are <code>onFocus/onBlur</code>. It does exactly what the names suggests and receives <code>(select, event)</code>
@@ -119,7 +119,7 @@
   to know the element that had the focus before.
 </p>
 
-<h3><code>onOpen/onClose</code> Actions</h3>
+<h2 class="t3"><code>onOpen/onClose</code> Actions</h2>
 
 <p>
   As their names suggest, these actions are fired when the component is about to be opened or closed respectively,

--- a/docs/app/templates/public-pages/docs/api-reference.hbs
+++ b/docs/app/templates/public-pages/docs/api-reference.hbs
@@ -22,6 +22,26 @@
       <td>When truthy, single selects allow to nullify the selection</td>
     </tr>
     <tr>
+      <td>labelText</td>
+      <td><code>string</code></td>
+      <td>Adds a <code>&lt;label&gt;</code> for the select field. The benefit to use this is, that <code>aria-*</code> attributes are already automatically correct like defined by <a href="https://www.w3.org/TR/wai-aria-1.2/" target="_blank" rel="noopener noreferrer">1.2 specs</a></td>
+    </tr>
+    <tr>
+      <td>labelClass</td>
+      <td><code>string</code></td>
+      <td>Adds custom class on the <code>&lt;label&gt;</code> tag</td>
+    </tr>
+    <tr>
+      <td>labelClickAction</td>
+      <td><code>string</code></td>
+      <td>Action which should be happen by clicking on label. Possible values: 'focus' or 'open'. Default is focus</td>
+    </tr>
+    <tr>
+      <td>labelComponent</td>
+      <td><code>string/contextual-component</code></td>
+      <td>Overrides the default label component</td>
+    </tr>
+    <tr>
       <td>animationEnabled</td>
       <td><code>boolean</code></td>
       <td>Flag to determine whether the content will allow CSS animations. Defaults to true</td>
@@ -171,6 +191,11 @@
       <td>noMatchesMessageComponent</td>
       <td><code>string</code></td>
       <td>The component to render instead of the default one around the no matches message.</td>
+    </tr>
+    <tr>
+      <td>resultCountMessage</td>
+      <td><code>function</code></td>
+      <td>This text is only for readers. For example '10 results'. The function is passing the count as number. Consumer should return a string</td>
     </tr>
     <tr>
       <td>onBlur</td>

--- a/docs/app/templates/public-pages/docs/architecture.hbs
+++ b/docs/app/templates/public-pages/docs/architecture.hbs
@@ -5,7 +5,7 @@
   It is also a showcase of how I think Ember components should be architectured to maximize their reusablity.
 </p>
 
-<h3>The Ember 2 Way ™</h3>
+<h2 class="t3">The Ember 2 Way ™</h2>
 
 <p>
   In plain English, it means that this component follows the "data down - actions up" design guidelines also known as DDAU.
@@ -15,7 +15,7 @@
   </ul>
 </p>
 
-<h3>Built with composition</h3>
+<h2 class="t3">Built with composition</h2>
 
 <p>
   Ember Power Select is built by combining existing addons/components. Each one of them focused on one simple task
@@ -43,7 +43,7 @@
   <p class="text-center">\{{#-in-element}}</p>
 </article>
 
-<h3>Built for composability</h3>
+<h2 class="t3">Built for composability</h2>
 
 <p>
   Ember Power Select is built as a simple skeleton that exposes some "holes" to be filled with
@@ -66,7 +66,7 @@
 
 <img src="/EPS_disected.png" alt="dissection of Ember Power Select">
 
-<h3>Leave the last word to the end user</h3>
+<h2 class="t3">Leave the last word to the end user</h2>
 
 <p>
   Actions exposed by the component take as little for granted as possible, and is up to you to

--- a/docs/app/templates/public-pages/docs/custom-search-action.hbs
+++ b/docs/app/templates/public-pages/docs/custom-search-action.hbs
@@ -40,7 +40,7 @@
   {{component (ensure-safe-component this.customSearchAction1)}}
 </CodeExample>
 
-<h3>Handling of thenables and cancellables (p.e. ember-concurrecy)</h3>
+<h2 class="t3">Handling of thenables and cancellables (p.e. ember-concurrecy)</h2>
 
 <p>
   It's also worth mentioning that Ember Power Select is smart enough to always prioritize the last request made,

--- a/docs/app/templates/public-pages/docs/installation.hbs
+++ b/docs/app/templates/public-pages/docs/installation.hbs
@@ -18,10 +18,10 @@
   The addon is using internal ember-concurrency. ember-concurrency needs some manual steps. For this steps see <a href="http://ember-concurrency.com/docs/installation" target="_blank" rel="noopener noreferrer">ember-concurrency</a> -> <i>"Configure Babel Transform"</i> on installation page.
 </p>
 
-<h3>Manual installation</h3>
+<h2 class="t3">Manual installation</h2>
 
 <p>
-  If you don't have used <code>ember install</code> you need to add <code>ember-basic-dropdown</code> and <code>ember-concurrency</code> as <code>devDependencies</code> in <code>package.json</code>. 
+  If you don't have used <code>ember install</code> you need to add <code>ember-basic-dropdown</code> and <code>ember-concurrency</code> as <code>devDependencies</code> in <code>package.json</code>.
 </p>
 
 <p>

--- a/docs/app/templates/public-pages/docs/roll-your-own-template.hbs
+++ b/docs/app/templates/public-pages/docs/roll-your-own-template.hbs
@@ -1,2 +1,2 @@
-<h3>roll-your-own-template</h3>
+<h2 class="t3">roll-your-own-template</h2>
 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Excepturi dolores vero saepe non, obcaecati consequuntur sint ipsum similique nam debitis nobis illo officiis quod aspernatur aliquid, totam quo blanditiis reiciendis.

--- a/docs/app/templates/public-pages/docs/test-helpers.hbs
+++ b/docs/app/templates/public-pages/docs/test-helpers.hbs
@@ -27,7 +27,7 @@
 
 <CodeSnippet @name="test-helpers-10-js.js"/>
 
-<h3><code>selectChoose(cssPath, optionTextOrOptionSelector, index?)</code></h3>
+<h2 class="t3"><code>selectChoose(cssPath, optionTextOrOptionSelector, index?)</code></h2>
 
 <p>
   This async helper allows you to select an option of a select by it's text, without worrying about
@@ -41,7 +41,7 @@ convenient:
 
 <CodeSnippet @name="test-helpers-3-js.js"/>
 
-<h3><code>selectSearch(cssPath, searchText)</code></h3>
+<h2 class="t3"><code>selectSearch(cssPath, searchText)</code></h2>
 
 <p>
   Use this helper to perform a search on a single/multiple select. You probably will use it in
@@ -50,7 +50,7 @@ convenient:
 
 <CodeSnippet @name="test-helpers-4-js.js"/>
 
-<h3><code>removeMultipleOption(cssPath, optionText)</code></h3>
+<h2 class="t3"><code>removeMultipleOption(cssPath, optionText)</code></h2>
 
 <p>
   Use this helper to remove an option from a multiple select.
@@ -58,7 +58,7 @@ convenient:
 
 <CodeSnippet @name="test-helpers-5-js.js"/>
 
-<h3><code>clearSelected(cssPath, optionText)</code></h3>
+<h2 class="t3"><code>clearSelected(cssPath, optionText)</code></h2>
 
 <p>
   Use this helper to remove an option from a single select when allowClear is set to true.
@@ -83,7 +83,7 @@ convenient:
 </p>
 <p><code>import { typeInSearch, clickTrigger } from 'my-app/tests/helpers/test-helpers'</code></p>
 
-<h3><code>clickTrigger(scope, options = {})</code></h3>
+<h2 class="t3"><code>clickTrigger(scope, options = {})</code></h2>
 
 <p>
   This helper opens the dropdown based on the class name (scope) defined on the power select. Scope is optional if integration test renders only one power select.
@@ -91,7 +91,7 @@ convenient:
 
 <CodeSnippet @name="test-helpers-7-js.js"/>
 
-<h3><code>typeInSearch(text)</code></h3>
+<h2 class="t3"><code>typeInSearch(text)</code></h2>
 
 <p>
   This helper is used in conjunction with opening a power select dropdown as long as search is not disabled.
@@ -99,7 +99,7 @@ convenient:
 
 <CodeSnippet @name="test-helpers-8-js.js"/>
 
-<h3><code>selectChoose(text)</code></h3>
+<h2 class="t3"><code>selectChoose(text)</code></h2>
 
 <p>
   Much like the acceptance one, this integration tests takes care of the entire process of opening

--- a/docs/app/templates/public-pages/docs/the-list.hbs
+++ b/docs/app/templates/public-pages/docs/the-list.hbs
@@ -4,7 +4,7 @@
   If there's a key area of the component that must be absolutely customizable, it's the dropdown with the list. This is probably the most dense chapter so far so we recommend that you read it cover to cover.
 </p>
 
-<h3>Position and destination</h3>
+<h2 class="t3">Position and destination</h2>
 
 <p>
   The dropdown in Ember Power Select is pretty smart. By default this component inserts the dropdown
@@ -68,7 +68,7 @@
   {{component (ensure-safe-component this.theList3)}}
 </CodeExample>
 
-<h3>The empty state</h3>
+<h2 class="t3">The empty state</h2>
 
 <p>
   What happens when the collection you pass to the component is empty?
@@ -97,7 +97,7 @@
   {{component (ensure-safe-component this.theList6)}}
 </CodeExample> --}}
 
-<h3>The loading state</h3>
+<h2 class="t3">The loading state</h2>
 
 <p>
   In the first chapter we mentioned that the options of this component can be any collection,
@@ -118,7 +118,7 @@
   {{component (ensure-safe-component this.theList7)}}
 </CodeExample>
 
-<h3>Disabling specific options or groups</h3>
+<h2 class="t3">Disabling specific options or groups</h2>
 
 <p>
   In <LinkTo @route="public-pages.docs.the-trigger" class="doc-page-nav-link-prev">The trigger</LinkTo> we saw how to disable the entire component,
@@ -149,7 +149,7 @@
   This is because it deserves an entire chapter of its own.
 </p>
 
-<h3>Prevent click propagation inside the list</h3>
+<h2 class="t3">Prevent click propagation inside the list</h2>
 
 <p>
  The options inside the list are selected with mousedown, a good way to prevent the selection is intercepting <code>mouseup</code> and calling <code>stopPropagation</code> on the event.

--- a/docs/app/templates/public-pages/docs/the-search.hbs
+++ b/docs/app/templates/public-pages/docs/the-search.hbs
@@ -1,6 +1,6 @@
 <h1 class="doc-page-title">The search</h1>
 
-<h3>The default behavior</h3>
+<h2 class="t3">The default behavior</h2>
 
 <p>
   The default select has no searchbox, but you can pass <code>@searchEnabled={{true}}</code> to enable a search that is surprisingly smart.
@@ -25,7 +25,7 @@
   {{component (ensure-safe-component this.theSearch2)}}
 </CodeExample>
 
-<h3>Customize the search field</h3>
+<h2 class="t3">Customize the search field</h2>
 
 <p>
   The default search works great when your options are just strings but when your options are
@@ -46,7 +46,7 @@
   the focus.
 </p>
 
-<h3>Prevent autofocus</h3>
+<h2 class="t3">Prevent autofocus</h2>
 
 <p>
   Sometimes you want to disable the default behavior of the search box,
@@ -57,7 +57,7 @@
 <CodeExample @hbs="the-search-4.hbs" @js="the-search-4.js">
   {{component (ensure-safe-component this.theSearch4)}}
 </CodeExample>
-<h3>Pass a custom matcher</h3>
+<h2 class="t3">Pass a custom matcher</h2>
 
 <p>
   Sometimes the default matcher is not enough for you, for example if you need to match against several
@@ -75,7 +75,7 @@
   the focus.
 </p>
 
-<h3>Using the search term inside the block</h3>
+<h2 class="t3">Using the search term inside the block</h2>
 
 <p>
   Is very common to need the search term from withing the block used to render each one of the options,
@@ -108,7 +108,7 @@
   </li>
 </ul>
 
-<h3>Search box placeholder</h3>
+<h2 class="t3">Search box placeholder</h2>
 
 <p>Pass <code>searchPlaceholder="Type your name..."</code> to show a placeholder in the search box</p>
 

--- a/docs/app/templates/public-pages/docs/the-trigger.hbs
+++ b/docs/app/templates/public-pages/docs/the-trigger.hbs
@@ -6,7 +6,7 @@
   many ways.
 </p>
 
-<h3>Disable the component</h3>
+<h2 class="t3">Disable the component</h2>
 
 <p>
   You can completely disable the trigger (and therefore the entire component) by passing
@@ -17,7 +17,7 @@
   {{component (ensure-safe-component this.theTrigger1)}}
 </CodeExample>
 
-<h3>The selected option</h3>
+<h2 class="t3">The selected option</h2>
 
 <p>
   As we saw in the <LinkTo @route="public-pages.docs.how-to-use-it">How to use it</LinkTo> section, Ember Power Select
@@ -39,7 +39,7 @@
   {{component (ensure-safe-component this.theTrigger2)}}
 </CodeExample>
 
-<h3>Set a placeholder</h3>
+<h2 class="t3">Set a placeholder</h2>
 
 <p>
   If you pass <code>placeholder="Some text"</code> to the component that message will be displayed
@@ -54,7 +54,7 @@ Take into account that in the multiple selects with search enabled, the trigger 
 and you should use the <code>searchPlaceholder</code> option instead. Check <LinkTo @route="public-pages.docs.the-search">The search</LinkTo>
 section for more info.
 
-<h3>Set a complex placeholder</h3>
+<h2 class="t3">Set a complex placeholder</h2>
 
 <p>
   Sometimes a simple string as placeholder is not enough and you want bold text, icons and such. In
@@ -70,7 +70,7 @@ section for more info.
   your component the placeholder text will be available.
 </p>
 
-<h3>Clear button</h3>
+<h2 class="t3">Clear button</h2>
 
 <p>
   Sometimes you want to allow the users to clear the selection they just made. Regular selects

--- a/docs/app/templates/public-pages/docs/troubleshooting.hbs
+++ b/docs/app/templates/public-pages/docs/troubleshooting.hbs
@@ -1,6 +1,6 @@
 <h1 class="doc-page-title">Troubleshooting</h1>
 
-<h3>The options are not visible in modals</h3>
+<h2 class="t3">The options are not visible in modals</h2>
 
 <p>
   The list of options in ember-power-select has by default <code>z-index: 1000</code>. This apparently
@@ -30,7 +30,7 @@
   </li>
 </ol>
 
-<h3>Nothing is rendered when I click the select</h3>
+<h2 class="t3">Nothing is rendered when I click the select</h2>
 
 <p>
   The addon is based on <a href="https://ember-basic-dropdown.com/">ember-basic-dropdown</a>.

--- a/ember-power-select/less/base.less
+++ b/ember-power-select/less/base.less
@@ -274,6 +274,13 @@
   }
 }
 
+.ember-power-select-visually-hidden {
+  height: 1px;
+  left: -9999px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
 
 .ember-power-select-dropdown[dir=rtl] {
   .ember-power-select-group {

--- a/ember-power-select/less/base.less
+++ b/ember-power-select/less/base.less
@@ -77,11 +77,11 @@
   flex-wrap: wrap;
   align-items: center;
   list-style: none;
-  
+
   & li.ember-power-select-trigger-multiple-input-container {
     flex-grow: 1;
     display: flex;
-    
+
     & input {
       flex-grow: 1;
     }

--- a/ember-power-select/package.json
+++ b/ember-power-select/package.json
@@ -163,6 +163,7 @@
       "./components/power-select-multiple/trigger.js": "./dist/_app_/components/power-select-multiple/trigger.js",
       "./components/power-select.js": "./dist/_app_/components/power-select.js",
       "./components/power-select/before-options.js": "./dist/_app_/components/power-select/before-options.js",
+      "./components/power-select/label.js": "./dist/_app_/components/power-select/label.js",
       "./components/power-select/no-matches-message.js": "./dist/_app_/components/power-select/no-matches-message.js",
       "./components/power-select/options.js": "./dist/_app_/components/power-select/options.js",
       "./components/power-select/placeholder.js": "./dist/_app_/components/power-select/placeholder.js",

--- a/ember-power-select/scss/base.scss
+++ b/ember-power-select/scss/base.scss
@@ -80,11 +80,11 @@
   flex-wrap: wrap;
   align-items: center;
   list-style: none;
-  
+
   & li.ember-power-select-trigger-multiple-input-container {
     flex-grow: 1;
     display: flex;
-    
+
     & input {
       flex-grow: 1;
     }

--- a/ember-power-select/scss/base.scss
+++ b/ember-power-select/scss/base.scss
@@ -281,6 +281,13 @@
   }
 }
 
+.ember-power-select-visually-hidden {
+  height: 1px;
+  left: -9999px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
 
 .ember-power-select-dropdown[dir=rtl] {
   .ember-power-select-group {

--- a/ember-power-select/src/components/power-select-multiple.hbs
+++ b/ember-power-select/src/components/power-select-multiple.hbs
@@ -8,6 +8,7 @@
   @labelClass={{@labelClass}}
   @labelText={{@labelText}}
   @labelClickAction={{@labelClickAction}}
+  @labelComponent={{ensure-safe-component @labelComponent}}
   @afterOptionsComponent={{ensure-safe-component @afterOptionsComponent}}
   @allowClear={{@allowClear}}
   @beforeOptionsComponent={{if @beforeOptionsComponent (ensure-safe-component @beforeOptionsComponent) null}}

--- a/ember-power-select/src/components/power-select-multiple.hbs
+++ b/ember-power-select/src/components/power-select-multiple.hbs
@@ -5,6 +5,9 @@
   @ariaInvalid={{@ariaInvalid}}
   @ariaLabel={{@ariaLabel}}
   @ariaLabelledBy={{@ariaLabelledBy}}
+  @labelClass={{@labelClass}}
+  @labelText={{@labelText}}
+  @labelClickAction={{@labelClickAction}}
   @afterOptionsComponent={{ensure-safe-component @afterOptionsComponent}}
   @allowClear={{@allowClear}}
   @beforeOptionsComponent={{if @beforeOptionsComponent (ensure-safe-component @beforeOptionsComponent) null}}

--- a/ember-power-select/src/components/power-select-multiple/input.hbs
+++ b/ember-power-select/src/components/power-select-multiple/input.hbs
@@ -12,9 +12,13 @@
   spellcheck={{false}}
   id="ember-power-select-trigger-multiple-input-{{@select.uniqueId}}"
   aria-labelledby={{@ariaLabelledBy}}
+  aria-describedby={{@ariaDescribedBy}}
   aria-label={{@ariaLabel}}
   value={{@select.searchText}}
+  role={{or @role "combobox"}}
+  aria-owns={{if @select.isOpen @listboxId}}
   aria-controls={{if @select.isOpen @listboxId}}
+  aria-autocomplete="list"
   placeholder={{this.maybePlaceholder}}
   disabled={{@select.disabled}}
   tabindex={{@tabindex}}

--- a/ember-power-select/src/components/power-select-multiple/input.ts
+++ b/ember-power-select/src/components/power-select-multiple/input.ts
@@ -16,6 +16,8 @@ interface PowerSelectMultipleInputSignature {
     ariaLabel?: string;
     ariaActiveDescendant?: string;
     ariaLabelledBy?: string;
+    ariaDescribedBy?: string;
+    role?: string;
     placeholderComponent?: string;
     isDefaultPlaceholder?: boolean;
     onInput?: (e: InputEvent) => boolean;

--- a/ember-power-select/src/components/power-select-multiple/trigger.hbs
+++ b/ember-power-select/src/components/power-select-multiple/trigger.hbs
@@ -60,6 +60,8 @@
           select=@select
           ariaActiveDescendant=@ariaActiveDescendant
           ariaLabelledBy=@ariaLabelledBy
+          ariaDescribedBy=@ariaDescribedBy
+          role=@role
           ariaLabel=@ariaLabel
           listboxId=@listboxId
           tabindex=@tabindex

--- a/ember-power-select/src/components/power-select-multiple/trigger.ts
+++ b/ember-power-select/src/components/power-select-multiple/trigger.ts
@@ -17,6 +17,8 @@ interface PowerSelectMultipleTriggerSignature {
     tabindex?: string;
     ariaLabel?: string;
     ariaLabelledBy?: string;
+    ariaDescribedBy?: string;
+    role?: string;
     ariaActiveDescendant: string;
     extra?: any;
     placeholderComponent?: string | ComponentLike<any>;

--- a/ember-power-select/src/components/power-select.hbs
+++ b/ember-power-select/src/components/power-select.hbs
@@ -40,15 +40,17 @@
       {{on "blur" this.handleBlur}}
       class="ember-power-select-trigger {{@triggerClass}}{{if publicAPI.isActive " ember-power-select-trigger--active"}}"
       aria-activedescendant={{if dropdown.isOpen (unless @searchEnabled (concat publicAPI.uniqueId "-" this.highlightedIndex))}}
-      aria-controls={{unless @searchEnabled listboxId}}
+      aria-controls={{if (and dropdown.isOpen (not @searchEnabled)) listboxId}}
       aria-describedby={{@ariaDescribedBy}}
       aria-haspopup={{unless @searchEnabled "listbox"}}
       aria-invalid={{@ariaInvalid}}
       aria-label={{@ariaLabel}}
       aria-labelledby={{@ariaLabelledBy}}
-      aria-owns=""
+      aria-owns={{if (and dropdown.isOpen (not @searchEnabled)) listboxId}}
       aria-required={{@required}}
-      role={{or @triggerRole "button"}}
+      aria-autocomplete={{if @searchEnabled "list"}}
+      aria-multiselectable={{if this.ariaMultiSelectable "true"}}
+      role={{or @triggerRole "combobox"}}
       title={{@title}}
       id={{@triggerId}}
       tabindex={{and (not @disabled) (or @tabindex "0")}}
@@ -189,6 +191,9 @@
           />
         {{/let}}
       {{/if}}
+      <div role="status" aria-live="polite" aria-atomic="true" class="ember-power-select-visually-hidden">
+        {{this.resultCountMessage}}
+      </div>
     </dropdown.Content>
   {{/let}}
 </BasicDropdown>

--- a/ember-power-select/src/components/power-select.hbs
+++ b/ember-power-select/src/components/power-select.hbs
@@ -40,13 +40,13 @@
       {{on "blur" this.handleBlur}}
       class="ember-power-select-trigger {{@triggerClass}}{{if publicAPI.isActive " ember-power-select-trigger--active"}}"
       aria-activedescendant={{if dropdown.isOpen (unless @searchEnabled (concat publicAPI.uniqueId "-" this.highlightedIndex))}}
-      aria-controls={{if (and dropdown.isOpen (not @searchEnabled)) listboxId}}
+      aria-controls={{if (and dropdown.isOpen (not @searchEnabled)) listboxId ""}}
       aria-describedby={{@ariaDescribedBy}}
       aria-haspopup={{unless @searchEnabled "listbox"}}
       aria-invalid={{@ariaInvalid}}
       aria-label={{@ariaLabel}}
       aria-labelledby={{@ariaLabelledBy}}
-      aria-owns={{if (and dropdown.isOpen (not @searchEnabled)) listboxId}}
+      aria-owns={{if (and dropdown.isOpen (not @searchEnabled)) listboxId ""}}
       aria-required={{@required}}
       aria-autocomplete={{if @searchEnabled "list"}}
       aria-multiselectable={{if this.ariaMultiSelectable "true"}}

--- a/ember-power-select/src/components/power-select.hbs
+++ b/ember-power-select/src/components/power-select.hbs
@@ -1,3 +1,19 @@
+{{#if (or @labelText @labelComponent)}}
+  {{#let (if
+    @labelComponent
+    (component (ensure-safe-component @labelComponent))
+    (component 'power-select/label')
+  ) as |Label|}}
+    <Label
+      @select={{this.storedAPI}}
+      @labelText={{@labelText}}
+      @labelId={{this.labelId}}
+      @triggerId={{this.triggerId}}
+      @extra={{@extra}}
+      class={{@labelClass}}
+    />
+  {{/let}}
+{{/if}}
 <BasicDropdown
   @horizontalPosition={{@horizontalPosition}}
   @destination={{@destination}}
@@ -45,23 +61,22 @@
       aria-haspopup={{unless @searchEnabled "listbox"}}
       aria-invalid={{@ariaInvalid}}
       aria-label={{@ariaLabel}}
-      aria-labelledby={{@ariaLabelledBy}}
+      aria-labelledby={{this.ariaLabelledBy}}
       aria-owns={{if (and dropdown.isOpen (not @searchEnabled)) listboxId ""}}
       aria-required={{@required}}
       aria-autocomplete={{if @searchEnabled "list"}}
-      aria-multiselectable={{if this.ariaMultiSelectable "true"}}
       role={{or @triggerRole "combobox"}}
       title={{@title}}
-      id={{@triggerId}}
+      id={{this.triggerId}}
       tabindex={{and (not @disabled) (or @tabindex "0")}}
       ...attributes
     >
-      {{#let 
-        (if 
-          @triggerComponent 
-          (component (ensure-safe-component @triggerComponent)) 
+      {{#let
+        (if
+          @triggerComponent
+          (component (ensure-safe-component @triggerComponent))
           (component 'power-select/trigger')
-        ) 
+        )
       as |Trigger|}}
         <Trigger
           @allowClear={{@allowClear}}
@@ -78,14 +93,16 @@
           @onInput={{this.handleInput}}
           @onKeydown={{this.handleKeydown}}
           @placeholder={{@placeholder}}
-          @placeholderComponent={{if 
-            @placeholderComponent 
-            (ensure-safe-component @placeholderComponent) 
+          @placeholderComponent={{if
+            @placeholderComponent
+            (ensure-safe-component @placeholderComponent)
             (component 'power-select/placeholder')
           }}
           @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
-          @ariaLabelledBy={{@ariaLabelledBy}}
+          @ariaLabelledBy={{this.ariaLabelledBy}}
+          @ariaDescribedBy={{@ariaDescribedBy}}
           @ariaLabel={{@ariaLabel}}
+          @role={{@triggerRole}}
           as |opt select|>
           {{yield opt select}}
         </Trigger>
@@ -96,12 +113,12 @@
       @animationEnabled={{@animationEnabled}}
     >
       {{#if (not-eq @beforeOptionsComponent null)}}
-        {{#let 
-          (if 
-            @beforeOptionsComponent 
+        {{#let
+          (if
+            @beforeOptionsComponent
             (component (ensure-safe-component @beforeOptionsComponent))
             (component 'power-select/before-options')
-          ) 
+          )
         as |BeforeOptions|}}
           <BeforeOptions
             @select={{publicAPI}}
@@ -118,54 +135,56 @@
             @selectedItemComponent={{ensure-safe-component @selectedItemComponent}}
             @searchPlaceholder={{@searchPlaceholder}}
             @ariaLabel={{@ariaLabel}}
-            @ariaLabelledBy={{@ariaLabelledBy}}
+            @ariaLabelledBy={{this.ariaLabelledBy}}
+            @ariaDescribedBy={{@ariaDescribedBy}}
+            @triggerRole={{@triggerRole}}
           />
         {{/let}}
       {{/if}}
       {{#if this.mustShowSearchMessage}}
-        {{#let 
-          (if 
-            @searchMessageComponent 
+        {{#let
+          (if
+            @searchMessageComponent
             (component (ensure-safe-component @searchMessageComponent))
             (component 'power-select/search-message')
-          ) 
+          )
         as |SearchMessage|}}
-          <SearchMessage 
+          <SearchMessage
             @searchMessage={{this.searchMessage}}
             @select={{publicAPI}}
-            id={{listboxId}} 
+            id={{listboxId}}
             aria-label={{@ariaLabel}}
-            aria-labelledby={{@ariaLabelledBy}} 
-          /> 
+            aria-labelledby={{this.ariaLabelledBy}}
+          />
         {{/let}}
       {{else if this.mustShowNoMessages}}
-        {{#let 
-          (if 
+        {{#let
+          (if
             @noMatchesMessageComponent
             (component (ensure-safe-component @noMatchesMessageComponent))
             (component 'power-select/no-matches-message')
-          ) 
+          )
          as |NoMatchesMessage|}}
-          <NoMatchesMessage 
-            @noMatchesMessage={{this.noMatchesMessage}} 
-            @select={{publicAPI}} 
-            id={{listboxId}} 
+          <NoMatchesMessage
+            @noMatchesMessage={{this.noMatchesMessage}}
+            @select={{publicAPI}}
+            id={{listboxId}}
             aria-label={{@ariaLabel}}
-            aria-labelledby={{@ariaLabelledBy}} 
+            aria-labelledby={{this.ariaLabelledBy}}
           />
         {{/let}}
       {{else}}
-        {{#let 
-          (if 
+        {{#let
+          (if
             @optionsComponent
             (component (ensure-safe-component @optionsComponent))
             (component 'power-select/options')
-          ) 
-          (if 
+          )
+          (if
             @groupComponent
             (component (ensure-safe-component @groupComponent))
             (component 'power-select/power-select-group')
-          ) 
+          )
         as |Options Group|}}
           <Options
             @loadingMessage={{or @loadingMessage "Loading options..."}}
@@ -176,13 +195,15 @@
             @extra={{@extra}}
             @highlightOnHover={{this.highlightOnHover}}
             @groupComponent={{Group}}
+            role="listbox"
+            aria-multiselectable={{if this.ariaMultiSelectable "true"}}
             id={{listboxId}}
             class="ember-power-select-options" as |option select|>
             {{yield option select}}
           </Options>
         {{/let}}
       {{/if}}
-      
+
       {{#if @afterOptionsComponent}}
         {{#let (component (ensure-safe-component @afterOptionsComponent)) as |AfterOptions|}}
           <AfterOptions

--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -63,6 +63,7 @@ export interface PowerSelectArgs {
   noMatchesMessage?: string;
   noMatchesMessageComponent?: string | ComponentLike<any>;
   matchTriggerWidth?: boolean;
+  resultCountMessage?: (resultCount: number) => string;
   options?: any[] | PromiseProxy<any[]>;
   selected?: any | PromiseProxy<any>;
   destination?: string;
@@ -228,6 +229,18 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
       : this.args.noMatchesMessage;
   }
 
+  get resultCountMessage(): string {
+    if (typeof this.args.resultCountMessage === 'function') {
+      return this.args.resultCountMessage(this.resultsCount);
+    }
+
+    if (this.resultsCount === 1) {
+      return `${this.resultsCount} result`;
+    }
+
+    return `${this.resultsCount} results`;
+  }
+
   get matchTriggerWidth() {
     return this.args.matchTriggerWidth === undefined
       ? true
@@ -302,6 +315,10 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
       return toPlainArray(this.args.selected);
     }
     return undefined;
+  }
+
+  get ariaMultiSelectable() {
+    return isArray(this.args.selected);
   }
 
   // Actions

--- a/ember-power-select/src/components/power-select/before-options.hbs
+++ b/ember-power-select/src/components/power-select/before-options.hbs
@@ -10,6 +10,8 @@
       value={{@select.searchText}}
       aria-activedescendant={{@ariaActiveDescendant}}
       aria-controls={{@listboxId}}
+      aria-owns={{@listboxId}}
+      aria-autocomplete="list"
       aria-haspopup="listbox"
       placeholder={{@searchPlaceholder}}
       aria-label={{@ariaLabel}}

--- a/ember-power-select/src/components/power-select/before-options.hbs
+++ b/ember-power-select/src/components/power-select/before-options.hbs
@@ -8,6 +8,7 @@
       spellcheck={{false}}
       class="ember-power-select-search-input"
       value={{@select.searchText}}
+      role={{or @role "combobox"}}
       aria-activedescendant={{@ariaActiveDescendant}}
       aria-controls={{@listboxId}}
       aria-owns={{@listboxId}}
@@ -16,6 +17,7 @@
       placeholder={{@searchPlaceholder}}
       aria-label={{@ariaLabel}}
       aria-labelledby={{@ariaLabelledBy}}
+      aria-describedby={{@ariaDescribedBy}}
       {{on "input" this.handleInput}}
       {{on "focus" @onFocus}}
       {{on "blur" @onBlur}}

--- a/ember-power-select/src/components/power-select/before-options.ts
+++ b/ember-power-select/src/components/power-select/before-options.ts
@@ -10,6 +10,8 @@ interface PowerSelectBeforeOptionsSignature {
     searchEnabled: boolean;
     ariaLabel?: string;
     ariaLabelledBy?: string;
+    ariaDescribedBy?: string;
+    role?: string;
     searchPlaceholder?: string;
     ariaActiveDescendant?: string;
     listboxId?: string;

--- a/ember-power-select/src/components/power-select/label.hbs
+++ b/ember-power-select/src/components/power-select/label.hbs
@@ -1,0 +1,3 @@
+<label id={{@labelId}} class="ember-power-select-label" ...attributes for={{@triggerId}} {{on "click" this.onLabelClick}}>
+  {{@labelText}}
+</label>

--- a/ember-power-select/src/components/power-select/label.ts
+++ b/ember-power-select/src/components/power-select/label.ts
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import type { Select } from '../power-select';
+
+interface PowerSelectLabelSignature {
+  Element: HTMLElement;
+  Args: {
+    select: Select;
+    labelText?: string;
+    labelId: string;
+    triggerId: string;
+    extra: any;
+  };
+}
+
+export default class PowerSelectLabelComponent extends Component<PowerSelectLabelSignature> {
+  @action
+  onLabelClick(e: MouseEvent): void {
+    if (!this.args.select) {
+      return;
+    }
+
+    this.args.select.actions.labelClick(e);
+  }
+}

--- a/ember-power-select/src/components/power-select/label.ts
+++ b/ember-power-select/src/components/power-select/label.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import type { Select } from '../power-select';
 
-interface PowerSelectLabelSignature {
+export interface PowerSelectLabelSignature {
   Element: HTMLElement;
   Args: {
     select: Select;

--- a/ember-power-select/src/components/power-select/options.hbs
+++ b/ember-power-select/src/components/power-select/options.hbs
@@ -1,4 +1,4 @@
-<ul role="listbox" id={{@listboxId}} {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
+<ul {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
   {{#if @select.loading}}
     {{#if @loadingMessage}}
       <li class="ember-power-select-option ember-power-select-option--loading-message" role="option" aria-selected={{false}}>{{@loadingMessage}}</li>

--- a/ember-power-select/src/components/power-select/options.hbs
+++ b/ember-power-select/src/components/power-select/options.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable require-context-role --}}
 <ul {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
   {{#if @select.loading}}
     {{#if @loadingMessage}}

--- a/ember-power-select/src/components/power-select/options.hbs
+++ b/ember-power-select/src/components/power-select/options.hbs
@@ -1,4 +1,4 @@
-<ul role="listbox" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
+<ul role="listbox" id={{@listboxId}} {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
   {{#if @select.loading}}
     {{#if @loadingMessage}}
       <li class="ember-power-select-option ember-power-select-option--loading-message" role="option" aria-selected={{false}}>{{@loadingMessage}}</li>
@@ -18,7 +18,8 @@
             @optionsComponent={{@optionsComponent}}
             @groupComponent={{@groupComponent}}
             @extra={{@extra}}
-            role="group"
+            role="presentation"
+            data-optgroup="true"
             class="ember-power-select-options" as |option|>
             {{yield option @select}}
           </Options>
@@ -30,7 +31,8 @@
           aria-disabled={{if opt.disabled "true"}}
           aria-current="{{ember-power-select-is-equal opt @select.highlighted}}"
           data-option-index="{{@groupIndex}}{{index}}"
-          role="option">
+          role="option"
+        >
           {{yield opt @select}}
         </li>
       {{/if}}

--- a/ember-power-select/src/components/power-select/options.ts
+++ b/ember-power-select/src/components/power-select/options.ts
@@ -15,6 +15,7 @@ interface PowerSelectOptionsSignature {
 interface PowerSelectOptionsArgs {
   select: Select;
   highlightOnHover?: boolean;
+  listboxId: string;
   groupIndex: string;
   loadingMessage: string;
   options: any[];
@@ -75,8 +76,8 @@ export default class PowerSelectOptionsComponent extends Component<PowerSelectOp
 
   @action
   addHandlers(element: Element) {
-    const role = element.getAttribute('role');
-    if (role === 'group') {
+    const isGroup = element.getAttribute('data-optgroup') === 'true';
+    if (isGroup) {
       return;
     }
     // eslint-disable-next-line @typescript-eslint/ban-types
@@ -140,9 +141,8 @@ export default class PowerSelectOptionsComponent extends Component<PowerSelectOp
       element.addEventListener('touchstart', this.touchStartHandler);
       element.addEventListener('touchend', this.touchEndHandler);
     }
-    if (role !== 'group') {
-      this.args.select.actions.scrollTo(this.args.select.highlighted);
-    }
+
+    this.args.select.actions.scrollTo(this.args.select.highlighted);
   }
 
   @action

--- a/ember-power-select/src/components/power-select/power-select-group.hbs
+++ b/ember-power-select/src/components/power-select/power-select-group.hbs
@@ -1,4 +1,4 @@
-<li class="ember-power-select-group" aria-disabled={{if @group.disabled "true"}} role="option" aria-selected={{false}}>
-  <span class="ember-power-select-group-name">{{@group.groupName}}</span>
+<li class="ember-power-select-group" aria-disabled={{if @group.disabled "true"}} role="group" aria-labelledby={{this.uniqueId}}>
+  <span class="ember-power-select-group-name" id={{this.uniqueId}}>{{@group.groupName}}</span>
   {{yield}}
 </li>

--- a/ember-power-select/src/components/power-select/power-select-group.ts
+++ b/ember-power-select/src/components/power-select/power-select-group.ts
@@ -1,4 +1,5 @@
-import templateOnly from '@ember/component/template-only';
+import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
 
 interface PowerSelectPowerSelectGroupSignature {
   Element: HTMLElement;
@@ -10,4 +11,6 @@ interface PowerSelectPowerSelectGroupSignature {
   };
 }
 
-export default templateOnly<PowerSelectPowerSelectGroupSignature>();
+export default class PowerSelectGroupComponent extends Component<PowerSelectPowerSelectGroupSignature> {
+  uniqueId = guidFor(this);
+}

--- a/test-app/app/components/custom-label-component.hbs
+++ b/test-app/app/components/custom-label-component.hbs
@@ -1,0 +1,3 @@
+<label id={{@labelId}} class="ember-power-select-custom-label-component" ...attributes for={{@triggerId}}>
+  {{@labelText}}
+</label>

--- a/test-app/app/components/custom-label-component.ts
+++ b/test-app/app/components/custom-label-component.ts
@@ -1,0 +1,4 @@
+import templateOnly from '@ember/component/template-only';
+import type { PowerSelectLabelSignature } from 'ember-power-select/components/power-select/label';
+
+export default templateOnly<PowerSelectLabelSignature>();

--- a/test-app/app/templates/helpers-testing-single-power-select.hbs
+++ b/test-app/app/templates/helpers-testing-single-power-select.hbs
@@ -1,4 +1,4 @@
-<h3>Helpers testing with single select</h3>
+<h2 class="t3">Helpers testing with single select</h2>
 <div class="select-choose">
   <PowerSelect @options={{this.numbers}} @selected={{this.selected}} @onChange={{fn (mut this.selected)}} @searchEnabled={{true}} as |num|>
     {{num}}

--- a/test-app/app/templates/helpers-testing.hbs
+++ b/test-app/app/templates/helpers-testing.hbs
@@ -1,4 +1,4 @@
-<h3>Helpers testing</h3>
+<h1>Helpers testing</h1>
 <div class="select-choose">
   <PowerSelect @options={{this.numbers}} @selected={{this.selected}} @onChange={{fn (mut this.selected)}} as |num|>
     {{num}}
@@ -51,7 +51,7 @@
   </PowerSelect>
 </div>
 
-<h3>Customized component</h3>
+<h2 class="t3">Customized component</h2>
 <div class="select-custom-search">
   <PowerSelect @selected={{this.selected3}}
     @onChange={{fn (mut this.selected3)}}

--- a/test-app/tests/integration/components/power-select/a11y-test.js
+++ b/test-app/tests/integration/components/power-select/a11y-test.js
@@ -645,7 +645,9 @@ module(
         .dom('.ember-power-select-trigger')
         .hasAttribute(
           'aria-owns',
-          document.querySelector('.ember-power-select-dropdown').id,
+          document.querySelector(
+            '.ember-power-select-dropdown .ember-power-select-options',
+          ).id,
         );
       assert
         .dom('.ember-power-select-trigger')
@@ -764,13 +766,6 @@ module(
 
       assert
         .dom('.ember-power-select-trigger')
-        .hasAttribute(
-          'aria-controls',
-          /^ember-power-select-options-ember\d+$/,
-          'The trigger has aria-controls value',
-        );
-      assert
-        .dom('.ember-power-select-trigger')
         .hasNoAttribute(
           'aria-activedescendant',
           'aria-activedescendant is not present when the dropdown is closed',
@@ -784,6 +779,14 @@ module(
         );
 
       await clickTrigger();
+
+      assert
+        .dom('.ember-power-select-trigger')
+        .hasAttribute(
+          'aria-controls',
+          /^ember-power-select-options-ember\d+$/,
+          'The trigger has aria-controls value',
+        );
 
       // by default, the first option is highlighted and marked as aria-activedescendant
       assert

--- a/test-app/tests/integration/components/power-select/a11y-test.js
+++ b/test-app/tests/integration/components/power-select/a11y-test.js
@@ -13,7 +13,7 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    test('Single-select: The top-level options list have `role=listbox` and nested lists have `role=group`', async function (assert) {
+    test('Single-select: The top-level options list have `role=listbox` and nested lists have `role=presentation`', async function (assert) {
       assert.expect(6);
 
       this.groupedNumbers = groupedNumbers;
@@ -36,10 +36,10 @@ module(
       );
       [].slice
         .call(nestedOptionList)
-        .forEach((e) => assert.dom(e).hasAttribute('role', 'group'));
+        .forEach((e) => assert.dom(e).hasAttribute('role', 'presentation'));
     });
 
-    test('Multiple-select: The top-level options list have `role=listbox` and nested lists have `role=group`', async function (assert) {
+    test('Multiple-select: The top-level options list have `role=listbox` and nested lists have `role=presentation`', async function (assert) {
       assert.expect(6);
 
       this.groupedNumbers = groupedNumbers;
@@ -62,7 +62,7 @@ module(
       );
       [].slice
         .call(nestedOptionList)
-        .forEach((e) => assert.dom(e).hasAttribute('role', 'group'));
+        .forEach((e) => assert.dom(e).hasAttribute('role', 'presentation'));
     });
 
     test('Single-select: All options have `role=option`', async function (assert) {
@@ -274,7 +274,7 @@ module(
         .exists({ count: 3 }, 'Three of them are disabled');
     });
 
-    test('Single-select: The trigger has `role=button`', async function (assert) {
+    test('Single-select: The trigger has `role=combobox`', async function (assert) {
       assert.expect(1);
 
       this.numbers = numbers;
@@ -287,10 +287,10 @@ module(
       await clickTrigger();
       assert
         .dom('.ember-power-select-trigger')
-        .hasAttribute('role', 'button', 'The trigger has role button');
+        .hasAttribute('role', 'combobox', 'The trigger has role combobox');
     });
 
-    test('Multiple-select: The trigger has `role=button`', async function (assert) {
+    test('Multiple-select: The trigger has `role=combobox`', async function (assert) {
       assert.expect(1);
 
       this.numbers = numbers;
@@ -303,7 +303,7 @@ module(
       await clickTrigger();
       assert
         .dom('.ember-power-select-trigger')
-        .hasAttribute('role', 'button', 'The trigger has role button');
+        .hasAttribute('role', 'combobox', 'The trigger has role combobox');
     });
 
     test('Single-select: The trigger attribute `aria-expanded` is true when the dropdown is opened', async function (assert) {
@@ -613,7 +613,11 @@ module(
       this.set('role', undefined);
       assert
         .dom('.ember-power-select-trigger')
-        .hasAttribute('role', 'button', 'The `role` was defaults to `button`.');
+        .hasAttribute(
+          'role',
+          'combobox',
+          'The `role` was defaults to `combobox`.',
+        );
     });
 
     test('Dropdown with search disabled has proper aria attributes to associate trigger with the options', async function (assert) {

--- a/test-app/tests/integration/components/power-select/customization-with-components-test.js
+++ b/test-app/tests/integration/components/power-select/customization-with-components-test.js
@@ -19,10 +19,10 @@ module(
       this.country = countries[1]; // Spain
 
       await render(hbs`
-      <PowerSelect 
-        @options={{this.countries}} 
-        @selected={{this.country}} 
-        @triggerComponent={{component "selected-country"}} 
+      <PowerSelect
+        @options={{this.countries}}
+        @selected={{this.country}}
+        @triggerComponent={{component "selected-country"}}
         @onChange={{fn (mut this.foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -68,10 +68,10 @@ module(
       this.country = countries[1]; // Spain
 
       await render(hbs`
-      <PowerSelect 
-        @options={{this.countries}} 
-        @selected={{this.country}} 
-        @selectedItemComponent={{component "selected-country"}} 
+      <PowerSelect
+        @options={{this.countries}}
+        @selected={{this.country}}
+        @selectedItemComponent={{component "selected-country"}}
         @onChange={{fn (mut this.foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -95,10 +95,10 @@ module(
       this.country = countries[1]; // Spain
 
       await render(hbs`
-      <PowerSelect 
-        @options={{this.countries}} 
-        @selected={{this.country}} 
-        @optionsComponent={{component "list-of-countries"}} 
+      <PowerSelect
+        @options={{this.countries}}
+        @selected={{this.country}}
+        @optionsComponent={{component "list-of-countries"}}
         @onChange={{fn (mut this.foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -120,11 +120,11 @@ module(
       this.country = countries[1]; // Spain
 
       await render(hbs`
-      <PowerSelect 
-        @options={{this.countries}} 
-        @selected={{this.country}} 
-        @optionsComponent={{component "list-of-countries"}} 
-        @onChange={{fn (mut this.foo)}} 
+      <PowerSelect
+        @options={{this.countries}}
+        @selected={{this.country}}
+        @optionsComponent={{component "list-of-countries"}}
+        @onChange={{fn (mut this.foo)}}
         @extra={{hash field="code"}} as |country|>
         {{country.code}}
       </PowerSelect>
@@ -307,9 +307,9 @@ module(
 
       this.searchFn = function () {};
       await render(hbs`
-      <PowerSelect 
-        @search={{this.searchFn}} 
-        @searchMessageComponent={{component "custom-search-message"}} 
+      <PowerSelect
+        @search={{this.searchFn}}
+        @searchMessageComponent={{component "custom-search-message"}}
         @onChange={{fn (mut this.foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -329,10 +329,10 @@ module(
       this.options = [];
 
       await render(hbs`
-      <PowerSelect 
-        @options={{this.options}} 
-        @noMatchesMessageComponent={{component "custom-no-matches-message"}} 
-        @noMatchesMessage="Nope" 
+      <PowerSelect
+        @options={{this.options}}
+        @noMatchesMessageComponent={{component "custom-no-matches-message"}}
+        @noMatchesMessage="Nope"
         @onChange={{fn (mut this.foo)}} as |option|>
         {{option}}
       </PowerSelect>
@@ -379,9 +379,9 @@ module(
       let numberOfGroups = 5; // number of groups in groupedNumber;
 
       await render(hbs`
-      <PowerSelect 
-        @options={{this.groupedNumbers}} 
-        @groupComponent={{component "custom-group-component"}} 
+      <PowerSelect
+        @options={{this.groupedNumbers}}
+        @groupComponent={{component "custom-group-component"}}
         @onChange={{fn (mut this.foo)}} as |country|>
         {{country.name}}
       </PowerSelect>
@@ -408,9 +408,9 @@ module(
       };
 
       await render(hbs`
-      <PowerSelect 
-        @options={{this.groupedNumbers}} 
-        @groupComponent={{component "custom-group-component" onInit=this.onInit}} 
+      <PowerSelect
+        @options={{this.groupedNumbers}}
+        @groupComponent={{component "custom-group-component" onInit=this.onInit}}
         @extra={{this.extra}}
         @onChange={{fn (mut this.foo)}} as |country|>
         {{country.name}}
@@ -422,6 +422,40 @@ module(
       assert
         .dom('.ember-power-select-options .custom-component')
         .exists({ count: numberOfGroups });
+    });
+
+    test('The `@labelComponent` was rendered with text `@labelText="Label for select` and is matching with trigger id', async function (assert) {
+      assert.expect(3);
+
+      this.countries = countries;
+
+      await render(hbs`
+      <PowerSelect
+        @options={{this.countries}}
+        @labelComponent={{component "custom-label-component"}}
+        @labelText="Label for select"
+        @onChange={{fn (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelect>
+    `);
+
+      assert
+        .dom('.ember-power-select-custom-label-component')
+        .exists('Label is present');
+
+      assert
+        .dom('.ember-power-select-custom-label-component')
+        .hasText('Label for select');
+
+      assert
+        .dom('.ember-power-select-trigger')
+        .hasAttribute(
+          'id',
+          document
+            .querySelector('.ember-power-select-custom-label-component')
+            .getAttribute('for'),
+          'The for from label is matching with id of trigger',
+        );
     });
 
     test('the power-select-multiple placeholder can be customized using `@placeholderComponent`', async function (assert) {
@@ -486,11 +520,11 @@ module(
       this.country = countries[1]; // Spain
 
       await render(hbs`
-      <PowerSelectMultiple 
-        @options={{this.countries}} 
-        @selected={{this.country}} 
-        @optionsComponent={{component "list-of-countries"}} 
-        @onChange={{fn (mut this.foo)}} 
+      <PowerSelectMultiple
+        @options={{this.countries}}
+        @selected={{this.country}}
+        @optionsComponent={{component "list-of-countries"}}
+        @onChange={{fn (mut this.foo)}}
         @extra={{hash field="code"}} as |country|>
         {{country.code}}
       </PowerSelectMultiple>
@@ -516,11 +550,11 @@ module(
       this.country = countries[1]; // Spain
 
       await render(hbs`
-      <PowerSelectMultiple 
-        @options={{this.countries}} 
-        @selected={{this.country}} 
-        @triggerComponent={{component "selected-country"}} 
-        @onChange={{fn (mut this.foo)}} 
+      <PowerSelectMultiple
+        @options={{this.countries}}
+        @selected={{this.country}}
+        @triggerComponent={{component "selected-country"}}
+        @onChange={{fn (mut this.foo)}}
         @extra={{hash coolFlagIcon=true}} as |country|>
         {{country.code}}
       </PowerSelectMultiple>
@@ -560,6 +594,40 @@ module(
         .exists(
           { count: 1 },
           'The custom selectedItemComponent renders with the extra.coolFlagIcon.',
+        );
+    });
+
+    test('The power-select-multiple `@labelComponent` was rendered with text `@labelText="Label for select` and is matching with trigger id', async function (assert) {
+      assert.expect(3);
+
+      this.countries = countries;
+
+      await render(hbs`
+      <PowerSelectMultiple
+        @options={{this.countries}}
+        @labelComponent={{component "custom-label-component"}}
+        @labelText="Label for select"
+        @onChange={{fn (mut this.foo)}} as |country|>
+        {{country.name}}
+      </PowerSelectMultiple>
+    `);
+
+      assert
+        .dom('.ember-power-select-custom-label-component')
+        .exists('Label is present');
+
+      assert
+        .dom('.ember-power-select-custom-label-component')
+        .hasText('Label for select');
+
+      assert
+        .dom('.ember-power-select-trigger')
+        .hasAttribute(
+          'id',
+          document
+            .querySelector('.ember-power-select-custom-label-component')
+            .getAttribute('for'),
+          'The for from label is matching with id of trigger',
         );
     });
   },

--- a/test-app/tests/integration/components/power-select/general-behaviour-test.js
+++ b/test-app/tests/integration/components/power-select/general-behaviour-test.js
@@ -83,6 +83,31 @@ module(
         .doesNotExist('The search box is NOT rendered');
     });
 
+    test('The label was rendered when it was passed with `@labelText="Label for select` and is matching with trigger id', async function (assert) {
+      assert.expect(3);
+
+      this.numbers = numbers;
+      await render(hbs`
+      <PowerSelect @options={{this.numbers}} @labelText="Label for select" @onChange={{fn (mut this.foo)}} as |option|>
+        {{option}}
+      </PowerSelect>
+    `);
+
+      assert.dom('.ember-power-select-label').exists('Label is present');
+
+      assert.dom('.ember-power-select-label').hasText('Label for select');
+
+      assert
+        .dom('.ember-power-select-trigger')
+        .hasAttribute(
+          'id',
+          document
+            .querySelector('.ember-power-select-label')
+            .getAttribute('for'),
+          'The for from label is matching with id of trigger',
+        );
+    });
+
     test('The search functionality can be enabled by passing `@searchEnabled={{true}}`', async function (assert) {
       assert.expect(2);
 

--- a/test-app/tests/integration/components/power-select/multiple-test.js
+++ b/test-app/tests/integration/components/power-select/multiple-test.js
@@ -1263,5 +1263,30 @@ module(
         .dom('.ember-power-select-multiple-option')
         .exists({ count: 1 }, 'Shows selected option');
     });
+
+    test('Multiple selects: The label was rendered when it was passed with `@labelText="Label for select` and is matching with trigger id', async function (assert) {
+      assert.expect(3);
+
+      this.numbers = numbers;
+      await render(hbs`
+      <PowerSelectMultiple @options={{this.numbers}} @labelText="Label for select" @onChange={{fn (mut this.foo)}} as |option|>
+        {{option}}
+      </PowerSelectMultiple>
+    `);
+
+      assert.dom('.ember-power-select-label').exists('Label is present');
+
+      assert.dom('.ember-power-select-label').hasText('Label for select');
+
+      assert
+        .dom('.ember-power-select-trigger')
+        .hasAttribute(
+          'id',
+          document
+            .querySelector('.ember-power-select-label')
+            .getAttribute('for'),
+          'The for from label is matching with id of trigger',
+        );
+    });
   },
 );


### PR DESCRIPTION
Some parts of a11y are not correct / not implemented since yet.

The goal is to make power-select out of the box ready for a11y by using [ARIA 1.2 specs](https://www.w3.org/TR/wai-aria-1.2/).

Changes:
- Add `@labelText`
  This adds `<label>` with all necessary attributes, that all a11y requirements are fulfilled
- Add `@labelClass` (allows to set styling classes on label tag)
- Add `@labelClickAction` (Default: focus)
  Click on label sets focus on power-select. This is the default behavior when using label-Tag with `<select>`. There is possible to pass `open` and the dropdown will be opened on label-tag click. This works only when using the new `labelText` paramenter
- Add `@labelComponent` to override standard label tag. Component get all necessary paramenter to make the same like we do internal in label component.
- Add `@resultCountMessage` (function). Allows to override default text which will only be used for readers. People which are using readers can here that the select has [xy] results. By searching this text will be updated.
  Default Text is [xy] results.


After changes we pass all Accessibility (tested with Lighthouse & some free tools):
![grafik](https://github.com/cibernox/ember-power-select/assets/19845290/29dbe6f5-c021-4155-b370-067d73b0736d)

Our docs page are passing now all requirements for a11y (there were necessary to modify some colors a little bit)