### PR TITLE
Use `ember-modifier` instead of `@ember/render-modifiers`

### DIFF
--- a/ember-power-select/package.json
+++ b/ember-power-select/package.json
@@ -74,10 +74,10 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.7",
-    "@ember/render-modifiers": "^2.1.0",
     "@embroider/util": "^1.13.0",
     "decorator-transforms": "^1.1.0",
     "ember-assign-helper": "^0.5.0",
+    "ember-modifier": "^4.1.0",
     "ember-truth-helpers": "^4.0.3"
   },
   "devDependencies": {

--- a/ember-power-select/src/components/power-select-multiple/trigger.hbs
+++ b/ember-power-select/src/components/power-select-multiple/trigger.hbs
@@ -9,7 +9,7 @@
     @ariaActiveDescendant
   }}
   class="ember-power-select-multiple-options"
-  {{did-update this.openChanged @select.isOpen}}
+  {{this.openChange @select.isOpen}}
   {{on "touchstart" this.chooseOption}}
   {{on "mousedown" this.chooseOption}}
   ...attributes

--- a/ember-power-select/src/components/power-select-multiple/trigger.ts
+++ b/ember-power-select/src/components/power-select-multiple/trigger.ts
@@ -4,6 +4,7 @@ import { get } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
 import type { Select } from '../power-select';
 import type { ComponentLike } from '@glint/template';
+import { modifier } from 'ember-modifier';
 
 interface PowerSelectMultipleTriggerSignature {
   Element: HTMLElement;
@@ -70,6 +71,10 @@ export default class TriggerComponent extends Component<PowerSelectMultipleTrigg
       this.args.select.actions.choose(object);
     }
   }
