### PR TITLE
Fix `BeforeOptions` search input having invalid `aria-activedescendant` when no results are found

### DIFF
--- a/ember-power-select/src/components/power-select.hbs
+++ b/ember-power-select/src/components/power-select.hbs
@@ -131,7 +131,7 @@
             @placeholderComponent={{or @placeholderComponent (component 'power-select/placeholder')}}
             @extra={{@extra}}
             @listboxId={{listboxId}}
-            @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
+            @ariaActiveDescendant={{if this.highlightedIndex (concat publicAPI.uniqueId "-" this.highlightedIndex)}}
             @selectedItemComponent={{ensure-safe-component @selectedItemComponent}}
             @searchPlaceholder={{@searchPlaceholder}}
             @ariaLabel={{@ariaLabel}}


### PR DESCRIPTION
### Summary

If there are no search results (hence no highlighted index) we currently show a truncated, invalid value for `aria-activedescendant` (for instance `ember74-`). In this PR we propose to only expose a value for `aria-active-descendant` if there are results.

### Example

The example below uses the `helpers-testing-single-power-select` instance in the `test-app`.

#### Automated accessibility checks using [axe](https://github.com/dequelabs/axe-core)


<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="1511" alt="05-ActiveDescendant-before" src="https://github.com/cibernox/ember-power-select/assets/788096/e31c0a21-3827-4fc7-aba4-4db09a8532c4">


</td><td>

<img width="1510" alt="06-ActiveDescendant-after" src="https://github.com/cibernox/ember-power-select/assets/788096/8dfcee04-fecb-4399-b3f2-0bc1f519bfa3">


</td></tr>
</table>

### Motivation

At @hashicorp we use `<PowerSelect>` extensively and we are grateful to see the many improvements introduced lately.

This change is primarily motivated by the desire to further improve the accessibility compliance of this component – in this instance, by providing a valid value for `aria-active-descendant`.