### PR TITLE
Fix `BeforeOptions` search input missing `aria-expanded`

### DIFF
--- a/ember-power-select/src/components/power-select/before-options.hbs
+++ b/ember-power-select/src/components/power-select/before-options.hbs
@@ -14,6 +14,7 @@
       aria-owns={{@listboxId}}
       aria-autocomplete="list"
       aria-haspopup="listbox"
+      aria-expanded={{if @select.isOpen "true" "false"}}
       placeholder={{@searchPlaceholder}}
       aria-label={{@ariaLabel}}
       aria-labelledby={{@ariaLabelledBy}}


### PR DESCRIPTION
### Summary

The search input in `BeforeOptions` has a `role="combobox"` which [requires an "aria-expanded" attribute](https://www.w3.org/TR/wai-aria-1.1/#combobox:~:text=Authors%20MUST%20set%20aria%2Dexpanded%20to%20true%20on%20an%20element%20with%20role%20combobox%20when%20it%20is%20expanded%20and%20false%20when%20it%20is%20collapsed.) (set to "true" or "false") depending on the state.

Generally, the `BeforeOptions` is only visible when the PowerSelect is expanded, but since we have access to its state we can use `@select.isOpen` to conditionally apply this value.

### Example

The example below uses the `helpers-testing-single-power-select` instance in the `test-app` with either a `@labelText="Label"` or an `@ariaLabel="Label"` provided to the `<PowerSelect>`.

#### Automated accessibility checks using [axe](https://github.com/dequelabs/axe-core)


<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="1510" alt="03-BeforeOptions-before" src="https://github.com/cibernox/ember-power-select/assets/788096/8f143a20-677e-4c52-b95a-829339d28464">


</td><td>

<img width="1509" alt="04-BeforeOptions-after" src="https://github.com/cibernox/ember-power-select/assets/788096/eacf03a6-cbae-40ce-b26c-63bc62a023a4">


</td></tr>
</table>

### Motivation

At @hashicorp we use `<PowerSelect>` extensively and we are grateful to see the many improvements introduced lately.

This change is primarily motivated by the desire to further improve the accessibility compliance of this component – in this instance, by providing the required aria attribute for the combobox element.