### PR TITLE
Remove `ember-assign-helper` dependency

### DIFF
--- a/ember-power-select/package.json
+++ b/ember-power-select/package.json
@@ -69,7 +69,6 @@
   "dependencies": {
     "@embroider/addon-shim": "^1.10.2",
     "decorator-transforms": "^2.3.0",
-    "ember-assign-helper": "^0.5.1",
     "ember-element-helper": "^0.8.8",
     "ember-modifier": "^4.2.2",
     "ember-truth-helpers": "^5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,9 +275,6 @@ importers:
       decorator-transforms:
         specifier: ^2.3.0
         version: 2.3.0(@babel/core@7.28.5)
-      ember-assign-helper:
-        specifier: ^0.5.1
-        version: 0.5.1
       ember-element-helper:
         specifier: ^0.8.8
         version: 0.8.8
@@ -3960,9 +3957,6 @@ packages:
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
-
-  ember-assign-helper@0.5.1:
-    resolution: {integrity: sha512-dXHbwlBTJWVjG7k4dhVrT3Gh4nQt6rC2LjyltuPztIhQ+YcPYHMqAPJRJYLGZu16aPSJbaGF8K+u51i7CLzqlQ==}
 
   ember-auto-import@2.12.0:
     resolution: {integrity: sha512-J9wVTddnpx1ZPf6CgtMs8byp5t9ZZITUX9v+H+PgSDSgbYbDrVlKr2RGDfJLrnaTpuWwZqh1b54/9jLaERr6QA==}
@@ -12454,12 +12448,6 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.267: {}
-
-  ember-assign-helper@0.5.1:
-    dependencies:
-      '@embroider/addon-shim': 1.10.2
-    transitivePeerDependencies:
-      - supports-color
 
   ember-auto-import@2.12.0(@glint/template@1.7.3)(webpack@5.104.1):
     dependencies:


### PR DESCRIPTION
We don't need anymore `ember-assign-helper`, because addon is gts