### PR TITLE
Typing on trigger should always return an array for multiple select

### DIFF
--- a/ember-power-select/src/components/power-select.ts
+++ b/ember-power-select/src/components/power-select.ts
@@ -1134,7 +1134,7 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
     // if "Aa" would cycle through the results.
     this._expirableSearchText = this._expirableSearchText + c;
     this._repeatingChar = repeatingChar;
-    const match = this.findWithOffset(
+    let match = this.findWithOffset(
       this.storedAPI.options,
       term,
       searchStartOffset,
@@ -1145,6 +1145,9 @@ export default class PowerSelectComponent extends Component<PowerSelectSignature
         this.storedAPI.actions.highlight(match);
         this.storedAPI.actions.scrollTo(match);
       } else {
+        if (this.args.multiple || this.args.legacyMultiple) {
+          match = [match];
+        }
         this.storedAPI.actions.select(match, e);
       }
     }


### PR DESCRIPTION
Discovered in my app last time this bug, which is super old and was already reported years ago 🙈 (fix #1522)

In a classic multiple select (when you have focused) and you press any key, which is matching, all selected values will be removed and only one is selected (see https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_select_multiple). We had already this behavior, but we have returned in multiple select never an array. This means, with this fix we do only fix an issue in app and do not change our current behavior.