### PR TITLE
Fix rollup config (style.js -> styles.js)

### DIFF
--- a/ember-power-select/rollup.config.mjs
+++ b/ember-power-select/rollup.config.mjs
@@ -70,7 +70,7 @@ export default [
       // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
       addon.publicEntrypoints([
         'index.js',
-        'style.js',
+        'styles.js',
         'test-support.js',
         'components/**/*.js',
         'helpers/**/*.js',


### PR DESCRIPTION
Starting with beta v8.0.0.beta.6 there was missing the `styles.js` export

fix #1738