### PR TITLE
Remove last Ember.Array (A()) using in addon, examples & tests

### DIFF
--- a/docs/app/components/snippets/action-handling-3.hbs
+++ b/docs/app/components/snippets/action-handling-3.hbs
@@ -2,6 +2,7 @@
   @selected={{this.selectedCities}}
   @options={{this.cities}}
   @onChange={{fn (mut this.selectedCities)}}
+  @searchEnabled={{true}}
   @labelText="Country"
   @onKeydown={{this.handleKeydown}} as |name|>
   {{name}}

--- a/docs/app/components/snippets/action-handling-3.js
+++ b/docs/app/components/snippets/action-handling-3.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { A } from '@ember/array';
 import { tracked } from '@glimmer/tracking';
 
 export default class extends Component {
@@ -16,7 +15,7 @@ export default class extends Component {
     'Springfield',
     'Tokio',
   ];
-  @tracked selectedCities = A();
+  @tracked selectedCities = [];
 
   @action
   handleKeydown(_dropdown, e) {

--- a/docs/app/components/snippets/create-custom-options-1.js
+++ b/docs/app/components/snippets/create-custom-options-1.js
@@ -1,10 +1,11 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { isBlank } from '@ember/utils';
-import { A } from '@ember/array';
 
 export default class extends Component {
-  options = A(['Barcelona', 'London', 'New York', 'Porto']);
+  @tracked options = ['Barcelona', 'London', 'New York', 'Porto'];
+
   selected = [];
 
   @action
@@ -16,7 +17,7 @@ export default class extends Component {
       !isBlank(select.searchText)
     ) {
       if (!this.selected.includes(select.searchText)) {
-        this.options.pushObject(select.searchText);
+        this.options = [...this.options, select.searchText];
         select.actions.choose(select.searchText);
       }
     }

--- a/docs/app/controllers/public-pages/cookbook/create-custom-options.js
+++ b/docs/app/controllers/public-pages/cookbook/create-custom-options.js
@@ -1,12 +1,14 @@
 import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { isBlank } from '@ember/utils';
-import { A } from '@ember/array';
 import CreateCustomOptions1 from '../../../components/snippets/create-custom-options-1';
 
 export default class extends Controller {
   createCustomOptions1 = CreateCustomOptions1;
-  options = A(['Barcelona', 'London', 'New York', 'Porto']);
+
+  @tracked options = ['Barcelona', 'London', 'New York', 'Porto'];
+
   selected = [];
 
   @action
@@ -18,7 +20,7 @@ export default class extends Controller {
       !isBlank(select.searchText)
     ) {
       if (!this.selected.includes(select.searchText)) {
-        this.options.push(select.searchText);
+        this.options = [...this.options, select.searchText];
         select.actions.choose(select.searchText);
       }
     }

--- a/ember-power-select/src/utils/group-utils.ts
+++ b/ember-power-select/src/utils/group-utils.ts
@@ -1,4 +1,3 @@
-import { A } from '@ember/array';
 import { isEqual } from '@ember/utils';
 
 export type MatcherFn = (option: any, text: string) => number;
@@ -180,7 +179,7 @@ export function filterOptions(
   matcher: MatcherFn,
   skipDisabled = false,
 ): any[] {
-  const opts = A();
+  const opts = [];
   const length = options.length;
   for (let i = 0; i < length; i++) {
     const entry = options.objectAt ? options.objectAt(i) : options[i];

--- a/test-app/tests/integration/components/power-select/general-behaviour-test.js
+++ b/test-app/tests/integration/components/power-select/general-behaviour-test.js
@@ -16,12 +16,12 @@ import {
 } from 'ember-power-select/test-support/helpers';
 import RSVP from 'rsvp';
 import { tracked } from '@glimmer/tracking';
-import { A } from '@ember/array';
 import { run, later } from '@ember/runloop';
 import { numbers, names, countries, digits } from '../constants';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ArrayProxy from '@ember/array/proxy';
 import ObjectProxy from '@ember/object/proxy';
+import { TrackedArray } from 'tracked-built-ins/.';
 
 const PromiseArrayProxy = ArrayProxy.extend(PromiseProxyMixin);
 const PromiseObject = ObjectProxy.extend(PromiseProxyMixin);
@@ -412,13 +412,13 @@ module(
       let done = assert.async();
       assert.expect(2);
 
-      let data = [];
-      this.proxy = A(data);
+      let data = new TrackedArray();
+      this.proxy = data;
       this.search = () => {
         return new RSVP.Promise(function (resolve) {
           resolve(data);
           later(function () {
-            data.pushObject('one'); // eslint-disable-line ember/no-array-prototype-extensions
+            data.push('one'); // eslint-disable-line ember/no-array-prototype-extensions
           }, 100);
         });
       };
@@ -451,13 +451,13 @@ module(
       let done = assert.async();
       assert.expect(5);
 
-      let data = ['one'];
-      this.proxy = A(data);
+      let data = new TrackedArray(['one']);
+      this.proxy = data;
       this.search = () => {
         return new RSVP.Promise(function (resolve) {
           resolve(data);
           later(function () {
-            data.pushObject('owner'); // eslint-disable-line ember/no-array-prototype-extensions
+            data.push('owner');
           }, 100);
         });
       };

--- a/test-app/tests/integration/components/power-select/keyboard-control-test.js
+++ b/test-app/tests/integration/components/power-select/keyboard-control-test.js
@@ -17,7 +17,6 @@ import {
 } from '../constants';
 import { triggerKeyEvent, focus } from '@ember/test-helpers';
 import RSVP from 'rsvp';
-import { A } from '@ember/array';
 
 module(
   'Integration | Component | Ember Power Select (Keyboard control)',
@@ -1163,7 +1162,7 @@ module(
 
     test('BUGFIX: when using ENTER to select an option in multiple select, the next ARROWDOWN should select the option after it', async function (assert) {
       this.numbers = numbers;
-      this.selected = A();
+      this.selected = [];
 
       await render(hbs`
       <PowerSelectMultiple

--- a/test-app/tests/integration/components/power-select/multiple-test.js
+++ b/test-app/tests/integration/components/power-select/multiple-test.js
@@ -17,7 +17,7 @@ import RSVP from 'rsvp';
 import { tracked } from '@glimmer/tracking';
 import { isEmpty } from '@ember/utils';
 import { run, later } from '@ember/runloop';
-import { A } from '@ember/array';
+import { TrackedArray } from 'tracked-built-ins';
 
 module(
   'Integration | Component | Ember Power Select (Multiple)',
@@ -1016,15 +1016,16 @@ module(
 
     test('The component works when the array of selected elements is mutated in place instead of replaced', async function (assert) {
       assert.expect(1);
+      
       this.numbers = numbers;
-      this.selected = A();
+      this.selected = new TrackedArray();
       await render(hbs`
       <PowerSelectMultiple @options={{this.numbers}} @selected={{this.selected}} @onChange={{fn (mut this.selected)}} as |option|>
         {{option}}
       </PowerSelectMultiple>
     `);
       await clickTrigger();
-      run(() => this.selected.pushObject(numbers[3])); // eslint-disable-line ember/no-array-prototype-extensions
+      run(() => (this.selected.push(numbers[3])));
       await click('.ember-power-select-option');
       assert
         .dom('.ember-power-select-multiple-option')


### PR DESCRIPTION
Ember.Array will be deprecated / removed early / later.
For this reason we should already avoid this using.

See:
https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-array-prototype-extensions.md