### PR TITLE
Add `@rootEventType` argument and set `mousedown` as default

### DIFF
--- a/docs/app/templates/public-pages/docs/api-reference.hbs
+++ b/docs/app/templates/public-pages/docs/api-reference.hbs
@@ -171,6 +171,14 @@
       </td>
     </tr>
     <tr>
+      <td>rootEventType</td>
+      <td><code>string</code></td>
+      <td>
+        Defaults to <code>"mousedown"</code>. Indicates the type of event the component will be listening to
+        in order to close.
+      </td>
+    </tr>
+    <tr>
       <td>matcher</td>
       <td><code>function</code></td>
       <td>The <code>function(option, searchTerm)</code> used to filter results. The default one will compare ignoring diacritics</td>

--- a/ember-power-select/src/components/power-select.hbs
+++ b/ember-power-select/src/components/power-select.hbs
@@ -28,6 +28,7 @@
   @calculatePosition={{@calculatePosition}}
   @triggerComponent={{ensure-safe-component @ebdTriggerComponent}}
   @contentComponent={{ensure-safe-component @ebdContentComponent}}
+  @rootEventType={{or @rootEventType "mousedown"}}
   as |dropdown|>
   {{#let (assign dropdown (hash
     selected=this.selected

--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -98,6 +98,7 @@ export interface PowerSelectArgs {
   triggerClass?: string;
   ariaInvalid?: string;
   eventType?: string;
+  rootEventType?: string;
   ariaDescribedBy?: string;
   calculatePosition?: CalculatePosition;
   ebdTriggerComponent?: string | ComponentLike<any>;


### PR DESCRIPTION
### Summary

- Adds the `@rootEventType` to be passed on to `BasicDropdown`
- Sets the default value of `@rootEventType` to `mousedown`
- Add documentation

### Description

I noticed that we set `eventType` to a default of `mousedown` for the `ember-basic-dropdown` trigger (see https://github.com/cibernox/ember-power-select/blob/3aec36878c8b2aa9cf335b7a2220ae448c359fa1/ember-power-select/src/components/power-select.hbs#L46C1-L46C47), but we don't set it for `rootEventType`, which is the event used when clicking outside of the dropdown to open/close. I believe these should be in sync and the default of `mousedown` makes sense (it's also how a default HTML `select` behaves).

We ran into this issue because the click event doesn't propagate when the original element is removed from the DOM. Causing selects to not close properly.