### PR TITLE
Fix before options component (add input when position is undefined) & Add tests for `@beforeOptionsComponent` with search field

### DIFF
--- a/ember-power-select/src/components/power-select-multiple.hbs
+++ b/ember-power-select/src/components/power-select-multiple.hbs
@@ -55,7 +55,7 @@
   @search={{@search}}
   @searchEnabled={{@searchEnabled}}
   @searchField={{@searchField}}
-  @searchFieldPosition={{or @searchFieldPosition "trigger"}}
+  @searchFieldPosition={{or @searchFieldPosition (if @beforeOptionsComponent "before-options" "trigger")}}
   @searchMessage={{@searchMessage}}
   @searchMessageComponent={{@searchMessageComponent}}
   @searchPlaceholder={{@searchPlaceholder}}

--- a/ember-power-select/src/components/power-select-multiple.hbs
+++ b/ember-power-select/src/components/power-select-multiple.hbs
@@ -55,7 +55,7 @@
   @search={{@search}}
   @searchEnabled={{@searchEnabled}}
   @searchField={{@searchField}}
-  @searchFieldPosition={{or @searchFieldPosition (if @beforeOptionsComponent "before-options" "trigger")}}
+  @searchFieldPosition={{or @searchFieldPosition "trigger"}}
   @searchMessage={{@searchMessage}}
   @searchMessageComponent={{@searchMessageComponent}}
   @searchPlaceholder={{@searchPlaceholder}}

