### PR TITLE
Fix error `TypeError: undefined is not an object (evaluating 'e.key.length')`

### DIFF
--- a/src/components/power-select.gts
+++ b/src/components/power-select.gts
@@ -744,7 +744,7 @@ export default class PowerSelect<
       e.stopImmediatePropagation();
       return;
     }
-    if (e.key.length === 1 && /^[a-z0-9]$/i.test(e.key)) {
+    if (e.key?.length === 1 && /^[a-z0-9]$/i.test(e.key)) {
       // Keys 0-9, a-z or numpad keys
       void this.triggerTypingTask.perform(e);
     } else if (e.key === ' ') {
@@ -1238,7 +1238,7 @@ export default class PowerSelect<
     let term;
 
     // Check if user intends to cycle through results. _repeatingChar can only be the first character.
-    const c = e.key.length === 1 ? e.key : '';
+    const c = e.key?.length === 1 ? e.key : '';
     if (c === this._repeatingChar) {
       term = c;
     } else {

--- a/src/components/power-select/input.gts
+++ b/src/components/power-select/input.gts
@@ -105,7 +105,7 @@ export default class PowerSelectInput<
             this.args.select.actions.open(e);
           }
         }
-      } else if (e.key.length === 1 && /[a-z0-9 ]/i.test(e.key)) {
+      } else if (e.key?.length === 1 && /[a-z0-9 ]/i.test(e.key)) {
         // Keys 0-9, a-z or SPACE
         e.stopPropagation();
       }


### PR DESCRIPTION
Discovered in my error logs with power-select v9, that this error appears on Safari browser:

`TypeError: undefined is not an object (evaluating 'e.key.length')`

The error is not reproducible, so it comes maybe from any browser extensions, which triggers a keydown event. Maybe its a custom triggered event from a browser extension, which is incomplete.

Handling `e.key` with `undefined` will avoid this error in app (as there is no other way to fix this issue)