### PR TITLE
Improve check for property in object (avoid exception with warp drive schemas)

### DIFF
--- a/src/utils/equal.ts
+++ b/src/utils/equal.ts
@@ -1,5 +1,10 @@
 export default function isEqual(a: unknown, b: unknown): boolean {
-  if (a && typeof (a as IsEqual).isEqual === 'function') {
+  if (
+    a &&
+    typeof a === 'object' &&
+    'isEqual' in a &&
+    typeof (a as IsEqual).isEqual === 'function'
+  ) {
     return (a as IsEqual).isEqual(b);
   }
 

--- a/src/utils/group-utils.ts
+++ b/src/utils/group-utils.ts
@@ -105,7 +105,9 @@ export function optionAtIndex<T>(
         if (isGroup(entry)) {
           const found = walk(
             (entry as unknown as GroupBase<T>).options,
-            ancestorIsDisabled || !!(entry as unknown as GroupBase<T>).disabled,
+            ancestorIsDisabled ||
+              ('disabled' in entry &&
+                !!(entry as unknown as GroupBase<T>).disabled),
           );
           if (found) {
             return found;
@@ -114,7 +116,8 @@ export function optionAtIndex<T>(
           return {
             disabled:
               ancestorIsDisabled ||
-              !!(entry as unknown as GroupBase<T>).disabled,
+              ('disabled' in (entry as GroupBase<T>) &&
+                !!(entry as unknown as GroupBase<T>).disabled),
             option: entry as Option<T>,
           };
         } else {

--- a/src/utils/group-utils.ts
+++ b/src/utils/group-utils.ts
@@ -106,7 +106,8 @@ export function optionAtIndex<T>(
           const found = walk(
             (entry as unknown as GroupBase<T>).options,
             ancestorIsDisabled ||
-              ('disabled' in entry &&
+              (typeof entry === 'object' &&
+                'disabled' in entry &&
                 !!(entry as unknown as GroupBase<T>).disabled),
           );
           if (found) {
@@ -116,7 +117,8 @@ export function optionAtIndex<T>(
           return {
             disabled:
               ancestorIsDisabled ||
-              ('disabled' in (entry as GroupBase<T>) &&
+              (typeof entry === 'object' &&
+                'disabled' in (entry as GroupBase<T>) &&
                 !!(entry as unknown as GroupBase<T>).disabled),
             option: entry as Option<T>,
           };


### PR DESCRIPTION
When passing somebody is passing a warp drive schema object (modern way), inside warp drive there is an exception which appears when the property is not present.

It avoid this exception there is necessary to add `'x' in custObject` check