--- a/ember-power-select/src/components/power-select/before-options.hbs
+++ b/ember-power-select/src/components/power-select/before-options.hbs
@@ -1,4 +1,12 @@
-{{#if (and @searchEnabled (or (eq @searchFieldPosition "before-options") (eq @searchFieldPosition undefined)))}}
+{{#if
+  (and
+    @searchEnabled
+    (or
+      (eq @searchFieldPosition "before-options")
+      (eq @searchFieldPosition undefined)
+    )
+  )
+}}
   <div class="ember-power-select-search">
     {{! template-lint-disable require-input-label }}
     <input

--- a/ember-power-select/src/components/power-select/before-options.hbs
+++ b/ember-power-select/src/components/power-select/before-options.hbs
@@ -1,4 +1,4 @@
-{{#if (and @searchEnabled (eq @searchFieldPosition "before-options"))}}
+{{#if (and @searchEnabled (or (eq @searchFieldPosition "before-options") (eq @searchFieldPosition undefined)))}}
   <div class="ember-power-select-search">
     {{! template-lint-disable require-input-label }}
     <input

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -600,6 +600,9 @@ importers:
       ember-template-lint:
         specifier: ^7.6.0
         version: 7.7.0(@babel/core@7.27.1)
+      ember-truth-helpers:
+        specifier: ^4.0.3
+        version: 4.0.3(ember-source@6.4.0(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-try:
         specifier: ^4.0.0
         version: 4.0.0(encoding@0.1.13)

--- a/test-app/app/components/custom-multiple-before-options.hbs
+++ b/test-app/app/components/custom-multiple-before-options.hbs
@@ -1,0 +1,16 @@
+<p id='custom-before-options-p-tag'>
+  {{@placeholder}}
+</p>
+
+{{#if (and @searchEnabled (eq @searchFieldPosition "before-options"))}}
+  <div id='custom-before-options-search-field'>
+    <input
+      type="search"
+      value=""
+    />
+  </div>
+{{/if}}
+
+{{#let (component (ensure-safe-component @placeholderComponent)) as |ComponentName|}}
+  <ComponentName @placeholder={{@placeholder}} />
+{{/let}}

--- a/test-app/app/components/custom-multiple-before-options.ts
+++ b/test-app/app/components/custom-multiple-before-options.ts
@@ -1,0 +1,15 @@
+import templateOnly from '@ember/component/template-only';
+import type { ComponentLike } from '@glint/template';
+import type { TSearchFieldPosition } from 'ember-power-select/components/power-select';
+
+export interface CustomMultipleBeforeOptionsSignature {
+  Element: Element;
+  Args: {
+    placeholder: string;
+    searchEnabled: boolean;
+    searchFieldPosition: TSearchFieldPosition;
+    placeholderComponent: ComponentLike<any>;
+  };
+}
+
+export default templateOnly<CustomMultipleBeforeOptionsSignature>();

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -87,6 +87,7 @@
     "ember-source-channel-url": "^3.0.0",
     "ember-template-imports": "^4.3.0",
     "ember-template-lint": "^7.6.0",
+    "ember-truth-helpers": "^4.0.3",
     "ember-try": "^4.0.0",
     "eslint": "^9.26.0",
     "eslint-config-prettier": "^10.1.5",

--- a/test-app/tests/integration/components/power-select/customization-with-components-test.js
+++ b/test-app/tests/integration/components/power-select/customization-with-components-test.js
@@ -597,6 +597,91 @@ module(
         );
     });
 
+    test('the power-select-multiple content before the list can be customized passing `@beforeOptionsComponent`, search field not in trigger', async function (assert) {
+      this.countries = countries;
+      this.country = [countries[1]]; // Spain
+
+      await render(hbs`
+      <div class="select-box">
+        <PowerSelectMultiple
+            @options={{this.countries}}
+            @selected={{this.country}}
+            @searchEnabled={{true}}
+            @beforeOptionsComponent={{component "custom-multiple-before-options"}}
+            @placeholder="inception"
+            @onChange={{fn (mut this.selected)}}
+            @extra={{hash coolFlagIcon=true}} as |country|>
+          {{country.code}}
+        </PowerSelectMultiple>
+      </div>
+    `);
+
+      await clickTrigger();
+
+      assert.dom('.ember-power-select-trigger input').doesNotExist();
+
+      assert
+        .dom('.ember-power-select-dropdown #custom-before-options-p-tag')
+        .exists(
+          'The custom component is rendered instead of the usual search bar',
+        );
+      assert
+        .dom('.ember-power-select-dropdown #custom-before-options-p-tag')
+        .hasText('inception', 'The placeholder attribute is passed through.');
+      assert
+        .dom('.ember-power-select-dropdown .ember-power-select-placeholder')
+        .exists('The placeholder component is passed through.');
+      assert
+        .dom('.ember-power-select-search-input')
+        .doesNotExist('The search input is not visible');
+      assert
+        .dom('.ember-power-select-dropdown .custom-before-options-search-field')
+        .doesNotExist('Custom search input is visible');
+    });
+
+    test('the power-select-multiple content before the list can be customized passing `@beforeOptionsComponent`, search field in trigger', async function (assert) {
+      this.countries = countries;
+      this.country = [countries[1]]; // Spain
+
+      await render(hbs`
+      <div class="select-box">
+        <PowerSelectMultiple
+            @options={{this.countries}}
+            @selected={{this.country}}
+            @searchEnabled={{true}}
+            @searchFieldPosition="trigger"
+            @beforeOptionsComponent={{component "custom-multiple-before-options"}}
+            @placeholder="inception"
+            @onChange={{fn (mut this.selected)}}
+            @extra={{hash coolFlagIcon=true}} as |country|>
+          {{country.code}}
+        </PowerSelectMultiple>
+      </div>
+    `);
+
+      await clickTrigger();
+
+      assert.dom('.ember-power-select-trigger input').exists('The search field is in trigger');
+
+      assert
+        .dom('.ember-power-select-dropdown #custom-before-options-p-tag')
+        .exists(
+          'The custom component is rendered instead of the usual search bar',
+        );
+      assert
+        .dom('.ember-power-select-dropdown #custom-before-options-p-tag')
+        .hasText('inception', 'The placeholder attribute is passed through.');
+      assert
+        .dom('.ember-power-select-dropdown .ember-power-select-placeholder')
+        .exists('The placeholder component is passed through.');
+      assert
+        .dom('.ember-power-select-search-input')
+        .doesNotExist('The search input is not visible');
+      assert
+        .dom('.ember-power-select-dropdown .custom-before-options-search-field')
+        .doesNotExist('Custom search input is visible');
+    });
+
     test('The power-select-multiple `@labelComponent` was rendered with text `@labelText="Label for select` and is matching with trigger id', async function (assert) {
       assert.expect(3);
 

--- a/test-app/tests/integration/components/power-select/customization-with-components-test.js
+++ b/test-app/tests/integration/components/power-select/customization-with-components-test.js
@@ -597,7 +597,7 @@ module(
         );
     });
 
-    test('the power-select-multiple content before the list can be customized passing `@beforeOptionsComponent`, search field not in trigger', async function (assert) {
+    test('the power-select-multiple content before the list can be customized passing `@beforeOptionsComponent`, search field in trigger', async function (assert) {
       this.countries = countries;
       this.country = [countries[1]]; // Spain
 
@@ -618,7 +618,7 @@ module(
 
       await clickTrigger();
 
-      assert.dom('.ember-power-select-trigger input').doesNotExist();
+      assert.dom('.ember-power-select-trigger input').exists('The search field is in trigger');
 
       assert
         .dom('.ember-power-select-dropdown #custom-before-options-p-tag')
@@ -639,7 +639,7 @@ module(
         .doesNotExist('Custom search input is visible');
     });
 
-    test('the power-select-multiple content before the list can be customized passing `@beforeOptionsComponent`, search field in trigger', async function (assert) {
+    test('the power-select-multiple content before the list can be customized passing `@beforeOptionsComponent`, search field in before-options', async function (assert) {
       this.countries = countries;
       this.country = [countries[1]]; // Spain
 
@@ -649,7 +649,7 @@ module(
             @options={{this.countries}}
             @selected={{this.country}}
             @searchEnabled={{true}}
-            @searchFieldPosition="trigger"
+            @searchFieldPosition="before-options"
             @beforeOptionsComponent={{component "custom-multiple-before-options"}}
             @placeholder="inception"
             @onChange={{fn (mut this.selected)}}
@@ -661,7 +661,7 @@ module(
 
       await clickTrigger();
 
-      assert.dom('.ember-power-select-trigger input').exists('The search field is in trigger');
+      assert.dom('.ember-power-select-trigger input').doesNotExist('The search field is not in trigger');
 
       assert
         .dom('.ember-power-select-dropdown #custom-before-options-p-tag')

--- a/test-app/types/global.d.ts
+++ b/test-app/types/global.d.ts
@@ -1,9 +1,11 @@
 import '@glint/environment-ember-loose';
 import EmberPowerSelectRegistry from 'ember-power-select/template-registry';
 import type { EmbroiderUtilRegistry } from '@embroider/util';
+import type EmberTruthRegistry from 'ember-truth-helpers/template-registry';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry
     extends EmbroiderUtilRegistry,
-      EmberPowerSelectRegistry {}
+      EmberPowerSelectRegistry,
+      EmberTruthRegistry {}
 }


### PR DESCRIPTION
fix #1881

This should fix the search field issue when somebody has used `PowerSelectBeforeOptions` component outside the addon but doesn't pass `@searchFieldPosition` as property to the component now. Bug was introduced [here](https://github.com/cibernox/ember-power-select/pull/1864/files#diff-89a31b278e584b37152993168044f0903d962eecaaf21a08bb5ca6f2b2bc5638R1), starting with v8.6