### PR TITLE
Fix a11y error for single select with search field position trigger

### DIFF
--- a/ember-power-select/src/components/power-select.hbs
+++ b/ember-power-select/src/components/power-select.hbs
@@ -67,7 +67,7 @@
       role={{or @triggerRole "combobox"}}
       title={{@title}}
       id={{this.triggerId}}
-      tabindex={{and (not @disabled) (or @tabindex "0")}}
+      tabindex={{and (not @disabled) (or this.tabindex "0")}}
       ...attributes
     >
       {{#let

--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -375,12 +375,15 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
       ? 'before-options'
       : this.args.searchFieldPosition;
   }
-  
+
   get tabindex(): string | number {
-    if (this.args.tabindex === undefined && this.searchFieldPosition === 'trigger') {
+    if (
+      this.args.tabindex === undefined &&
+      this.searchFieldPosition === 'trigger'
+    ) {
       return '-1';
     }
-    
+
     return this.args.tabindex || '0';
   }
 

--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -378,6 +378,7 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
 
   get tabindex(): string | number {
     if (
+      this.args.searchEnabled &&
       this.args.tabindex === undefined &&
       this.searchFieldPosition === 'trigger'
     ) {

--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -370,10 +370,18 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
     return '';
   }
 
-  get searchFieldPosition(): string {
+  get searchFieldPosition(): TSearchFieldPosition {
     return this.args.searchFieldPosition === undefined
       ? 'before-options'
       : this.args.searchFieldPosition;
+  }
+  
+  get tabindex(): string | number {
+    if (this.args.tabindex === undefined && this.searchFieldPosition === 'trigger') {
+      return '-1';
+    }
+    
+    return this.args.tabindex || '0';
   }
 
   // Actions

--- a/ember-power-select/src/components/power-select/input.hbs
+++ b/ember-power-select/src/components/power-select/input.hbs
@@ -8,9 +8,9 @@
     class="ember-power-select-search-input-field"
     value={{@select.searchText}}
     role={{or @role "combobox"}}
-    aria-activedescendant={{@ariaActiveDescendant}}
-    aria-controls={{@listboxId}}
-    aria-owns={{@listboxId}}
+    aria-activedescendant={{if @select.isOpen @ariaActiveDescendant}}
+    aria-controls={{if @select.isOpen @listboxId}}
+    aria-owns={{if @select.isOpen @listboxId}}
     aria-autocomplete="list"
     aria-haspopup="listbox"
     aria-expanded={{if @select.isOpen "true" "false"}}

--- a/test-app/app/components/custom-trigger-with-search.ts
+++ b/test-app/app/components/custom-trigger-with-search.ts
@@ -17,6 +17,8 @@ export interface CustomTriggerWithSearchSignature {
 export default class CustomGroupComponent extends Component<CustomTriggerWithSearchSignature> {
   @action
   onSearch(evt: Event) {
-    this.args.select.actions.search((evt.target as HTMLInputElement).value ?? '');
+    this.args.select.actions.search(
+      (evt.target as HTMLInputElement).value ?? '',
+    );
   }
 }


### PR DESCRIPTION
Similare like in multiple select we need to set some area tags only when dropdown is open and also set the `tabindex` to `-1` for trigger field when the search field is inside trigger.
This solves some a11y issues which we can see in chrome lighthouse