### PR TITLE
Update installation docs and fixes in readme

### DIFF
--- a/docs/app/components/snippets/installation-0.gts
+++ b/docs/app/components/snippets/installation-0.gts
@@ -1,3 +1,0 @@
-import BasicDropdownWormhole from 'ember-basic-dropdown/components/basic-dropdown-wormhole';
-
-<template><BasicDropdownWormhole /></template>

--- a/docs/app/templates/public-pages/docs/installation.gts
+++ b/docs/app/templates/public-pages/docs/installation.gts
@@ -5,71 +5,55 @@ import { LinkTo } from '@ember/routing';
   <h1 class="doc-page-title">Installation</h1>
 
   <p>
-    Ember Power Select is distributed as an
-    <a
-      href="http://www.ember-cli.com/"
-      target="_blank"
-      rel="noopener noreferrer"
-    >Ember CLI</a>
-    addon, so the majority of the installation will be done by running the
-    following command in your Ember project directory:
+    To install
+    <code>ember-power-select</code>, run the following command in your Ember
+    project directory:
   </p>
 
   <p>
     <div class="code-block">
-      <pre>$ ember install ember-power-select</pre>
+      <pre>$ pnpm install ember-power-select</pre>
     </div>
   </p>
 
   <p>
-    When installing via
-    <code>ember install</code>, the addon will automatically add the necessary
-    snippets to your app.
-  </p>
-
-  <p>
-    The addon uses ember-concurrency internally, which require some manual steps
-    for installation. For these steps, see the
-    <a
-      href="http://ember-concurrency.com/docs/installation"
-      target="_blank"
-      rel="noopener noreferrer"
-    >ember-concurrency</a>
-    installation page under
-    <i>"Configure Babel Transform"</i>.
-  </p>
-
-  <h2 class="t3">Manual Installation</h2>
-
-  <p>
-    If you haven't used
-    <code>ember install</code>, you need to add
+    This addon is built on top of
     <code>ember-basic-dropdown</code>
     and
-    <code>ember-concurrency</code>
-    as
-    <code>devDependencies</code>
-    in your
-    <code>package.json</code>.
+    <code>ember-concurrency</code>. If you haven't installed them yet, please
+    follow their official installation guides:
+  </p>
+
+  <ul>
+    <li>
+      <a
+        href="https://ember-basic-dropdown.com/docs/installation"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        ember-basic-dropdown Installation Guide
+      </a>
+    </li>
+    <li>
+      <a
+        href="https://ember-concurrency.com/docs/installation"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        ember-concurrency Installation Guide
+      </a>
+    </li>
+  </ul>
+
+  <p>
+    After installing the dependencies, complete the following additional setup
+    steps.
   </p>
 
   <p>
-    After installation, add the following line to the templates where you want
-    to render the power select content, such as in your
-    <code>application.hbs</code>. This component will render the power select
-    content.
-  </p>
-
-  <CodeExample
-    @glimmerTs="installation-0.gts"
-    @showResult={{false}}
-    @activeTab="glimmer-ts"
-  />
-
-  <p>
-    If you use vanilla CSS, add the following line to your
+    If you are using vanilla CSS, add the following line to your
     <code>app.js</code>
-    or any route/controller/component
+    or any route, controller, or component
     <code>.js/.ts</code>
     file:
   </p>
@@ -127,16 +111,6 @@ import { LinkTo } from '@ember/routing';
   <p>
     For more information about styling, see
     <LinkTo @route="public-pages.docs.styles">Basic Customization: Styles</LinkTo>.
-  </p>
-
-  <p>
-    For further details on ember-concurrency installation, visit the
-    <a
-      href="http://ember-concurrency.com/docs/installation"
-      target="_blank"
-      rel="noopener noreferrer"
-    >ember-concurrency</a>
-    installation page.
   </p>
 
   <div class="doc-page-nav">

