### PR TITLE
Add `@searchFieldPosition` argument

### DIFF
--- a/ember-power-select/src/components/power-select-multiple.hbs
+++ b/ember-power-select/src/components/power-select-multiple.hbs
@@ -11,7 +11,7 @@
   @labelComponent={{ensure-safe-component @labelComponent}}
   @afterOptionsComponent={{ensure-safe-component @afterOptionsComponent}}
   @allowClear={{@allowClear}}
-  @beforeOptionsComponent={{if @beforeOptionsComponent (ensure-safe-component @beforeOptionsComponent) null}}
+  @beforeOptionsComponent={{if @beforeOptionsComponent (ensure-safe-component @beforeOptionsComponent)}}
   @buildSelection={{or @buildSelection this.defaultBuildSelection}}
   @calculatePosition={{@calculatePosition}}
   @closeOnSelect={{@closeOnSelect}}
@@ -49,6 +49,7 @@
   @search={{@search}}
   @searchEnabled={{@searchEnabled}}
   @searchField={{@searchField}}
+  @searchFieldPosition={{(or @searchFieldPosition 'trigger')}}
   @searchMessage={{@searchMessage}}
   @searchMessageComponent={{@searchMessageComponent}}
   @searchPlaceholder={{@searchPlaceholder}}

--- a/ember-power-select/src/components/power-select-multiple/trigger.hbs
+++ b/ember-power-select/src/components/power-select-multiple/trigger.hbs
@@ -52,7 +52,7 @@
       </li>
     {{/if}}
   {{/each}}
-  {{#if @searchEnabled}}
+  {{#if (and @searchEnabled (eq @searchFieldPosition 'trigger'))}}
     <li class="ember-power-select-trigger-multiple-input-container">
       {{#let
         (component

--- a/ember-power-select/src/components/power-select-multiple/trigger.ts
+++ b/ember-power-select/src/components/power-select-multiple/trigger.ts
@@ -13,6 +13,7 @@ interface PowerSelectMultipleTriggerSignature {
     searchEnabled: boolean;
     placeholder?: string;
     searchField: string;
+    searchFieldPosition?: string;
     listboxId?: string;
     tabindex?: string;
     ariaLabel?: string;

--- a/ember-power-select/src/components/power-select.hbs
+++ b/ember-power-select/src/components/power-select.hbs
@@ -86,6 +86,7 @@
           @select={{publicAPI}}
           @searchEnabled={{@searchEnabled}}
           @searchField={{@searchField}}
+          @searchFieldPosition={{this.searchFieldPosition}}
           @onFocus={{this.handleFocus}}
           @onBlur={{this.handleBlur}}
           @extra={{@extra}}
@@ -134,6 +135,7 @@
             @ariaActiveDescendant={{if this.highlightedIndex (concat publicAPI.uniqueId "-" this.highlightedIndex)}}
             @selectedItemComponent={{ensure-safe-component @selectedItemComponent}}
             @searchPlaceholder={{@searchPlaceholder}}
+            @searchFieldPosition={{this.searchFieldPosition}}
             @ariaLabel={{@ariaLabel}}
             @ariaLabelledBy={{this.ariaLabelledBy}}
             @ariaDescribedBy={{@ariaDescribedBy}}

--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -87,6 +87,7 @@ export interface PowerSelectArgs {
   animationEnabled?: boolean;
   tabindex?: number | string;
   searchPlaceholder?: string;
+  searchFieldPosition?: string;
   verticalPosition?: string;
   horizontalPosition?: string;
   triggerId?: string;
@@ -361,6 +362,12 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
     }
 
     return '';
+  }
+
+  get searchFieldPosition(): string {
+    return this.args.searchFieldPosition === undefined
+      ? 'before-options'
+      : this.args.searchFieldPosition;
   }
 
   // Actions

--- a/ember-power-select/src/components/power-select/before-options.hbs
+++ b/ember-power-select/src/components/power-select/before-options.hbs
@@ -1,4 +1,4 @@
-{{#if @searchEnabled}}
+{{#if (and @searchEnabled (eq @searchFieldPosition 'before-options'))}}
   <div class="ember-power-select-search">
     {{!-- template-lint-disable require-input-label --}}
     <input type="search"

--- a/ember-power-select/src/components/power-select/before-options.ts
+++ b/ember-power-select/src/components/power-select/before-options.ts
@@ -13,6 +13,7 @@ interface PowerSelectBeforeOptionsSignature {
     ariaDescribedBy?: string;
     role?: string;
     searchPlaceholder?: string;
+    searchFieldPosition?: string;
     ariaActiveDescendant?: string;
     listboxId?: string;
     onKeydown: (e: KeyboardEvent) => false | void;

--- a/test-app/tests/integration/components/power-select/multiple-test.js
+++ b/test-app/tests/integration/components/power-select/multiple-test.js
@@ -55,6 +55,21 @@ module(
       assert.dom('.ember-power-select-dropdown input').doesNotExist();
     });
 
+    test('Multiple selects have a search box in the dropdown when the search is enabled and search position is `after-options`', async function (assert) {
+      assert.expect(2);
+
+      this.numbers = numbers;
+      await render(hbs`
+      <PowerSelectMultiple @options={{this.numbers}} @selected={{this.foo}} @onChange={{fn (mut this.foo)}} @searchEnabled={{true}} @searchFieldPosition="before-options" as |option|>
+        {{option}}
+      </PowerSelectMultiple>
+    `);
+
+      await clickTrigger();
+      assert.dom('.ember-power-select-trigger input').doesNotExist();
+      assert.dom('.ember-power-select-dropdown input').exists();
+    });
+
     test('The searchbox of multiple selects has type="search" and a form attribute to prevent submitting the wrapper form when pressing enter', async function (assert) {
       assert.expect(2);
 
@@ -84,6 +99,20 @@ module(
 
       await clickTrigger();
       assert.dom('.ember-power-select-trigger-multiple-input').isFocused();
+    });
+
+    test('When the select opens and search position is `after-options`, the search input (if any) in the dropdown gets the focus', async function (assert) {
+      assert.expect(1);
+
+      this.numbers = numbers;
+      await render(hbs`
+      <PowerSelectMultiple @options={{this.numbers}} @selected={{this.foo}} @onChange={{fn (mut this.foo)}} @searchEnabled={{true}} @searchFieldPosition="before-options" as |option|>
+        {{option}}
+      </PowerSelectMultiple>
+    `);
+
+      await clickTrigger();
+      assert.dom('.ember-power-select-search-input').isFocused();
     });
 
     test("Click on an element selects it and closes the dropdown and focuses the trigger's input", async function (assert) {


### PR DESCRIPTION
### Summary

Follow-up on #1752, gradually introducing `@searchFieldPosition` (`after-options` | `trigger`).

### Description

`<PowerSelect />` instances will have `@searchFieldPosition` set to `before-options` by default.
`<PowerSelectMultiple />` instances will have `@searchFieldPosition` set to `trigger` by default with the option to change it to `before-options`.

`<PowerSelectMultiple @searchEnabled={{true}} @searchFieldPosition="before-options" />` instances will have a search input placed in the dropdown, before the options, acting exactly as it currently does in `<PowerSelect @searchEnabled={{true}} />`.