### PR TITLE
Allow void in all `on` events

### DIFF
--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -126,10 +126,10 @@ export interface PowerSelectArgs {
     term: string,
     select: Select,
   ) => readonly any[] | Promise<readonly any[]>;
-  onOpen?: (select: Select, e: Event) => boolean | undefined;
-  onClose?: (select: Select, e: Event) => boolean | undefined;
-  onInput?: (term: string, select: Select, e: Event) => string | false | void;
-  onKeydown?: (select: Select, e: KeyboardEvent) => boolean | undefined;
+  onOpen?: (select: Select, e: Event) => boolean | void | undefined;
+  onClose?: (select: Select, e: Event) => boolean | void | undefined;
+  onInput?: (term: string, select: Select, e: Event) => string | boolean | void;
+  onKeydown?: (select: Select, e: KeyboardEvent) => boolean | void | undefined;
   onFocus?: (select: Select, event: FocusEvent) => void;
   onBlur?: (select: Select, event: FocusEvent) => void;
   scrollTo?: (option: any, select: Select) => void;


### PR DESCRIPTION
While moving our docs, i have discroverd this typing issues... We can allow users to return also void instaed of undefined (it make no difference for us internal)