### PR TITLE
fix: copy all properties of the group

### DIFF
--- a/ember-power-select/src/utils/group-utils.ts
+++ b/ember-power-select/src/utils/group-utils.ts
@@ -119,7 +119,7 @@ export interface Group {
   groupName: string;
 }
 function copyGroup(group: Group, suboptions: any[]): Group {
-  const groupCopy: Group = { groupName: group.groupName, options: suboptions };
+  const groupCopy: Group = { ...group, options: suboptions };
   if (Object.prototype.hasOwnProperty.call(group, 'disabled')) {
     groupCopy.disabled = group.disabled;
   }


### PR DESCRIPTION
## Why?
In our use case of `ember-power-select` we add custom properties onto the groups to conditionally render those groups in a different way (in the `@groupComponent` that we pass to `PowerSelectMultiple`).

However, because the `copyGroup` function strips those custom properties, our styling is broken as soon as a user enters a search term.

## What?
Change the `copyGroup` function to include all fields.