### PR TITLE
Remove `Component` keyword in class name

### DIFF
--- a/demo-app/components/custom-before-options-two.gts
+++ b/demo-app/components/custom-before-options-two.gts
@@ -1,10 +1,10 @@
-import PowerSelectBeforeOptionsComponent from '#src/components/power-select/before-options.gts';
+import PowerSelectBeforeOptions from '#src/components/power-select/before-options.gts';
 import type { SelectedCountryExtra } from '../utils/constants';
 import { on } from '@ember/modifier';
 
 export default class CustomBeforeOptionsTwo<
   T,
-> extends PowerSelectBeforeOptionsComponent<T, SelectedCountryExtra> {
+> extends PowerSelectBeforeOptions<T, SelectedCountryExtra> {
   <template>
     {{#if @extra.passedAction}}
       <button

--- a/demo-app/components/custom-before-options-two.gts
+++ b/demo-app/components/custom-before-options-two.gts
@@ -2,9 +2,10 @@ import PowerSelectBeforeOptions from '#src/components/power-select/before-option
 import type { SelectedCountryExtra } from '../utils/constants';
 import { on } from '@ember/modifier';
 
-export default class CustomBeforeOptionsTwo<
+export default class CustomBeforeOptionsTwo<T> extends PowerSelectBeforeOptions<
   T,
-> extends PowerSelectBeforeOptions<T, SelectedCountryExtra> {
+  SelectedCountryExtra
+> {
   <template>
     {{#if @extra.passedAction}}
       <button

--- a/demo-app/components/custom-before-options.gts
+++ b/demo-app/components/custom-before-options.gts
@@ -1,9 +1,9 @@
-import PowerSelectBeforeOptionsComponent from '#src/components/power-select/before-options.gts';
+import PowerSelectBeforeOptions from '#src/components/power-select/before-options.gts';
 
 export default class CustomBeforeOptions<
   T,
   TExtra = undefined,
-> extends PowerSelectBeforeOptionsComponent<T, TExtra> {
+> extends PowerSelectBeforeOptions<T, TExtra> {
   <template>
     <p id="custom-before-options-p-tag">
       {{@placeholder}}

--- a/demo-app/components/custom-label-component.gts
+++ b/demo-app/components/custom-label-component.gts
@@ -1,10 +1,10 @@
-import PowerSelectLabelComponent from '#src/components/power-select/label.gts';
+import PowerSelectLabel from '#src/components/power-select/label.gts';
 
 export default class CustomLabelComponent<
   T,
   TExtra = unknown,
   IsMultiple extends boolean = false,
-> extends PowerSelectLabelComponent<T, TExtra, IsMultiple> {
+> extends PowerSelectLabel<T, TExtra, IsMultiple> {
   <template>
     <label
       id={{@labelId}}

--- a/demo-app/components/custom-trigger-component.gts
+++ b/demo-app/components/custom-trigger-component.gts
@@ -1,9 +1,9 @@
-import PowerSelectTriggerComponent from '#src/components/power-select/trigger.gts';
+import PowerSelectTrigger from '#src/components/power-select/trigger.gts';
 
 export default class CustomTrigger<
   T,
   TExtra = undefined,
-> extends PowerSelectTriggerComponent<T, TExtra> {
+> extends PowerSelectTrigger<T, TExtra> {
   <template>
     <div class="custom-trigger-component">{{@loadingMessage}}</div>
   </template>

--- a/demo-app/components/custom-trigger-that-handles-focus.gts
+++ b/demo-app/components/custom-trigger-that-handles-focus.gts
@@ -1,8 +1,8 @@
-import PowerSelectTriggerComponent from '#src/components/power-select/trigger.gts';
+import PowerSelectTrigger from '#src/components/power-select/trigger.gts';
 import type { Country, SelectedCountryExtra } from '../utils/constants';
 import { on } from '@ember/modifier';
 
-export default class CustomTriggerThatHandlesFocus extends PowerSelectTriggerComponent<
+export default class CustomTriggerThatHandlesFocus extends PowerSelectTrigger<
   Country,
   SelectedCountryExtra
 > {

--- a/demo-app/components/list-of-countries.gts
+++ b/demo-app/components/list-of-countries.gts
@@ -4,11 +4,7 @@ import { get } from '@ember/helper';
 
 export default class ListOfCountries<
   IsMultiple extends boolean = false,
-> extends PowerSelectOptions<
-  Country,
-  SelectedCountryExtra,
-  IsMultiple
-> {
+> extends PowerSelectOptions<Country, SelectedCountryExtra, IsMultiple> {
   <template>
     <div class="ember-power-select-options">
       <p>

--- a/demo-app/components/list-of-countries.gts
+++ b/demo-app/components/list-of-countries.gts
@@ -1,10 +1,10 @@
-import PowerSelectOptionsComponent from '#src/components/power-select/options.gts';
+import PowerSelectOptions from '#src/components/power-select/options.gts';
 import type { Country, SelectedCountryExtra } from '../utils/constants';
 import { get } from '@ember/helper';
 
 export default class ListOfCountries<
   IsMultiple extends boolean = false,
-> extends PowerSelectOptionsComponent<
+> extends PowerSelectOptions<
   Country,
   SelectedCountryExtra,
   IsMultiple

--- a/demo-app/components/selected-country.gts
+++ b/demo-app/components/selected-country.gts
@@ -1,10 +1,10 @@
-import PowerSelectTriggerComponent from '#src/components/power-select/trigger.gts';
+import PowerSelectTrigger from '#src/components/power-select/trigger.gts';
 import type { Country, SelectedCountryExtra } from '../utils/constants';
 import emberPowerSelectIsArray from '#src/helpers/ember-power-select-is-array.ts';
 
 export default class SelectedCountry<
   T extends boolean = false,
-> extends PowerSelectTriggerComponent<Country, SelectedCountryExtra, T> {
+> extends PowerSelectTrigger<Country, SelectedCountryExtra, T> {
   <template>
     {{#if (emberPowerSelectIsArray @select.selected)}}
       {{#each @select.selected as |option|}}

--- a/src/components/power-select.gts
+++ b/src/components/power-select.gts
@@ -550,8 +550,7 @@ export default class PowerSelect<
   get labelComponent(): ComponentLike<
     PowerSelectLabelSignature<T, TExtra, IsMultiple>
   > {
-    return (this.args.labelComponent ??
-      PowerSelectLabel) as ComponentLike<
+    return (this.args.labelComponent ?? PowerSelectLabel) as ComponentLike<
       PowerSelectLabelSignature<T, TExtra, IsMultiple>
     >;
   }
@@ -559,8 +558,7 @@ export default class PowerSelect<
   get triggerComponent(): ComponentLike<
     PowerSelectTriggerSignature<T, TExtra, IsMultiple>
   > {
-    return (this.args.triggerComponent ??
-      PowerSelectTrigger) as ComponentLike<
+    return (this.args.triggerComponent ?? PowerSelectTrigger) as ComponentLike<
       PowerSelectTriggerSignature<T, TExtra, IsMultiple>
     >;
   }
@@ -604,8 +602,7 @@ export default class PowerSelect<
   get optionsComponent(): ComponentLike<
     PowerSelectOptionsSignature<T, TExtra, IsMultiple>
   > {
-    return (this.args.optionsComponent ??
-      PowerSelectOptions) as ComponentLike<
+    return (this.args.optionsComponent ?? PowerSelectOptions) as ComponentLike<
       PowerSelectOptionsSignature<T, TExtra, IsMultiple>
     >;
   }

--- a/src/components/power-select.gts
+++ b/src/components/power-select.gts
@@ -17,13 +17,13 @@ import {
 } from '../utils/group-utils.ts';
 import { task, timeout } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
-import PowerSelectLabelComponent from './power-select/label.gts';
-import PowerSelectTriggerComponent from './power-select/trigger.gts';
+import PowerSelectLabel from './power-select/label.gts';
+import PowerSelectTrigger from './power-select/trigger.gts';
 import PowerSelectPlaceholderComponent from './power-select/placeholder.gts';
-import PowerSelectBeforeOptionsComponent from './power-select/before-options.gts';
+import PowerSelectBeforeOptions from './power-select/before-options.gts';
 import SearchMessageComponent from './power-select/search-message.gts';
 import NoMatchesMessageComponent from './power-select/no-matches-message.gts';
-import PowerSelectOptionsComponent from './power-select/options.gts';
+import PowerSelectOptions from './power-select/options.gts';
 import PowerSelectGroupComponent from './power-select/power-select-group.gts';
 import type { BasicDropdownDefaultBlock } from 'ember-basic-dropdown/components/basic-dropdown';
 import type { Dropdown, TRootEventType } from 'ember-basic-dropdown/types';
@@ -301,7 +301,7 @@ function getOptionMatcher<T>(
   }
 }
 
-export default class PowerSelectComponent<
+export default class PowerSelect<
   T,
   IsMultiple extends boolean = false,
   TExtra = undefined,
@@ -551,7 +551,7 @@ export default class PowerSelectComponent<
     PowerSelectLabelSignature<T, TExtra, IsMultiple>
   > {
     return (this.args.labelComponent ??
-      PowerSelectLabelComponent) as ComponentLike<
+      PowerSelectLabel) as ComponentLike<
       PowerSelectLabelSignature<T, TExtra, IsMultiple>
     >;
   }
@@ -560,7 +560,7 @@ export default class PowerSelectComponent<
     PowerSelectTriggerSignature<T, TExtra, IsMultiple>
   > {
     return (this.args.triggerComponent ??
-      PowerSelectTriggerComponent) as ComponentLike<
+      PowerSelectTrigger) as ComponentLike<
       PowerSelectTriggerSignature<T, TExtra, IsMultiple>
     >;
   }
@@ -578,7 +578,7 @@ export default class PowerSelectComponent<
     PowerSelectBeforeOptionsSignature<T, TExtra, IsMultiple>
   > {
     return (this.args.beforeOptionsComponent ??
-      PowerSelectBeforeOptionsComponent) as ComponentLike<
+      PowerSelectBeforeOptions) as ComponentLike<
       PowerSelectBeforeOptionsSignature<T, TExtra, IsMultiple>
     >;
   }
@@ -605,7 +605,7 @@ export default class PowerSelectComponent<
     PowerSelectOptionsSignature<T, TExtra, IsMultiple>
   > {
     return (this.args.optionsComponent ??
-      PowerSelectOptionsComponent) as ComponentLike<
+      PowerSelectOptions) as ComponentLike<
       PowerSelectOptionsSignature<T, TExtra, IsMultiple>
     >;
   }

--- a/src/components/power-select/before-options.gts
+++ b/src/components/power-select/before-options.gts
@@ -46,7 +46,7 @@ export interface PowerSelectBeforeOptionsSignature<
   };
 }
 
-export default class PowerSelectBeforeOptionsComponent<
+export default class PowerSelectBeforeOptions<
   T = unknown,
   TExtra = unknown,
   IsMultiple extends boolean = false,

--- a/src/components/power-select/label.gts
+++ b/src/components/power-select/label.gts
@@ -27,7 +27,7 @@ export interface PowerSelectLabelSignature<
   Args: PowerSelectLabelArgs<T, TExtra, IsMultiple>;
 }
 
-export default class PowerSelectLabelComponent<
+export default class PowerSelectLabel<
   T = unknown,
   TExtra = unknown,
   IsMultiple extends boolean = false,

--- a/src/components/power-select/options.gts
+++ b/src/components/power-select/options.gts
@@ -70,7 +70,7 @@ if (typeof FastBoot === 'undefined') {
   })(window.Element.prototype);
 }
 
-export default class PowerSelectOptionsComponent<
+export default class PowerSelectOptions<
   T = unknown,
   TExtra = unknown,
   IsMultiple extends boolean = false,

--- a/src/components/power-select/power-select-group.gts
+++ b/src/components/power-select/power-select-group.gts
@@ -18,7 +18,7 @@ export interface PowerSelectPowerSelectGroupSignature<
   };
 }
 
-export default class PowerSelectPowerSelectGroupComponent<
+export default class PowerSelectPowerSelectGroup<
   T extends GroupBase,
   TExtra = unknown,
   IsMultiple extends boolean = false,

--- a/src/components/power-select/trigger.gts
+++ b/src/components/power-select/trigger.gts
@@ -57,7 +57,7 @@ export interface PowerSelectTriggerSignature<
   };
 }
 
-export default class PowerSelectTriggerComponent<
+export default class PowerSelectTrigger<
   T = unknown,
   TExtra = unknown,
   IsMultiple extends boolean = false,

--- a/src/template-registry.ts
+++ b/src/template-registry.ts
@@ -2,18 +2,16 @@
 // Add all your components, helpers and modifiers to the template registry here, so apps don't have to do this.
 // See https://typed-ember.gitbook.io/glint/environments/ember/authoring-addons
 
-import type PowerSelectComponent from './components/power-select';
-import type PowerSelectMultipleInputComponent from './components/power-select/input';
+import type PowerSelect from './components/power-select';
 import type emberPowerSelectIsEqual from './helpers/ember-power-select-is-equal';
 import type emberPowerSelectIsArray from './helpers/ember-power-select-is-array';
 import type emberPowerSelectIsGroup from './helpers/ember-power-select-is-group';
 import type emberPowerSelectIsSelectedPresent from './helpers/ember-power-select-is-selected-present';
 
 export default interface Registry {
-  PowerSelect: typeof PowerSelectComponent;
+  PowerSelect: typeof PowerSelect;
   'ember-power-select-is-group': typeof emberPowerSelectIsGroup;
   'ember-power-select-is-equal': typeof emberPowerSelectIsEqual;
   'ember-power-select-is-array': typeof emberPowerSelectIsArray;
   'ember-power-select-is-selected-present': typeof emberPowerSelectIsSelectedPresent;
-  'PowerSelect::Input': typeof PowerSelectMultipleInputComponent;
 }

--- a/tests/integration/components/power-select/general-behaviour-test.gts
+++ b/tests/integration/components/power-select/general-behaviour-test.gts
@@ -24,7 +24,7 @@ import {
   type Country,
 } from '../../../../demo-app/utils/constants';
 import { modifier } from 'ember-modifier';
-import PowerSelectBeforeOptionsComponent, {
+import PowerSelectBeforeOptions, {
   type PowerSelectBeforeOptionsSignature,
 } from '#src/components/power-select/before-options.gts';
 import type { ComponentLike } from '@glint/template';
@@ -450,7 +450,7 @@ module(
       this.numbers = numbers;
       this.foo = () => {};
 
-      this.beforeOptionsComponent = PowerSelectBeforeOptionsComponent;
+      this.beforeOptionsComponent = PowerSelectBeforeOptions;
 
       await render<NumbersContext>(
         <template>

--- a/tests/integration/components/power-select/type-test-options-default.gts
+++ b/tests/integration/components/power-select/type-test-options-default.gts
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from '../../../helpers';
-import PowerSelectOptionsComponent from '#src/components/power-select/options.gts';
+import PowerSelectOptions from '#src/components/power-select/options.gts';
 
 // Extending PowerSelectOptionsComponent without providing type params should
 // work (T should default to unknown). Without the fix, this produces TS2707.
-class CustomOptions extends PowerSelectOptionsComponent {}
+class CustomOptions extends PowerSelectOptions {}
 
 module(
   'Integration | Component | Ember Power Select (Type tests - options default type param)',

--- a/tests/integration/components/power-select/type-test-options-variance.gts
+++ b/tests/integration/components/power-select/type-test-options-variance.gts
@@ -1,8 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from '../../../helpers';
 import { render } from '@ember/test-helpers';
-import PowerSelectOptionsComponent from '#src/components/power-select/options.gts';
-import PowerSelectBeforeOptionsComponent from '#src/components/power-select/before-options.gts';
+import PowerSelectOptions from '#src/components/power-select/options.gts';
+import PowerSelectBeforeOptions from '#src/components/power-select/before-options.gts';
 import PowerSelect from '#src/components/power-select.gts';
 import Component from '@glimmer/component';
 import { fn } from '@ember/helper';
@@ -15,11 +15,11 @@ interface Dog {
 // Real-world pattern: a custom options component (e.g. virtual scrolling)
 // that is reused across PowerSelects with different option types.
 // T must be unknown because the component doesn't know what it will render.
-class VirtualOptions extends PowerSelectOptionsComponent<unknown> {}
+class VirtualOptions extends PowerSelectOptions<unknown> {}
 
 // Same pattern for before-options: a custom search UI that doesn't care about T.
 // No explicit type arg needed — the default is already `unknown`.
-class CustomBeforeOptions extends PowerSelectBeforeOptionsComponent {}
+class CustomBeforeOptions extends PowerSelectBeforeOptions {}
 
 class MyComponent extends Component {
   dogs: Dog[] = [


### PR DESCRIPTION
In components we should remove in naming the `Component` keyword. After this change nobody must manually rename the component after import from `<PowerSelectComponent>` to `<PowerSelect>` & this follows our docs