+
+  openChange = modifier((element: Element, [isOpen]: [boolean]) => {
+    this.openChanged(element, [isOpen]);
+  });
 
   selectedObject<T>(list: IndexAccesible<T> | T[], index: number): T {
     if (isIndexAccesible(list)) {

--- a/ember-power-select/src/components/power-select-multiple/trigger.ts
+++ b/ember-power-select/src/components/power-select-multiple/trigger.ts
@@ -5,6 +5,7 @@ import { scheduleOnce } from '@ember/runloop';
 import type { Select } from '../power-select';
 import type { ComponentLike } from '@glint/template';
 import { modifier } from 'ember-modifier';
+import { deprecate } from '@ember/debug';
 
 interface PowerSelectMultipleTriggerSignature {
   Element: HTMLElement;
@@ -47,11 +48,22 @@ export default class TriggerComponent extends Component<PowerSelectMultipleTrigg
 
   // Actions
   @action
-  openChanged(_el: Element, [isOpen]: [boolean]) {
-    if (isOpen === false && this._lastIsOpen === true) {
-      scheduleOnce('actions', null, this.args.select.actions.search, '');
-    }
-    this._lastIsOpen = isOpen;
+  openChanged(element: Element, [isOpen]: [boolean]) {
+    deprecate(
+      'You are using a power-select-multiple trigger with ember/render-modifier. Replace {{did-update this.openChanged @select.isOpen}} with {{this.openChange @select.isOpen}}.',
+      false,
+      {
+        for: 'ember-power-select',
+        id: 'ember-power-select.no-at-ember-render-modifiers',
+        since: {
+          enabled: '8.1',
+          available: '8.1',
+        },
+        until: '9.0.0',
+      },
+    );
+
+    this._openChanged(element, [isOpen]);
   }
 
   @action
@@ -73,8 +85,15 @@ export default class TriggerComponent extends Component<PowerSelectMultipleTrigg
   }
 
   openChange = modifier((element: Element, [isOpen]: [boolean]) => {
-    this.openChanged(element, [isOpen]);
+    this._openChanged(element, [isOpen]);
   });
+
+  private _openChanged(_el: Element, [isOpen]: [boolean]) {
+    if (isOpen === false && this._lastIsOpen === true) {
+      scheduleOnce('actions', null, this.args.select.actions.search, '');
+    }
+    this._lastIsOpen = isOpen;
+  }
 
   selectedObject<T>(list: IndexAccesible<T> | T[], index: number): T {
     if (isIndexAccesible(list)) {

--- a/ember-power-select/src/components/power-select.hbs
+++ b/ember-power-select/src/components/power-select.hbs
@@ -44,13 +44,10 @@
     {{!-- template-lint-disable no-positive-tabindex --}}
     <dropdown.Trigger
       @eventType={{or @eventType "mousedown"}}
-      {{did-insert this._updateOptions @options}}
-      {{did-update this._updateOptions @options}}
-      {{did-insert this._updateSelected @selected}}
-      {{did-update this._updateSelected @selected}}
-      {{did-insert this._registerAPI publicAPI}}
-      {{did-update this._registerAPI publicAPI}}
-      {{did-update this._performSearch this.searchText}}
+      {{this.updateOptions @options}}
+      {{this.updateSelected @selected}}
+      {{this.updateRegisterAPI publicAPI}}
+      {{this.updatePerformSearch this.searchText}}
       {{on "keydown" this.handleTriggerKeydown}}
       {{on "focus" this.handleFocus}}
       {{on "blur" this.handleBlur}}

--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -19,6 +19,7 @@ import {
   type MatcherFn,
 } from '../utils/group-utils.ts';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { modifier } from 'ember-modifier';
 import type {
   Dropdown,
   DropdownActions,
@@ -655,7 +656,7 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
   }
 
   @action
-  _performSearch(_: any, [term]: [string]): void {
+  _performSearch(_: Element, [term]: [string]): void {
     if (!this.args.search) return;
     if (term === '') {
       this.loading = false;
@@ -699,6 +700,42 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
       scheduleOnce('actions', this, this._resetHighlighted);
     }
   }
+
+  updateOptions = modifier(
+    () => {
+      this._updateOptions();
+    },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    { eager: false },
+  );
+
+  updateSelected = modifier(
+    () => {
+      this._updateSelected();
+    },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    { eager: false },
+  );
+
+  updateRegisterAPI = modifier(
+    (triggerElement: Element, [publicAPI]: [Select]) => {
+      this._registerAPI(triggerElement, [publicAPI]);
+    },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    { eager: false },
+  );
+
+  updatePerformSearch = modifier(
+    (triggerElement: Element, [term]: [string]) => {
+      this._performSearch(triggerElement, [term]);
+    },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    { eager: false },
+  );
 
   _defaultBuildSelection(option: any): any {
     return option;

--- a/ember-power-select/src/components/power-select/before-options.hbs
+++ b/ember-power-select/src/components/power-select/before-options.hbs
@@ -23,7 +23,7 @@
       {{on "focus" @onFocus}}
       {{on "blur" @onBlur}}
       {{on "keydown" this.handleKeydown}}
-      {{did-insert this.focusInput}}
-      {{will-destroy this.clearSearch}}>
+      {{this.setupInput}}
+    >
   </div>
 {{/if}}

--- a/ember-power-select/src/components/power-select/before-options.ts
+++ b/ember-power-select/src/components/power-select/before-options.ts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { scheduleOnce, later } from '@ember/runloop';
 import { action } from '@ember/object';
+import { modifier } from 'ember-modifier';
 import type { Select } from '../power-select';
 
 interface PowerSelectBeforeOptionsSignature {
@@ -24,6 +25,8 @@ interface PowerSelectBeforeOptionsSignature {
 }
 
 export default class PowerSelectBeforeOptionsComponent extends Component<PowerSelectBeforeOptionsSignature> {
+  didSetup: boolean = false;
+
   @action
   clearSearch(): void {
     scheduleOnce('actions', this.args.select.actions, 'search', '');
@@ -55,4 +58,21 @@ export default class PowerSelectBeforeOptionsComponent extends Component<PowerSe
       }
     }, 0);
   }
+
+  setupInput = modifier(
+    (el: HTMLElement) => {
+      if (this.didSetup) {
+        return;
+      }
+
+      this.didSetup = true;
+
+      this.focusInput(el);
+
+      return () => this.clearSearch();
+    },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    { eager: false },
+  );
 }

--- a/ember-power-select/src/components/power-select/before-options.ts
+++ b/ember-power-select/src/components/power-select/before-options.ts
@@ -3,6 +3,7 @@ import { scheduleOnce, later } from '@ember/runloop';
 import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
 import type { Select } from '../power-select';
+import { deprecate } from '@ember/debug';
 
 interface PowerSelectBeforeOptionsSignature {
   Element: HTMLElement;
@@ -29,6 +30,20 @@ export default class PowerSelectBeforeOptionsComponent extends Component<PowerSe
 
   @action
   clearSearch(): void {
+    deprecate(
+      'You are using power-select before-option component with ember/render-modifier. Replace {{will-destroy this.clearSearch}} with {{this.setupInput}}.',
+      false,
+      {
+        for: 'ember-power-select',
+        id: 'ember-power-select.no-at-ember-render-modifiers',
+        since: {
+          enabled: '8.1',
+          available: '8.1',
+        },
+        until: '9.0.0',
+      },
+    );
+
     scheduleOnce('actions', this.args.select.actions, 'search', '');
   }
 
@@ -52,11 +67,21 @@ export default class PowerSelectBeforeOptionsComponent extends Component<PowerSe
 
   @action
   focusInput(el: HTMLElement) {
-    later(() => {
-      if (this.args.autofocus !== false) {
-        el.focus();
-      }
-    }, 0);
+    deprecate(
+      'You are using power-select before-option component with ember/render-modifier. Replace {{did-insert this.focusInput}} with {{this.setupInput}}.',
+      false,
+      {
+        for: 'ember-power-select',
+        id: 'ember-power-select.no-at-ember-render-modifiers',
+        since: {
+          enabled: '8.1',
+          available: '8.1',
+        },
+        until: '9.0.0',
+      },
+    );
+
+    this._focusInput(el);
   }
 
   setupInput = modifier(
@@ -67,12 +92,21 @@ export default class PowerSelectBeforeOptionsComponent extends Component<PowerSe
 
       this.didSetup = true;
 
-      this.focusInput(el);
+      this._focusInput(el);
 
-      return () => this.clearSearch();
+      return () =>
+        scheduleOnce('actions', this.args.select.actions, 'search', '');
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     { eager: false },
   );
+
+  private _focusInput(el: HTMLElement) {
+    later(() => {
+      if (this.args.autofocus !== false) {
+        el.focus();
+      }
+    }, 0);
+  }
 }

--- a/ember-power-select/src/components/power-select/options.hbs
+++ b/ember-power-select/src/components/power-select/options.hbs
@@ -1,5 +1,5 @@
 {{!-- template-lint-disable require-context-role --}}
-<ul {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
+<ul {{this.setupHandlers}} ...attributes>
   {{#if @select.loading}}
     {{#if @loadingMessage}}
       <li class="ember-power-select-option ember-power-select-option--loading-message" role="option" aria-selected={{false}}>{{@loadingMessage}}</li>

--- a/ember-power-select/src/components/power-select/options.ts
+++ b/ember-power-select/src/components/power-select/options.ts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { modifier } from 'ember-modifier';
 import type { Select } from '../power-select';
 import type { ComponentLike } from '@glint/template';
 declare const FastBoot: any;
@@ -73,6 +74,16 @@ export default class PowerSelectOptionsComponent extends Component<PowerSelectOp
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _: TouchEvent,
   ): void => {}) as EventListener;
+
+  private _listElement: Element | null = null;
+  private _didHandlerSetup: boolean = false;
+
+  willDestroy(): void {
+    super.willDestroy();
+    if (this._listElement) {
+      this.removeHandlers(this._listElement);
+    }
+  }
 
   @action
   addHandlers(element: Element) {
@@ -153,6 +164,15 @@ export default class PowerSelectOptionsComponent extends Component<PowerSelectOp
     element.removeEventListener('touchmove', this.touchMoveHandler);
     element.removeEventListener('touchend', this.touchEndHandler);
   }
+
+  setupHandlers = modifier((element: Element) => {
+    if (this._didHandlerSetup) {
+      return;
+    }
+    this._didHandlerSetup = true;
+    this._listElement = element;
+    this.addHandlers(element);
+  });
 
   _optionFromIndex(index: string) {
     const parts = index.split('.');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,9 +314,6 @@ importers:
 
   ember-power-select:
     dependencies:
-      '@ember/render-modifiers':
-        specifier: ^2.1.0
-        version: 2.1.0(@babel/core@7.24.3)(@glint/template@1.4.0)(ember-source@5.7.0)
       '@embroider/addon-shim':
         specifier: ^1.8.7
         version: 1.8.7
@@ -329,6 +326,9 @@ importers:
       ember-assign-helper:
         specifier: ^0.5.0
         version: 0.5.0(ember-source@5.7.0)
+      ember-modifier:
+        specifier: ^4.1.0
+        version: 4.1.0(ember-source@5.7.0)
       ember-truth-helpers:
         specifier: ^4.0.3
         version: 4.0.3(ember-source@5.7.0)
@@ -2507,6 +2507,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    dev: true
 
   /@ember/string@3.1.1:
     resolution: {integrity: sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==}
@@ -8267,6 +8268,7 @@ packages:
     dependencies:
       resolve: 1.22.8
       semver: 5.7.2
+    dev: true
 
   /ember-cli-version-checker@3.1.3:
     resolution: {integrity: sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==}
@@ -8632,6 +8634,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    dev: true
 
   /ember-modifier@4.1.0(ember-source@5.7.0):
     resolution: {integrity: sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==}

--- a/test-app/app/components/custom-group-component.hbs
+++ b/test-app/app/components/custom-group-component.hbs
@@ -1,1 +1,1 @@
-<div class="custom-component" {{did-insert this.setup}}>{{yield}}</div>
+<div class="custom-component" {{this.setup}}>{{yield}}</div>

--- a/test-app/app/components/custom-group-component.js
+++ b/test-app/app/components/custom-group-component.js
@@ -1,9 +1,15 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
+import { modifier } from 'ember-modifier';
 
 export default class CustomGroupComponent extends Component {
-  @action
-  setup() {
+  didSetup = false;
+
+  setup = modifier(() => {
+    if (this.didSetup) {
+      return;
+    }
+
+    this.didSetup = true;
     this.onInit?.bind(this)();
-  }
+  });
 }


### PR DESCRIPTION
This PR removes all usages from `@ember/render-modifiers`.

`@ember/render-modifiers` were meant as a transitional tool from the pre-Octane era, and not long-term usage.

See: https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-at-ember-render-modifiers.md

This changes are not braking.

For apps, which have called our old actions in there custom components, there were added deprecation warnings with notes how they must replace until v9