### PR TITLE
Add check to avoid auto focus for input field in trigger

### DIFF
--- a/ember-power-select/src/components/power-select/input.ts
+++ b/ember-power-select/src/components/power-select/input.ts
@@ -152,7 +152,10 @@ export default class PowerSelectInput extends Component<PowerSelectInputSignatur
 
       this.didSetup = true;
 
-      if (this.args.searchFieldPosition === undefined || this.args.searchFieldPosition === 'before-options') {
+      if (
+        this.args.searchFieldPosition === undefined ||
+        this.args.searchFieldPosition === 'before-options'
+      ) {
         this._focusInput(el);
       }
 

--- a/ember-power-select/src/components/power-select/input.ts
+++ b/ember-power-select/src/components/power-select/input.ts
@@ -152,7 +152,9 @@ export default class PowerSelectInput extends Component<PowerSelectInputSignatur
 
       this.didSetup = true;
 
-      this._focusInput(el);
+      if (this.args.searchFieldPosition === undefined || this.args.searchFieldPosition === 'before-options') {
+        this._focusInput(el);
+      }
 
       return () => {
         this.args.select.actions?.search('');


### PR DESCRIPTION
This is a incident, which is already longer time, but comes up after merging multiple with single... the auto focus from search input field is only planned when the field is in `before-options`