### PR TITLE
Allow ember-concurrency task `Promise<void>` in @search arg

### DIFF
--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -123,7 +123,7 @@ export interface PowerSelectArgs {
   search?: (
     term: string,
     select: Select,
-  ) => readonly any[] | Promise<readonly any[]>;
+  ) => readonly any[] | Promise<readonly any[]> | Promise<void> ;
   onOpen?: (select: Select, e: Event) => boolean | undefined;
   onClose?: (select: Select, e: Event) => boolean | undefined;
   onInput?: (term: string, select: Select, e: Event) => string | false | void;


### PR DESCRIPTION
Type support for case where ember-concurrency task.perform is set as the search function.

restartableTask<unknown, (term: string) => Promise<void>>(asyncArrowTaskFn: (term: string) => Promise<void>): TaskForAsyncTaskFunction<unknown, (term: string) => Promise<void>> (+4 overloads)


```
updateSearch = restartableTask(async (term: string) => {
    await timeout(250)
    this.router.transitionTo({ queryParams: { projectQuery: term } })
  })

<PowerSelect
@search={{this.updateSearch.perform}}
/>
```