--- a/ember-power-select/README.md
+++ b/ember-power-select/README.md
@@ -1,79 +1,69 @@
-# ember-power-select
+[![NPM](https://badge.fury.io/js/ember-power-select.svg)](https://www.npmjs.com/package/ember-power-select)
+[![Ember Observer Score](https://emberobserver.com/badges/ember-power-select.svg)](https://emberobserver.com/addons/ember-power-select)
+![Ember Version](https://img.shields.io/badge/ember-%3E%3D3.28-brightgreen?logo=emberdotjs&logoColor=white)
+[![Discord](https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord)](https://discord.com/channels/480462759797063690/486202731766349824)
+[![Build Status](https://github.com/cibernox/ember-power-select/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/cibernox/ember-power-select)
 
-[![CI](https://github.com/cibernox/ember-power-select/actions/workflows/ci.yml/badge.svg)](https://github.com/cibernox/ember-power-select/actions/workflows/ci.yml)
-[![Ember Observer Score](http://emberobserver.com/badges/ember-power-select.svg)](http://emberobserver.com/addons/ember-power-select)
-[![Code Climate](https://codeclimate.com/github/cibernox/ember-power-select/badges/gpa.svg)](https://codeclimate.com/github/cibernox/ember-power-select)
-[![npm version](https://badge.fury.io/js/ember-power-select.svg)](https://badge.fury.io/js/ember-power-select)
+# ember-power-select
 
 Ember Power Select is a select component written in Ember with a focus in flexibility and extensibility.
 
 It is designed to work well with the way we build Ember apps, so it plays nicely with promises, ember-concurrency's tasks,
 ember-data collections and follows idiomatic patterns.
 
+### Features
+
+* 🖊 **TypeScript support** – ships with type definitions for smooth TypeScript integration.
+* ✨ **Glint support** – template type-checking out of the box for safer templates.
+* 🚀 **FastBoot compatible** – works in server-rendered Ember apps.
+* 🕶 **Shadow DOM support** – can be rendered inside shadow roots without breaking positioning or events.
+* 🛠 **Addon v2 ready** – modern Ember Addon v2 format.
+* 🔧 **Flexible API** – fully customizable; you control the markup and styling.
+* ♿ **Accessible by default** – full keyboard navigation, ARIA attributes, and focus management built-in.
+
+#### Selection & Search
+
+* 🧩 **Single & multiple selection** – built-in support for both modes.
+* 🔎 **Built-in search field** – optional search input for filtering options.
+* 📍 **Flexible search placement** – render the search field inside the trigger *or* inside the dropdown list.
+* 📝 **Rich content rendering** – render HTML or custom components inside options and triggers.
+* 🔍 **Smart filtering** – diacritic-insensitive search with accent sanitization.
+* 🧠 **Custom matchers** – plug in your own matching and scoring logic.
+* ⚡ **Asynchronous search** – remote and delayed searching with debounce support.
+* ⏳ **Promise-aware** – works with promises and async data.
+* 🔄 **ember-concurrency friendly** – works seamlessly with task cancellation.
+
+#### UX & Customization
+
+* 🧺 **Grouping & placeholders** – grouped options (no nesting limit) and customizable placeholders.
+* ❌ **Clearable selections** – easily reset or clear selected values.
+* 🚫 **Disabled states** – disable the whole component or individual options.
+* 🎨 **Theming support** – easy CSS-based theming and design customization.
+* 🎞 **CSS animations & transitions** – smooth opening/closing and state-change animations.
+* 🧩 **Fully composable** – replace any internal part with your own components or completely custom UI.
+
 ## Compatibility
 
 * Ember.js v3.28 or above
 * Ember CLI v3.28 or above
 
-Version 1.X works in Ember **2.3.1+**, beta and canary with no deprecations
-whatsoever. Any deprecation will be considered a bug.
-
-Version 2.X requires Ember **2.10.0+**.
-
-Version 3.X requires Ember **3.11.0+**.
-
-Version 4.X requires Ember **3.13.0+**.
-
-Version 5.X & 6.X requires Ember **3.16.0+**.
-
-Version 7.X & 8.X requires Ember **3.28.0+**.
-
 ## Installation
 
 ```
-ember install ember-power-select
+pnpm install ember-power-select
 ```
 
 For more installation details see [documentation](https://ember-power-select.com/docs/installation)
-
-## Features overview
-
-Ember Power Select wants to be as agnostic as possible about how you're going to use it, but it still provides
-some default implementations that will match 95% of your needs, and exposes actions to customize the other
-5% of usages.
-
-Features include:
-
-* Single select
-* Multiple select
-* HTML inside the options or the trigger.
-* Filter options sanitizing diacritics.
-* Custom matchers.
-* Asynchonous searches.
-* Theming
-* Fully promise-aware, with loading states.
-* Compatible with ember-concurrency task cancellation.
-* Compatibility with ember-data's ArrayProxies
-* Groups (with not deep limit), placeholders...
-* Clear the selection
-* Disable the component or individual options
-* CSS animations and transitions
-* ... and anything else you want. Just replace parts of the selects with your own components.
 
 ## Usage
 
 Check the full documentation with live examples at [www.ember-power-select.com](http://www.ember-power-select.com) and
 please open an issue if something doesn't work or is not clear enough.
 
-Good docs are important :)
-
 ## Extensions
 
 Ember-power-select's focus on flexibility enables the community to build richer and more tailor made
 components on top of it, focused in solving one particular problem, using composition.
-
-Check the [addons](http://www.ember-power-select.com/addons) section to see some and if you create
-one that you want to open source open a PR to include it in the list.
 
 ## Browser support
 


### PR DESCRIPTION
We no longer recommend installing the addon via the blueprint. The blueprint installation is something "magical" and maintaining support for all Ember file types (`js`, `ts`, `gjs`, `gts`) requires a significant amount of work. It is clearer and easier for us to maintain if addon consumers perform each installation step manually.

The blueprints are still present, but will be removed in next major