### PR TITLE
fix: `Type error: (n.selected || []).slice is not a function` in multiple select

### DIFF
--- a/ember-power-select/src/components/power-select-multiple.ts
+++ b/ember-power-select/src/components/power-select-multiple.ts
@@ -60,7 +60,9 @@ export default class PowerSelectMultipleComponent extends Component<PowerSelectM
   }
 
   defaultBuildSelection(option: any, select: Select) {
-    const newSelection = Array.isArray(select.selected) ? select.selected.slice(0) : [];
+    const newSelection = Array.isArray(select.selected)
+      ? select.selected.slice(0)
+      : [];
     let idx = -1;
     for (let i = 0; i < newSelection.length; i++) {
       if (isEqual(newSelection[i], option)) {

--- a/ember-power-select/src/components/power-select-multiple.ts
+++ b/ember-power-select/src/components/power-select-multiple.ts
@@ -60,7 +60,7 @@ export default class PowerSelectMultipleComponent extends Component<PowerSelectM
   }
 
   defaultBuildSelection(option: any, select: Select) {
-    const newSelection = (select.selected || []).slice(0);
+    const newSelection = Array.isArray(select.selected) ? select.selected.slice(0) : [];
     let idx = -1;
     for (let i = 0; i < newSelection.length; i++) {
       if (isEqual(newSelection[i], option)) {


### PR DESCRIPTION
I had an issue popping up in sentry, `Type error: (n.selected || []).slice is not a function` here:  

```ts
defaultBuildSelection(option: any, select: Select) {
    const newSelection = (select.selected || []).slice(0);
````

The proposed fix checks for `Array.isArray(select.selected)` in runtime (which should not hurt), but we should probably also fix this by narrowing the type of Select.selected – possibly as a generic of what you pass in to options.