### PR TITLE
Remove use of `ember-lifeline` (addon & docs)

### DIFF
--- a/docs/app/components/snippets/action-handling-6.js
+++ b/docs/app/components/snippets/action-handling-6.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { runTask } from 'ember-lifeline';
+import { task, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
 const numbers = [
@@ -26,12 +26,18 @@ export default class extends Component {
 
   @action
   startSelfDestroyCountdown() {
-    let tick = () => {
-      this.counter--;
-      if (!this.destroyed) {
-        runTask(this, tick, 1000);
-      }
-    };
-    this.countdown = runTask(this, tick, 1000);
+    this.countdownLaterTask.perform();
   }
+
+  tick = () => {
+    this.counter--;
+    if (!this.destroyed) {
+      this.countdownLaterTask.perform();
+    }
+  };
+
+  countdownLaterTask = task(async () => {
+    await timeout(1000);
+    this.tick();
+  });
 }

--- a/docs/app/components/snippets/debounce-searches-1.js
+++ b/docs/app/components/snippets/debounce-searches-1.js
@@ -1,18 +1,21 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { debounceTask } from 'ember-lifeline';
+import { restartableTask, timeout } from 'ember-concurrency';
 import RSVP from 'rsvp';
 
 export default class extends Component {
+  @action
   searchRepo(term) {
     return new RSVP.Promise((resolve, reject) => {
-      debounceTask(this, '_performSearch', term, resolve, reject, 600);
+      this._performSearch.perform(term, resolve, reject);
     });
   }
 
-  _performSearch(term, resolve, reject) {
+  _performSearch = restartableTask(async (term, resolve, reject) => {
+    await timeout(600);
     let url = `https://api.github.com/search/repositories?q=${term}`;
     fetch(url)
       .then((resp) => resp.json())
       .then((json) => resolve(json.items), reject);
-  }
+  });
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -86,7 +86,6 @@
     "ember-data": "5.5.0",
     "ember-fetch": "^8.1.2",
     "ember-inflector": "^6.0.0",
-    "ember-lifeline": "^7.0.0",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^9.0.1",

--- a/ember-power-select/package.json
+++ b/ember-power-select/package.json
@@ -74,7 +74,6 @@
     "@embroider/util": "^1.13.2",
     "decorator-transforms": "^2.3.0",
     "ember-assign-helper": "^0.5.0",
-    "ember-lifeline": "^7.0.0",
     "ember-modifier": "^4.2.0",
     "ember-truth-helpers": "^4.0.3 || ^5.0.0"
   },

--- a/ember-power-select/src/components/power-select-multiple/trigger.ts
+++ b/ember-power-select/src/components/power-select-multiple/trigger.ts
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { get } from '@ember/object';
-import { scheduleTask } from 'ember-lifeline';
 import type { Select, TSearchFieldPosition } from '../power-select';
 import type { ComponentLike } from '@glint/template';
 import { modifier } from 'ember-modifier';
@@ -90,7 +89,7 @@ export default class TriggerComponent extends Component<PowerSelectMultipleTrigg
 
   private _openChanged(_el: Element, [isOpen]: [boolean]) {
     if (isOpen === false && this._lastIsOpen === true) {
-      scheduleTask(this, 'actions', () => {
+      Promise.resolve().then(() => {
         this.args.select.actions?.search('');
       });
     }

--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -3,7 +3,6 @@ import { tracked } from '@glimmer/tracking';
 import { action, get } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { addObserver, removeObserver } from '@ember/object/observers';
-import { scheduleTask } from 'ember-lifeline';
 import { isEqual, isNone } from '@ember/utils';
 import { assert, deprecate } from '@ember/debug';
 import {
@@ -504,7 +503,9 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
   @action
   handleFocus(event: FocusEvent): void {
     if (!this.isDestroying) {
-      scheduleTask(this, 'actions', this._updateIsActive, true);
+      Promise.resolve().then(() => {
+        this._updateIsActive(true);
+      });
     }
     if (this.searchFieldPosition === 'trigger') {
       if (event.target) {
@@ -523,7 +524,9 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
   @action
   handleBlur(event: FocusEvent): void {
     if (!this.isDestroying) {
-      scheduleTask(this, 'actions', this._updateIsActive, false);
+      Promise.resolve().then(() => {
+        this._updateIsActive(false);
+      });
     }
     if (this.args.onBlur) {
       this.args.onBlur(this.storedAPI, event);
@@ -750,7 +753,9 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
           }
         });
     } else {
-      scheduleTask(this, 'actions', this._resetHighlighted);
+      Promise.resolve().then(() => {
+        this._resetHighlighted();
+      });
     }
   }
 
@@ -803,7 +808,11 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
   private __registerAPI(_: Element, [publicAPI]: [Select]): void {
     this.storedAPI = publicAPI;
     if (this.args.registerAPI) {
-      scheduleTask(this, 'actions', this.args.registerAPI, publicAPI);
+      Promise.resolve().then(() => {
+        if (this.args.registerAPI) {
+          this.args.registerAPI(publicAPI);
+        }
+      });
     }
   }
 
@@ -836,7 +845,9 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
             this._searchResult = results;
             this.loading = false;
             this.lastSearchedText = term;
-            scheduleTask(this, 'actions', this._resetHighlighted);
+            Promise.resolve().then(() => {
+              this._resetHighlighted();
+            });
           }
         })
         .catch(() => {
@@ -848,7 +859,9 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
     } else {
       this.lastSearchedText = term;
       this._searchResult = searchResult;
-      scheduleTask(this, 'actions', this._resetHighlighted);
+      Promise.resolve().then(() => {
+        this._resetHighlighted();
+      });
     }
   }
 

--- a/ember-power-select/src/components/power-select/before-options.ts
+++ b/ember-power-select/src/components/power-select/before-options.ts
@@ -1,9 +1,9 @@
 import Component from '@glimmer/component';
-import { runTask } from 'ember-lifeline';
 import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
 import type { Select, TSearchFieldPosition } from '../power-select';
 import { deprecate } from '@ember/debug';
+import { task, timeout } from 'ember-concurrency';
 
 interface PowerSelectBeforeOptionsSignature {
   Element: HTMLElement;
@@ -105,14 +105,13 @@ export default class PowerSelectBeforeOptionsComponent extends Component<PowerSe
   );
 
   private _focusInput(el: HTMLElement) {
-    runTask(
-      this,
-      () => {
-        if (this.args.autofocus !== false) {
-          el.focus();
-        }
-      },
-      0,
-    );
+    this.focusLaterTask.perform(el);
   }
+
+  private focusLaterTask = task(async (el: HTMLElement) => {
+    await timeout(0);
+    if (this.args.autofocus !== false) {
+      el.focus();
+    }
+  });
 }

--- a/ember-power-select/src/components/power-select/input.ts
+++ b/ember-power-select/src/components/power-select/input.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
-import { runTask, scheduleTask } from 'ember-lifeline';
 import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
+import { task, timeout } from 'ember-concurrency';
 import type { Select, TSearchFieldPosition } from '../power-select';
 
 interface PowerSelectInputSignature {
@@ -85,7 +85,7 @@ export default class PowerSelectInput extends Component<PowerSelectInputSignatur
       this._lastIsOpen === true &&
       document.activeElement !== element
     ) {
-      scheduleTask(this, 'actions', () => {
+      Promise.resolve().then(() => {
         this.args.select.actions?.search('');
       });
     }
@@ -93,14 +93,13 @@ export default class PowerSelectInput extends Component<PowerSelectInputSignatur
   }
 
   private _focusInput(el: HTMLElement) {
-    runTask(
-      this,
-      () => {
-        if (this.args.autofocus !== false) {
-          el.focus();
-        }
-      },
-      0,
-    );
+    this.focusLaterTask.perform(el);
   }
+
+  private focusLaterTask = task(async (el: HTMLElement) => {
+    await timeout(0);
+    if (this.args.autofocus !== false) {
+      el.focus();
+    }
+  });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,9 +191,6 @@ importers:
       ember-inflector:
         specifier: ^6.0.0
         version: 6.0.0(@babel/core@7.28.3)
-      ember-lifeline:
-        specifier: ^7.0.0
-        version: 7.0.0(@ember/test-helpers@5.2.2(@babel/core@7.28.3)(@glint/template@1.5.2))
       ember-load-initializers:
         specifier: ^3.0.1
         version: 3.0.1(ember-source@6.4.0(@glimmer/component@2.0.0)(rsvp@4.8.5))
@@ -311,9 +308,6 @@ importers:
       ember-assign-helper:
         specifier: ^0.5.0
         version: 0.5.1
-      ember-lifeline:
-        specifier: ^7.0.0
-        version: 7.0.0(@ember/test-helpers@5.2.2(@babel/core@7.28.3)(@glint/template@1.5.2))
       ember-modifier:
         specifier: ^4.2.0
         version: 4.2.2(@babel/core@7.28.3)

--- a/test-app/tests/integration/components/power-select/general-behaviour-test.js
+++ b/test-app/tests/integration/components/power-select/general-behaviour-test.js
@@ -1449,6 +1449,7 @@ module(
         .dom('.ember-power-select-option[aria-current="true"]')
         .hasText('two');
       this.set('numbers', ['one', 'three', 'five', 'seven', 'nine']);
+      await settled();
       assert
         .dom('.ember-power-select-option[aria-current="true"]')
         .hasText('one');


### PR DESCRIPTION
- `ember-lifeline` is unmaintained, and is already triggering deprecation warnings in newer Ember versions
- The recommendation to use it is outdated, see [this issue](https://github.com/ember-cli/eslint-plugin-ember/issues/2185)
- `ember-power-select` is widely used, so the less dependencies the better

In `test-app` will drop `ember-lifeline` after TS improvements, to avoid merge conflicts (test-app was converted in other PR to TS)