### PR TITLE
Drop support for ember < 4.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.28
-          - ember-lts-4.4
-          - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.4
           - ember-lts-5.8

--- a/ember-power-select/README.md
+++ b/ember-power-select/README.md
@@ -1,6 +1,6 @@
 [![NPM](https://badge.fury.io/js/ember-power-select.svg)](https://www.npmjs.com/package/ember-power-select)
 [![Ember Observer Score](https://emberobserver.com/badges/ember-power-select.svg)](https://emberobserver.com/addons/ember-power-select)
-![Ember Version](https://img.shields.io/badge/ember-%3E%3D3.28-brightgreen?logo=emberdotjs&logoColor=white)
+![Ember Version](https://img.shields.io/badge/ember-%3E%3D4.12-brightgreen?logo=emberdotjs&logoColor=white)
 [![Discord](https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord)](https://discord.com/channels/480462759797063690/486202731766349824)
 [![Build Status](https://github.com/cibernox/ember-power-select/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/cibernox/ember-power-select)
 
@@ -44,8 +44,8 @@ ember-data collections and follows idiomatic patterns.
 
 ## Compatibility
 
-* Ember.js v3.28 or above
-* Ember CLI v3.28 or above
+- Embroider or ember-auto-import v2
+- Ember.js v4.12 or above
 
 ## Installation
 

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -8,45 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.4',
-            '@glimmer/component': '^1.1.2',
-            'ember-cli': '~4.12.2',
-            'ember-load-initializers': '^2.1.2',
-            'ember-qunit': '^6.0.0',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.28.0',
-            'ember-truth-helpers': '^4.0.3',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.4',
-        npm: {
-          devDependencies: {
-            '@glimmer/component': '^1.1.2',
-            '@ember/test-helpers': '5.1.0',
-            '@ember/test-waiters': '^3.1.0',
-            'ember-load-initializers': '^2.1.2',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~4.4.0',
-            'ember-truth-helpers': '^4.0.3',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.8',
-        npm: {
-          devDependencies: {
-            '@glimmer/component': '^1.1.2',
-            'ember-resolver': '^11.0.0',
-            'ember-source': '~4.8.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Ember 3.28 LTS reached EOL (end of life) on January 2, 2023.
Dropping support for older Ember versions helps us reduce maintenance costs and enables us to use modern Ember conventions and features.