### PR TITLE
Mark ember-power-select-is-equal as public & add as note in migrate docs

### DIFF
--- a/docs/app/templates/public-pages/docs/migrate-7-0-to-8-0.hbs
+++ b/docs/app/templates/public-pages/docs/migrate-7-0-to-8-0.hbs
@@ -22,6 +22,9 @@
     </p>
   </li>
   <li>
+    <p>Helper: The helper <code>power-select-is-selected</code> was renamed to <code>ember-power-select-is-equal</code>. If you have used in your custom components, you need to replace it</p>
+  </li>
+  <li>
     <p>Vanilla JS: If you have used vanilla js you must now import the css in <code>app.js</code> manually like (for other css adding examples see under installation)</p>
     <CodeBlock @language="js" @code="import 'ember-power-select/styles';" />
   </li>

--- a/ember-power-select/src/helpers/ember-power-select-is-equal.ts
+++ b/ember-power-select/src/helpers/ember-power-select-is-equal.ts
@@ -2,7 +2,6 @@ import { helper } from '@ember/component/helper';
 import { isArray as isEmberArray } from '@ember/array';
 import { isEqual } from '@ember/utils';
 
-// TODO: Make it private or scoped to the component
 export function emberPowerSelectIsEqual(
   [option, selected]: [any, any] /* , hash*/,
 ): boolean {


### PR DESCRIPTION
Add helper renaming to upgrade docs and make this helper as public.

As reported in #1738 this helper was already used by apps outside of our components.

It make also sense to use this helper for custom components, otherwise they need to replicate our code parts.