### PR TITLE
Treat empty strings as an `undefined` selection

### DIFF
--- a/src/components/power-select.gts
+++ b/src/components/power-select.gts
@@ -15,6 +15,7 @@ import {
   defaultTypeAheadMatcher,
   pathForOption,
 } from '../utils/group-utils.ts';
+import isSelectedPresent from '../helpers/ember-power-select-is-selected-present.ts';
 import { task, timeout } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
 import PowerSelectLabel from './power-select/label.gts';
@@ -467,11 +468,10 @@ export default class PowerSelect<
   }
 
   get selected(): Selected<T, IsMultiple> | undefined {
-    if (this._resolvedSelected) {
+    if (isSelectedPresent(this._resolvedSelected)) {
       return toPlainArray(this._resolvedSelected) as Selected<T, IsMultiple>;
     } else if (
-      this.args.selected !== undefined &&
-      this.args.selected !== null &&
+      isSelectedPresent(this.args.selected) &&
       !isPromiseLike(this.args.selected)
     ) {
       return toPlainArray(this.args.selected) as Selected<T, IsMultiple>;
@@ -972,7 +972,7 @@ export default class PowerSelect<
   }
 
   private __updateSelected(): void {
-    if (this.args.selected === undefined || this.args.selected === null) return;
+    if (!isSelectedPresent(this.args.selected)) return;
     if (isPromiseLike(this.args.selected)) {
       if (this._lastSelectedPromise === this.args.selected) return; // promise is still the same
       const currentSelectedPromise = this.args.selected;

--- a/src/helpers/ember-power-select-is-selected-present.ts
+++ b/src/helpers/ember-power-select-is-selected-present.ts
@@ -1,5 +1,5 @@
 export default function emberPowerSelectIsSelectedPresent<T>(
   value: T | undefined,
 ): value is T {
-  return value !== null && value !== undefined;
+  return value !== null && value !== undefined && value !== '';
 }

--- a/tests/integration/components/power-select/general-behaviour-test.gts
+++ b/tests/integration/components/power-select/general-behaviour-test.gts
@@ -2222,6 +2222,39 @@ module(
         .hasText('fourteen');
     });
 
+    test<NumbersContext>('An empty-string selection is treated as an empty select', async function (assert) {
+      const self = this;
+
+      assert.expect(2);
+
+      this.numbers = numbers;
+      this.selected = '';
+      this.foo = () => {};
+
+      await render<NumbersContext>(
+        <template>
+          <HostWrapper>
+            <PowerSelect
+              @options={{self.numbers}}
+              @selected={{self.selected}}
+              @allowClear={{true}}
+              @onChange={{self.foo}}
+              as |option|
+            >
+              {{option}}
+            </PowerSelect>
+          </HostWrapper>
+        </template>,
+      );
+
+      assert
+        .dom('.ember-power-select-trigger', getRootNode(this.element))
+        .hasText('', 'The trigger stays empty');
+      assert
+        .dom('.ember-power-select-clear-btn', getRootNode(this.element))
+        .doesNotExist('Empty strings do not render a clear button');
+    });
+
     test<NumbersContext>("Disabled single selects don't have a clear button even if `allowClear` is true", async function (assert) {
       const self = this;
 


### PR DESCRIPTION
In ember-power-select v7, empty strings were considered an "empty" value and the select would be in an unselected state.

In v8, an issue was fixed where the number `0` wasn't considered a valid select option, but the way it was implemented also unintentionally broke the empty string behavior.

This change restores the old empty string behavior while still supporting the number 0 as well.

Closes #2082