### PR TITLE
Fix multiple select error `TypeError Cannot read properties of null (reading 'length')`

### DIFF
--- a/ember-power-select/src/components/power-select-multiple/input.ts
+++ b/ember-power-select/src/components/power-select-multiple/input.ts
@@ -77,7 +77,7 @@ export default class PowerSelectMultipleInputComponent extends Component<PowerSe
               this.args.searchField,
             );
             this.args.select.actions.search(
-              get(lastSelection, this.args.searchField),
+              get(lastSelection, this.args.searchField) || '',
             );
           }
           this.args.select.actions.open(e);


### PR DESCRIPTION
…fixes cases where the result of `get(lastSelection, this.args.searchField)` is not guaranteed to be a string

see https://github.com/cibernox/ember-power-select/issues/1854#issuecomment-2551863511

close #1854