### PR TITLE
Use correct typing for rootEventType

### DIFF
--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -23,6 +23,7 @@ import { modifier } from 'ember-modifier';
 import type {
   Dropdown,
   DropdownActions,
+  TRootEventType,
 } from 'ember-basic-dropdown/components/basic-dropdown';
 import type { CalculatePosition } from 'ember-basic-dropdown/utils/calculate-position';
 import { isArray } from '@ember/array';
@@ -98,7 +99,7 @@ export interface PowerSelectArgs {
   triggerClass?: string;
   ariaInvalid?: string;
   eventType?: string;
-  rootEventType?: string;
+  rootEventType?: TRootEventType;
   ariaDescribedBy?: string;
   calculatePosition?: CalculatePosition;
   ebdTriggerComponent?: string | ComponentLike<any>;


### PR DESCRIPTION
As discussed in #1819 we should use the type from ember-basic-dropdown which was introduced in v8.2.0