### PR TITLE
A11y: fix incorrect handling on clear & selected item buttons

### DIFF
--- a/src/components/power-select/trigger.gts
+++ b/src/components/power-select/trigger.gts
@@ -157,7 +157,7 @@ export default class PowerSelectTrigger<
         }}
         class="ember-power-select-multiple-options"
         {{this.openChange @select.isOpen}}
-        {{on "pointerup" this.chooseOption}}
+        {{on "click" this.chooseOption}}
         ...attributes
       >
         {{#if (selectIsSelectedPresent this.selectedMultiple)}}
@@ -176,6 +176,7 @@ export default class PowerSelectTrigger<
                   aria-label="remove element"
                   class="ember-power-select-multiple-remove-btn"
                   data-selected-index={{idx}}
+                  {{on "touchend" this.stopPropagation}}
                   {{on "mousedown" this.stopPropagation}}
                 >
                   &times;
@@ -303,8 +304,9 @@ export default class PowerSelectTrigger<
           <span
             class="ember-power-select-clear-btn"
             role="button"
-            {{on "pointerup" this.clear}}
+            {{on "touchend" this.stopPropagation}}
             {{on "mousedown" this.stopPropagation}}
+            {{on "click" this.clear}}
           >&times;</span>
         {{/if}}
       {{else}}

--- a/src/components/power-select/trigger.gts
+++ b/src/components/power-select/trigger.gts
@@ -79,13 +79,10 @@ export default class PowerSelectTrigger<
   }
 
   @action
-  clear(e: Event): false | void {
+  clear(e: Event): void {
     e.stopPropagation();
     const value = this.args.select.multiple ? [] : undefined;
     this.args.select.actions.select(value as Selected<T, IsMultiple>);
-    if (e.type === 'touchstart') {
-      return false;
-    }
   }
 
   isOptionDisabled(option: Option<T>): boolean {
@@ -113,6 +110,10 @@ export default class PowerSelectTrigger<
       const object = this.selectedObject(this.selectedMultiple, numericIndex);
       this.args.select.actions.choose(object);
     }
+  }
+
+  stopPropagation(e: Event): void {
+    e.stopPropagation();
   }
 
   openChange = modifier((element: Element, [isOpen]: [boolean]) => {
@@ -146,7 +147,6 @@ export default class PowerSelectTrigger<
   <template>
     {{#if @select.multiple}}
       {{! template-lint-disable no-invalid-interactive }}
-      {{! template-lint-disable no-pointer-down-event-binding }}
       {{! template-lint-disable no-unsupported-role-attributes }}
       {{! template-lint-disable require-aria-activedescendant-tabindex }}
       <ul
@@ -157,8 +157,7 @@ export default class PowerSelectTrigger<
         }}
         class="ember-power-select-multiple-options"
         {{this.openChange @select.isOpen}}
-        {{on "touchstart" this.chooseOption}}
-        {{on "mousedown" this.chooseOption}}
+        {{on "pointerup" this.chooseOption}}
         ...attributes
       >
         {{#if (selectIsSelectedPresent this.selectedMultiple)}}
@@ -171,11 +170,13 @@ export default class PowerSelectTrigger<
                 }}"
             >
               {{#unless @select.disabled}}
+                {{! template-lint-disable no-pointer-down-event-binding }}
                 <span
                   role="button"
                   aria-label="remove element"
                   class="ember-power-select-multiple-remove-btn"
                   data-selected-index={{idx}}
+                  {{on "mousedown" this.stopPropagation}}
                 >
                   &times;
                 </span>
@@ -302,8 +303,8 @@ export default class PowerSelectTrigger<
           <span
             class="ember-power-select-clear-btn"
             role="button"
-            {{on "mousedown" this.clear}}
-            {{on "touchstart" this.clear}}
+            {{on "pointerup" this.clear}}
+            {{on "mousedown" this.stopPropagation}}
           >&times;</span>
         {{/if}}
       {{else}}


### PR DESCRIPTION
Hello!
We are having an accessibility issue where in cases where `@multiple=true` the user cannot drag the pointer off the selected item after clicking in order to cancel the removal of said item. Same issue exists for the clear button.

Believe this is an issue with the `on "mousedown"` usage. I fixed it by changing it to work off of pointerup and not allowing the "down" events to propagate when the user is clicking on a button itself.

Not sure if it's the most graceful solution. Would be happy to update PR if there is a better way and this is wanted.

Thank you
