### PR TITLE
Add sass/css export into package.json

### DIFF
--- a/ember-power-select/package.json
+++ b/ember-power-select/package.json
@@ -14,9 +14,12 @@
     "name": "Miguel Camba",
     "email": "miguel.camba@gmail.com"
   },
+  "sass": "./ember-power-select.scss",
+  "style": "./dist/vendor/ember-power-select.css",
   "exports": {
     ".": {
       "types": "./declarations/index.d.ts",
+      "sass": "./ember-power-select.scss",
       "default": "./dist/index.js"
     },
     "./*": {


### PR DESCRIPTION
While updating the dependencies (https://github.com/ember-power-addons/ember-power-select/pull/2041), I discovered that the Sass/style exports are missing from `package.json`.

Adding the SCSS exports enables support for importing SCSS via `pkg:` imports (for example, `@use "pkg:ember-basic-dropdown"`). This has been supported since Dart Sass v1.71.0: [[Announcing pkg: Importers](https://sass-lang.com/blog/announcing-pkg-importers/?utm_source=chatgpt.com)](https://sass-lang.com/blog/announcing-pkg-importers/?utm_source=chatgpt.com)

For Vite apps, you need the following setup:

```js
import { defineConfig } from 'vite';
import { NodePackageImporter } from "sass-embedded";

export default defineConfig({
  css: {
    preprocessorOptions: {
      scss: {
        api: "modern-compiler",
        importers: [new NodePackageImporter()],
      },
    },
  },
  ...
});
```