### PR TITLE
Remove incorrect `Element` from args in `PowerSelectMultipleTrigger`

### DIFF
--- a/ember-power-select/src/components/power-select-multiple/trigger.ts
+++ b/ember-power-select/src/components/power-select-multiple/trigger.ts
@@ -10,7 +10,6 @@ import { deprecate } from '@ember/debug';
 interface PowerSelectMultipleTriggerSignature {
   Element: HTMLElement;
   Args: {
-    Element: HTMLElement;
     select: Select;
     searchEnabled: boolean;
     placeholder?: string;


### PR DESCRIPTION
Discovered in one of my glint projects that we have in multiple trigger the parameter `Element`.

This brings some issues.
1. The paramter is required and you need to pass a `HTMLElement` which is unused
2. you need to add `template-lint-disable no-capital-arguments`, because parameters in uppercase are not allowed

This bug was maybe introduced when there was added glint inside power select

We can safely remove this parameter